### PR TITLE
terms, privacy urls, ios version

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/lib/constants/config.dart
+++ b/lib/constants/config.dart
@@ -7,6 +7,6 @@ class Config {
   static final cpuPrivateKey = "5Hy2cvMbrusscGnusLWqYuXyM8fZ65G7DTzs4nDXyiV5wo77n9a";
   static final debugInviteSecret = "";
   static final enableHttpMock = false;
-  static final termsAndConditionsUrl = "https://www.joinseeds.com/seeds-terms-and-conditions.html";
-  static final privacyPolicyUrl = "https://www.joinseeds.com/seeds-privacy-policy.html";
+  static final termsAndConditionsUrl = "https://www.joinseeds.com/seeds-app-terms-and-conditions.html";
+  static final privacyPolicyUrl = "https://www.joinseeds.com/seeds-app-privacy-policy.html";
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: seeds
 description: SEEDS Wallet
 
-version: 1.1.0+4
+version: 1.1.0+8
 
 environment:
   sdk: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
- Changed privacy and T&C URLs to URLs without navigation for iOS app store release

Addresses app store issue:
_We noticed that your app or its metadata includes irrelevant third-party platform information. 
Specifically, your app includes Google Play references in the Joinseed tab.
Referencing third-party platforms in your app or its metadata is not permitted on the App Store unless there is specific interactive functionality._

This was because our links to terms and privacy policy were navigating the entire SEEDS website, which has all these things.

- Changed versioning on iOS to be in synch with flutter
