### PR TITLE
add a flag for key guardian notification

### DIFF
--- a/lib/widgets/pending_notification.dart
+++ b/lib/widgets/pending_notification.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:seeds/providers/services/firebase/firebase_remote_config.dart';
 
 guardianNotification(bool showGuardianNotification) {
-  if (showGuardianNotification) {
+  if (showGuardianNotification && FirebaseRemoteConfigService().featureFlagGuardiansEnabled) {
     return Icon(Icons.brightness_1, size: 18.0, color: Colors.redAccent);
   } else {
-    return Container();
+    return SizedBox.shrink();
   }
 }
+


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
A flag was added for key guardian notification 

no Issue 

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

added a flag for key guardian notification (pending_notification.dart)

### 🙈 Screenshots

_For all UI changes_

| description 1 | description 2 |
| --- | --- |
| img1 | img2 |

### 👯‍♀️ Paired with

 "nobody" 
