### PR TITLE
reverted changes for protobuf

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,10 +52,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    configurations {
-        implementation.exclude module:'protobuf-lite'
-    }
-
    signingConfigs {
        release {
            keyAlias keystoreProperties['keyAlias']
@@ -76,7 +72,9 @@ flutter {
 }
 
 dependencies {
+    implementation 'com.google.firebase:firebase-dynamic-links:19.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.google.firebase:firebase-messaging:20.2.4'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'


### PR DESCRIPTION
Scanner does not work, it breaks the app on Android. 

I dont believe the issue with the scanner comes from these changes, but i am reverting it just in case. 

And to give more people a chance to test this before we merge it back in. 

