### PR TITLE
Making all avatar images round - using cover mode for the image

### DIFF
--- a/lib/screens/app/profile/profile.dart
+++ b/lib/screens/app/profile/profile.dart
@@ -87,6 +87,7 @@ class _ProfileState extends State<Profile> {
                                       )
                                     : CachedNetworkImage(
                                         imageUrl: model?.profile?.image ?? '',
+                                        fit: BoxFit.cover,
                                         errorWidget: (context, url, error) {
                                           return Container(
                                             color: AppColors.getColorByString(

--- a/lib/screens/app/wallet/transfer_form.dart
+++ b/lib/screens/app/wallet/transfer_form.dart
@@ -108,7 +108,7 @@ class _TransferFormState extends State<TransferForm>
                     ),
                     child: Hero(
                       child:
-                          CachedNetworkImage(imageUrl: widget.arguments.avatar),
+                          CachedNetworkImage(imageUrl: widget.arguments.avatar, fit: BoxFit.cover),
                       tag: "avatar#${widget.arguments.accountName}",
                     ),
                   )

--- a/lib/widgets/transaction_avatar.dart
+++ b/lib/widgets/transaction_avatar.dart
@@ -26,7 +26,7 @@ class TransactionAvatar extends StatelessWidget {
           child: Container(
             width: size,
             height: size,
-            child: CachedNetworkImage(imageUrl: image),
+            child: CachedNetworkImage(imageUrl: image,fit: BoxFit.cover),
             decoration: decoration,
           ));
     } else if (image.endsWith('.svg')) {


### PR DESCRIPTION
Avatars would show rectangular images with a blue background and as square areas inside the round avatar pix - looked bad.

Now zooming in to fill the area.