### PR TITLE
Send user to password input when biometric fails

### DIFF
--- a/lib/features/biometrics/auth_bloc.dart
+++ b/lib/features/biometrics/auth_bloc.dart
@@ -35,11 +35,10 @@ class AuthBloc {
           _authenticated.add(AuthState.setupNeeded);
         }
       });
-    
     available
       .map(preferredAuthType)
       .listen(_preferred.add);
-    
+
     _execute.listen((cmd) => _executeCommand(cmd));
   }
 
@@ -145,6 +144,8 @@ class AuthBloc {
       .catchError((error) {
         debugPrint("Error auth with biometrics: $error");
         _authenticated.addError("Auth error: $error");
+        // Biometrics auth failed, Send user to password input.
+        _addPasswordToAvailable();
       });
   }
 


### PR DESCRIPTION
On Android, Currently we leave the user in a broken state when the device contains biometrics but it's deactivated. 

**Steps to error state:**
Use a device with biometrics
Disable biometrics to login into apps on this device's settings
Open SEEDs app
The biometric auth library we use, reports back saying yes, we have "Face biometric"
We try to auth with face biometric but an error gets thrown. 

Fix: When biometrics throws an error, redirect user to login using input code. 

**Disable biometrics to login into apps**
![image](https://user-images.githubusercontent.com/8041901/90977244-8853c080-e561-11ea-9b84-4bbbc84f4e10.png)

