### PR TITLE
Deployment Target was fixed by deleting IPHONEOS_DEPLOYMENT_TARGET

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -36,6 +36,8 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
-    flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+        config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
+    end
   end
 end


### PR DESCRIPTION
This pull request is to fix and issue due to Compiling for iOS 8.0, but module 'SwiftProtobuf' has a minimum deployment target of iOS 9.0: 

Resolution reference: https://stackoverflow.com/a/64048124