### PR TITLE
Protobuf error

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,10 +52,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    configurations {
-        implementation.exclude module:'protobuf-lite'
-    }
-
    signingConfigs {
        release {
            keyAlias keystoreProperties['keyAlias']
@@ -76,9 +72,7 @@ flutter {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-dynamic-links:19.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.google.firebase:firebase-messaging:20.2.4'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,6 +52,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    configurations {
+        implementation.exclude module:'protobuf-lite'
+    }
+
    signingConfigs {
        release {
            keyAlias keystoreProperties['keyAlias']

--- a/lib/screens/app/guardians/guardian_user_tile.dart
+++ b/lib/screens/app/guardians/guardian_user_tile.dart
@@ -48,7 +48,6 @@ Widget guardianUserTile({MemberModel user, Guardian guardian, String currentUser
       });
 }
 
-//ignore: dead_code
 Widget trailingWidget(Guardian guardian, MemberModel user, String currentUserId, Function tileOnTap) {
   switch (guardian.status) {
     case GuardianStatus.requestedMe:
@@ -100,7 +99,7 @@ Widget trailingWidget(Guardian guardian, MemberModel user, String currentUserId,
       } else {
         return SizedBox.shrink();
       }
-      break;
+      break; // ignore: dead_code
     }
     default:
       return SizedBox.shrink();

--- a/lib/screens/app/guardians/guardian_user_tile.dart
+++ b/lib/screens/app/guardians/guardian_user_tile.dart
@@ -48,6 +48,7 @@ Widget guardianUserTile({MemberModel user, Guardian guardian, String currentUser
       });
 }
 
+//ignore: dead_code
 Widget trailingWidget(Guardian guardian, MemberModel user, String currentUserId, Function tileOnTap) {
   switch (guardian.status) {
     case GuardianStatus.requestedMe:


### PR DESCRIPTION
This error keeps showing with android builds. 

Issue is we are using native implementation of firebase libs and dart packages. 

java.lang.RuntimeException: Duplicate class com.google.protobuf.AbstractMessageLite found in modules protobuf-java-2.5.0.jar (com.google.protobuf:protobuf-java:2.5.0) and protobuf-lite-3.0.1.jar (com.google.protobuf:protobuf-lite:3.0.1)

protobuf-java and protobuf-lite are incompatible packages. They both include classes in the com.google.protobuf package

Fix: Remove native implementations 
       implementation.exclude module:'protobuf-lite'

https://github.com/firebase/firebase-android-sdk/issues/1143