### PR TITLE
transaction list fix

### DIFF
--- a/lib/providers/notifiers/transactions_notifier.dart
+++ b/lib/providers/notifiers/transactions_notifier.dart
@@ -32,7 +32,7 @@ class TransactionsNotifier extends ChangeNotifier {
 
     List<TransactionModel> actualTransactions = await _http.getTransactions();
 
-    if (actualTransactions.length > cacheTransactions.values.length) {
+    if (actualTransactions.length > 0) {
       await cacheTransactions.clear();
       await cacheTransactions.addAll(actualTransactions);
     }


### PR DESCRIPTION
bug: only if the number of transactions in the cache is smaller than the newly fetched list would the list update. However, we always want the newest.