### PR TITLE
Putting Hive in a safe box

### DIFF
--- a/lib/providers/notifiers/invites_notifier.dart
+++ b/lib/providers/notifiers/invites_notifier.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:seeds/models/models.dart';
-import 'package:seeds/providers/notifiers/members_notifier.dart';
 import 'package:seeds/providers/services/http_service.dart';
 
 class InvitesNotifier extends ChangeNotifier {
@@ -12,7 +11,7 @@ class InvitesNotifier extends ChangeNotifier {
   Map<String, String> inviteSecrets;
 
   static of(BuildContext context, {bool listen = false}) =>
-      Provider.of<MembersNotifier>(context, listen: listen);
+      Provider.of<InvitesNotifier>(context, listen: listen);
 
   void init({HttpService http}) {
     _http = http;

--- a/lib/providers/notifiers/members_notifier.dart
+++ b/lib/providers/notifiers/members_notifier.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:seeds/constants/system_accounts.dart';
 import 'package:seeds/models/models.dart';
 import 'package:seeds/providers/services/http_service.dart';
+import 'package:seeds/utils/extensions/SafeHive.dart';
 
 class MembersNotifier extends ChangeNotifier {
   HttpService _http;
@@ -36,7 +37,7 @@ class MembersNotifier extends ChangeNotifier {
   }
 
   Future<MemberModel> getAccountDetails(String accountName) async {
-    var box = await Hive.openBox<MemberModel>("members");
+    Box<MemberModel> box = await SafeHive.safeOpenBox("members");
 
     if (isSystemAccount(accountName)) {
       return getSystemAccount(accountName);
@@ -46,9 +47,9 @@ class MembersNotifier extends ChangeNotifier {
       MemberModel member = await _http.getMember(accountName);
 
       if (member != null) {
-        box.put(accountName, member);
+        await box.put(accountName, member);
       } else {
-        box.put(
+        await box.put(
           accountName,
           MemberModel(
             account: accountName,
@@ -63,7 +64,7 @@ class MembersNotifier extends ChangeNotifier {
   }
 
   Future<void> fetchMembersCache() async {
-    Box cacheMembers = await Hive.openBox<MemberModel>("members");
+    Box cacheMembers = await SafeHive.safeOpenBox<MemberModel>("members");
 
     if (cacheMembers != null && cacheMembers.isNotEmpty) {
       allMembers = cacheMembers.values.toList();
@@ -73,7 +74,7 @@ class MembersNotifier extends ChangeNotifier {
   }
 
   Future<void> addMembers(List<MemberModel> members) async {
-    Box cacheMembers = await Hive.openBox<MemberModel>("members");
+    Box cacheMembers = await SafeHive.safeOpenBox<MemberModel>("members");
     members.forEach((actualMember) {
       var memberKey = actualMember.account;
 
@@ -120,3 +121,4 @@ class MembersNotifier extends ChangeNotifier {
     notifyListeners();
   }
 }
+

--- a/lib/providers/notifiers/transactions_notifier.dart
+++ b/lib/providers/notifiers/transactions_notifier.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:seeds/models/models.dart';
 import 'package:seeds/providers/notifiers/auth_notifier.dart';
 import 'package:seeds/providers/services/http_service.dart';
+import 'package:seeds/utils/extensions/SafeHive.dart';
 
 class TransactionsNotifier extends ChangeNotifier {
   List<TransactionModel> transactions;
@@ -19,7 +20,7 @@ class TransactionsNotifier extends ChangeNotifier {
 
   Future fetchTransactionsCache() async {
     Box cacheTransactions =
-        await Hive.openBox<TransactionModel>("transactions");
+        await SafeHive.safeOpenBox<TransactionModel>("transactions");
     if (cacheTransactions != null && cacheTransactions.isNotEmpty) {
       transactions = cacheTransactions.values.toList();
       notifyListeners();
@@ -28,7 +29,7 @@ class TransactionsNotifier extends ChangeNotifier {
 
   Future refreshTransactions() async {
     Box cacheTransactions =
-        await Hive.openBox<TransactionModel>("transactions");
+        await SafeHive.safeOpenBox<TransactionModel>("transactions");
 
     List<TransactionModel> actualTransactions = await _http.getTransactions();
 

--- a/lib/utils/extensions/SafeHive.dart
+++ b/lib/utils/extensions/SafeHive.dart
@@ -1,0 +1,19 @@
+import 'package:hive/hive.dart';
+
+extension SafeHive on HiveInterface {
+    static Future<Box<E>> safeOpenBox<E>(String name) async {
+      var box;
+      try {
+        if (Hive.isBoxOpen(name)) {
+          return Hive.box(name);
+        }
+        box = await Hive.openBox<E>(name);
+      } catch (e){
+        print("Hive error ${e.toString()}");
+        await Hive.deleteBoxFromDisk(name);
+        box = await Hive.openBox<E>(name);
+        print("recovered Hive $name.");
+      }
+      return box;
+    }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,8 +49,7 @@ dependencies:
   image_picker: ^0.6.7
   image_cropper: ^1.2.1
   sentry: ^3.0.1
-  hive: ^1.4.1+1
-  hive_flutter: ^0.2.1
+  hive: ^1.4.4
   rxdart: ^0.24.0
   permission_handler: ^5.0.1
   barcode_scan: ^3.0.1


### PR DESCRIPTION
Hive error "HiveError: This should not happen. Please open an issue on GitHub" fixed by deleting offending files and recreating them.

The symptom of this was endless loading on the dashboard - saw it on iOS simulator, Igor saw it on Android.

This happens when the hive cache gets corrupted - unknown as to why, we should switch away from Hive.

But until then, this workaround fixed it on my system - deleting the cache file and recreating it. 

It is unknown under which conditions this bug would occur - potentially due to not closing the hive box? Not sure.

@7flash does hive need to be closed? Who should be closing it?