### PR TITLE
Feature/Upgrade Flutter to 1.20.2 fix

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   passcode_screen: 1.0.2  # More time to look into the breaking version 1.1.0 before upgrading
   percent_indicator: ^2.1.1+1
   expandable: ^4.1.2
-  flutter_svg: ^0.17.1
+  flutter_svg: ^0.18.0
   flutter_fluid_slider: ^1.0.2
   firebase_dynamic_links: ^0.5.1
   eosdart:


### PR DESCRIPTION
Upgraded Flutter to the latest 1.20.2 

This upgrade to `flutter_svg` **from:** ^0.17.1 **to:** ^0.18.0 was necessary to fix the build. 

Make you to run `flutter clean` after upgrading. 