### PR TITLE
Small UI improvment

### DIFF
--- a/lib/screens/app/ecosystem/overview.dart
+++ b/lib/screens/app/ecosystem/overview.dart
@@ -155,7 +155,7 @@ class _OverviewState extends State<Overview> {
                   'Tap to participate',
                   'assets/images/governance.svg',
                   'Trust Tokens',
-                  model?.balance?.amount.toString(),
+                  (model?.balance?.amount != null) ? model?.balance?.amount.toString() : "-",
                   onVote,
                 ),),
                 Consumer<BalanceNotifier>(builder: (ctx, model, _) => buildCategory(

--- a/lib/screens/app/ecosystem/overview.dart
+++ b/lib/screens/app/ecosystem/overview.dart
@@ -158,7 +158,6 @@ class _OverviewState extends State<Overview> {
                   model?.balance?.amount.toString(),
                   onVote,
                 ),),
-                Divider(),
                 Consumer<BalanceNotifier>(builder: (ctx, model, _) => buildCategory(
                   'Community - Invite',
                   'Tap to send an invite',
@@ -167,7 +166,6 @@ class _OverviewState extends State<Overview> {
                   model?.balance?.quantity?.seedsFormatted,
                   onInvite,
                 ),),
-                Divider(),
                 Consumer<PlantedNotifier>(builder: (ctx, model, _) => buildCategory(
                   'Harvest - Plant',
                   'Tap to plant Seeds',

--- a/lib/screens/app/wallet/transfer_form.dart
+++ b/lib/screens/app/wallet/transfer_form.dart
@@ -78,7 +78,7 @@ class _TransferFormState extends State<TransferForm>
     );
   }
 
-  final controller = TextEditingController(text: '0.00');
+  final controller = TextEditingController(text: '');
 
   void onSend() {
     if (_formKey.currentState.validate()) {
@@ -107,8 +107,8 @@ class _TransferFormState extends State<TransferForm>
                       ),
                     ),
                     child: Hero(
-                      child:
-                          CachedNetworkImage(imageUrl: widget.arguments.avatar, fit: BoxFit.cover),
+                      child: CachedNetworkImage(
+                          imageUrl: widget.arguments.avatar, fit: BoxFit.cover),
                       tag: "avatar#${widget.arguments.accountName}",
                     ),
                   )
@@ -126,27 +126,23 @@ class _TransferFormState extends State<TransferForm>
         ),
         Hero(
           tag: "nickname#${widget.arguments.fullName}",
-          child: Material(
-            child: Container(
-              margin: EdgeInsets.only(top: 10, left: 20, right: 20),
-              child: Text(
-                widget.arguments.fullName,
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
-              ),
+          child: Container(
+            margin: EdgeInsets.only(top: 10, left: 20, right: 20),
+            child: Text(
+              widget.arguments.fullName,
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
             ),
           ),
         ),
         Hero(
           tag: "account#${widget.arguments.fullName}",
-          child: Material(
-            child: Container(
-              margin: EdgeInsets.only(top: 5, left: 20, right: 20),
-              child: Text(
-                widget.arguments.accountName,
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 14, color: AppColors.grey),
-              ),
+          child: Container(
+            margin: EdgeInsets.only(top: 5, left: 20, right: 20),
+            child: Text(
+              widget.arguments.accountName,
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 14, color: AppColors.grey),
             ),
           ),
         ),
@@ -211,11 +207,12 @@ class _TransferFormState extends State<TransferForm>
                   buildProfile(),
                   buildBalance(balance),
                   MainTextField(
-                    keyboardType:
-                        TextInputType.numberWithOptions(signed: false, decimal: true),
+                    keyboardType: TextInputType.numberWithOptions(
+                        signed: false, decimal: true),
                     controller: controller,
                     labelText: 'Transfer amount',
                     endText: 'SEEDS',
+                    autofocus: true,
                     validator: (val) {
                       String error;
                       double availableBalance =

--- a/lib/widgets/main_text_field.dart
+++ b/lib/widgets/main_text_field.dart
@@ -12,6 +12,7 @@ class MainTextField extends StatelessWidget {
   final Function validator;
   final Function(String) onChanged;
   final FocusNode focusNode;
+  final bool autofocus;
 
   MainTextField({
     this.controller,
@@ -24,6 +25,7 @@ class MainTextField extends StatelessWidget {
     this.validator,
     this.onChanged,
     this.focusNode,
+    this.autofocus,
   });
 
   Widget build(BuildContext context) {
@@ -48,6 +50,7 @@ class MainTextField extends StatelessWidget {
                 maxLength: maxLength,
                 validator: validator,
                 onChanged: (value) => onChanged(value),
+                autofocus: autofocus != null ? autofocus : false,
                 focusNode: focusNode,
                 decoration: InputDecoration(
                   filled: true,

--- a/lib/widgets/transaction_details.dart
+++ b/lib/widgets/transaction_details.dart
@@ -19,24 +19,20 @@ class TransactionDetails extends StatelessWidget {
           height: width * 0.22,
           child: image,
         ),
-        Material(
-          child: Container(
-            margin: EdgeInsets.only(top: 10, left: 20, right: 20),
-            child: Text(
-              title,
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
-            ),
+        Container(
+          margin: EdgeInsets.only(top: 10, left: 20, right: 20),
+          child: Text(
+            title,
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
           ),
         ),
-        Material(
-          child: Container(
-            margin: EdgeInsets.only(top: 5, left: 20, right: 20),
-            child: Text(
-              beneficiary,
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 14, color: AppColors.grey),
-            ),
+        Container(
+          margin: EdgeInsets.only(top: 5, left: 20, right: 20),
+          child: Text(
+            beneficiary,
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 14, color: AppColors.grey),
           ),
         ),
       ],


### PR DESCRIPTION
Small UI improvement there and there: 

- Remove weird gray background color behind people name or title on Transfer, invite, plant screen
- Remove divider on the Ecosystem page since CardView already has its elevation used as a divider, no need for more.
- Add autofocus on the transfer screen so the user just has to type the amount without having to click on the textfield and remove the "0.00" value.
- Not display "null" as a value of trust token when the screen is loading.