### PR TITLE
added cancelGuardiansSafe, removed debug code

### DIFF
--- a/lib/providers/services/eos_service.dart
+++ b/lib/providers/services/eos_service.dart
@@ -493,7 +493,25 @@ class EosService {
         ..data = {"user_account": accountName}
     ]);
 
-    return client.pushTransaction(transaction, broadcast: true);
+    return await client.pushTransaction(transaction, broadcast: true);    
+  }
+
+  /// Cancel guardians.
+  ///
+  /// Safe fallthrough - does not fail when user doesn't have guardians.
+  ///
+  /// This cancels any recovery currently in process, and removes all guardians
+  ///
+  Future<dynamic> cancelGuardiansSafe() async {
+    try {
+      return await cancelGuardians(); 
+    } catch (error) {
+      if (error.toString().contains("does not have guards")) {
+        return;
+      } else {
+        throw error;
+      }
+    }
   }
 
   /// Claim recovered account for user - this switches the new public key live at the end of the

--- a/lib/screens/app/wallet/dashboard.dart
+++ b/lib/screens/app/wallet/dashboard.dart
@@ -74,15 +74,6 @@ class _DashboardState extends State<Dashboard> {
   }
 
   void onReceive() async {
-    // TESTING - showcase code for set up / remove permissions - remove
-    //var perm = await EosService.of(context, listen: false).getAccountPermissions();
-    //print("perm: "+perm.toString());
-    //await EosService.of(context, listen: false).removeGuardianPermission();
-    //await EosService.of(context, listen: false).setGuardianPermission();
-    //var perm2 = await EosService.of(context, listen: false).getAccountPermissions();
-    //print("perm after: "+perm2.toString());
-    // delete this.
-    
     NavigationService.of(context).navigateTo(Routes.receive);
   }
 


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

added this API in the EOS service: 

`cancelGuardiansSafe`

Use this instead of 

`cancelGuardians`

@gguijarro-c-chwy complained that cancel would throw an error when there were no guardians. 

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Doing this client side as I like to fail early, fail often, on potentially unexpected results 

So I leave the contract as is, it fails to inform clients that they did something that may have been unintended. 
