### PR TITLE
Firebase Remote Config Added

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:seeds/providers/notifiers/auth_notifier.dart';
 import 'package:seeds/providers/notifiers/settings_notifier.dart';
 import 'package:seeds/providers/providers.dart';
 import 'package:seeds/providers/services/firebase/firebase_database_service.dart';
+import 'package:seeds/providers/services/firebase/firebase_remote_config.dart';
 import 'package:seeds/providers/services/navigation_service.dart';
 import 'package:seeds/providers/services/firebase/push_notification_service.dart';
 import 'package:seeds/screens/app/app.dart';
@@ -63,6 +64,7 @@ main(List<String> args) async {
   Hive.registerAdapter<MemberModel>(MemberAdapter());
   Hive.registerAdapter<TransactionModel>(TransactionAdapter());
   await Firebase.initializeApp();
+  FirebaseRemoteConfigService().initialise();
   PushNotificationService().initialise();
   SystemChrome.setPreferredOrientations(
       [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]).then((_) {

--- a/lib/providers/services/firebase/firebase_remote_config.dart
+++ b/lib/providers/services/firebase/firebase_remote_config.dart
@@ -1,0 +1,39 @@
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+
+const String _FeatureFlagGuardianKey = "feature_guardians";
+
+class FirebaseRemoteConfigService {
+  final defaults = <String, dynamic>{_FeatureFlagGuardianKey: false};
+
+  final RemoteConfig _remoteConfig;
+  static FirebaseRemoteConfigService _instance;
+
+  FirebaseRemoteConfigService({RemoteConfig remoteConfig}) : _remoteConfig = remoteConfig;
+
+  static Future<FirebaseRemoteConfigService> getInstance() async {
+    if (_instance == null) {
+      _instance = FirebaseRemoteConfigService(remoteConfig: await RemoteConfig.instance);
+    }
+
+    return _instance;
+  }
+
+  Future initialise() async {
+    try {
+      await _remoteConfig.setDefaults(defaults);
+      await _fetchAndActivate();
+    } on FetchThrottledException catch (exception) {
+      // Fetch throttled.
+      print('Remote config fetch throttled: $exception');
+    } catch (exception) {
+      print('Unable to fetch remote config. Cached or default values will be used');
+    }
+  }
+
+  Future _fetchAndActivate() async {
+    await _remoteConfig.fetch();
+    await _remoteConfig.activateFetched();
+  }
+
+  bool get featureFlagGuardiansEnabled => _remoteConfig.getBool(_FeatureFlagGuardianKey);
+}

--- a/lib/providers/services/firebase/firebase_remote_config.dart
+++ b/lib/providers/services/firebase/firebase_remote_config.dart
@@ -3,22 +3,18 @@ import 'package:firebase_remote_config/firebase_remote_config.dart';
 const String _FeatureFlagGuardianKey = "feature_guardians";
 
 class FirebaseRemoteConfigService {
-  final defaults = <String, dynamic>{_FeatureFlagGuardianKey: false};
+  final defaults = <String, dynamic>{_FeatureFlagGuardianKey: true};
+  RemoteConfig _remoteConfig;
 
-  final RemoteConfig _remoteConfig;
-  static FirebaseRemoteConfigService _instance;
+  FirebaseRemoteConfigService._();
 
-  FirebaseRemoteConfigService({RemoteConfig remoteConfig}) : _remoteConfig = remoteConfig;
+  factory FirebaseRemoteConfigService() => _instance;
 
-  static Future<FirebaseRemoteConfigService> getInstance() async {
-    if (_instance == null) {
-      _instance = FirebaseRemoteConfigService(remoteConfig: await RemoteConfig.instance);
-    }
-
-    return _instance;
-  }
+  static final FirebaseRemoteConfigService _instance = FirebaseRemoteConfigService._();
 
   Future initialise() async {
+    _remoteConfig = await RemoteConfig.instance;
+
     try {
       await _remoteConfig.setDefaults(defaults);
       await _fetchAndActivate();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   firebase_messaging: ^7.0.0
   firebase_storage: ^4.0.0
   cloud_firestore: ^0.14.0+2
+  firebase_remote_config: ^0.4.0+1
   liquid_pull_to_refresh: ^1.1.1
   shimmer: ^1.0.1
   random_words: ^1.0.2


### PR DESCRIPTION
Remote Configuration from Firebase. 

**What is Remote Config?**
Firebase Remote Config is a cloud service that lets you change the behavior and appearance of your app without requiring users to download an app update. When using Remote Config, you create in-app default values that control the behavior and appearance of your app. Then, you can later use the Firebase console or the Remote Config backend APIs to override in-app default values for all app users or for segments of your user base.

**Why Use Remote Config on Seeds?**
We are developing a new large feature. This feature can be hidden behind a feature flag until it's completed. 
Then using the remote config to activate this feature for users. 

**Benefits?**
Avoid having long lasting feature branches that are often complicated to manage and diverge from develop/master



