### PR TITLE
Fix to pixel 5

### DIFF
--- a/lib/providers/notifiers/auth_notifier.dart
+++ b/lib/providers/notifiers/auth_notifier.dart
@@ -42,7 +42,7 @@ class AuthNotifier extends ChangeNotifier {
       status = AuthStatus.locked;
     }
 
-    if (_passcode == null && _passcodeActive) {
+    if ((_passcode == null || _passcodeActive == null) && _passcodeActive) {
       status = AuthStatus.emptyPasscode;
     }
 


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

No Issue Ticket: `_passcodeActive` was being accessed without previous initialization. 

I notice this issue using google pixel 5

This was causing a crash due to null in a bool check

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Fix: Treat null and false

### 👯‍♀️ Paired with

Solo
