### PR TITLE
remove double dispose

### DIFF
--- a/lib/widgets/fullscreen_loader.dart
+++ b/lib/widgets/fullscreen_loader.dart
@@ -114,7 +114,6 @@ class _FullscreenLoaderState extends State<FullscreenLoader> with SingleTickerPr
   @override
   void dispose() {
     animationController?.dispose();
-    super.dispose();
     statusSubscription?.cancel();
     messageSubscription?.cancel();
     super.dispose();


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

No issue number - just a small bugfix

This class called super.dispose() twice which would cause flutter assertion exceptions

Porting from 1.4.4. fix

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer


### 👯‍♀️ Paired with

no
