### PR TITLE
Adding second currency provider API - WIP

### DIFF
--- a/ios/Flutter/Flutter.podspec
+++ b/ios/Flutter/Flutter.podspec
@@ -1,0 +1,18 @@
+#
+# NOTE: This podspec is NOT to be published. It is only used as a local source!
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Flutter'
+  s.version          = '1.0.0'
+  s.summary          = 'High-performance, high-fidelity mobile apps.'
+  s.description      = <<-DESC
+Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
+                       DESC
+  s.homepage         = 'https://flutter.io'
+  s.license          = { :type => 'MIT' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
+  s.ios.deployment_target = '8.0'
+  s.vendored_frameworks = 'Flutter.framework'
+end

--- a/lib/constants/config.dart
+++ b/lib/constants/config.dart
@@ -16,4 +16,5 @@ class Config {
       'https://www.joinseeds.com/seeds-app-privacy-policy.html';
   static final explorer = 'https://telos.bloks.io';
   static final dhoExplorer = 'https://dho.hypha.earth'; //  http://10.0.2.2:8080
+  static final fixerApiKey = "3b0819cba60943d4151af8de60ba5c10";
 }

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -219,37 +219,64 @@ class TransactionModel {
 }
 
 class FiatRateModel {
-  final Map<String, double> ratesPerUSD;
+  Map<String, double> rates;
+  String base;
   final bool error;
 
   List<String> get currencies {
-    var list = List<String>.from(ratesPerUSD.keys);
+    var list = List<String>.from(rates.keys);
     list.sort();
     return list;
   }
 
-  FiatRateModel(this.ratesPerUSD, {this.error = false});
+  FiatRateModel(this.rates, {this.base = "USD", this.error = false});
 
   factory FiatRateModel.fromJson(Map<String, dynamic> json) {
     if (json != null && json.isNotEmpty) {
-      return FiatRateModel(Map<String, double>.from(json['rates']));
+      return FiatRateModel(new Map<String, double>.from(json["rates"]));
     } else {
       return FiatRateModel(null, error: true);
     }
   }
 
+  factory FiatRateModel.fromJsonFixer(Map<String, dynamic> json) {
+    if (json != null && json.isNotEmpty) {
+      var model = FiatRateModel(new Map<String, double>.from(json["rates"]), base: json["base"]);
+      model.rebase("USD");
+      return model;
+    } else {
+      return FiatRateModel(null, error: true);
+    }
+  }
+      
   double usdTo(double usdValue, String currency) {
-    var rate = ratesPerUSD[currency];
+    double rate = rates[currency];
     assert(rate != null);
     return usdValue * rate;
   }
-
+      
   double toUSD(double currencyValue, String currency) {
-    var rate = ratesPerUSD[currency];
+    double rate = rates[currency];
     assert(rate != null);
     return rate > 0 ? currencyValue / rate : 0;
   }
+      
+  void rebase(String symbol) {
+    var rate = rates[symbol];
+    if (rate != null) {
+      base = symbol;
+      rates = rates.map((key, value) => MapEntry(key, value / rate));
+    } else {
+      print("error - can't rebase to " + symbol);
+    }
+  }
+
+  void merge(FiatRateModel other) {
+    if (!other.error) rates.addAll(other.rates);
+  }
+
 }
+
 
 class RateModel {
   final double seedsPerUSD;

--- a/lib/providers/notifiers/rate_notiffier.dart
+++ b/lib/providers/notifiers/rate_notiffier.dart
@@ -27,10 +27,12 @@ class RateNotifier extends ChangeNotifier with CurrencyConverter {
       return Future.wait(
       [
         _http.getUSDRate(),
-        _http.getFiatRates()
+        _http.getFiatRates(),
+        _http.getFiatRatesAlternate()
       ]).then((result) {
         rate = result[0];
         fiatRate = result[1];
+        fiatRate.merge(result[2]);
         notifyListeners();
       });
     } else {

--- a/lib/providers/services/http_service.dart
+++ b/lib/providers/services/http_service.dart
@@ -473,6 +473,20 @@ class HttpService {
       return FiatRateModel(null, error: true);
     }
   }
+  
+  Future<FiatRateModel> getFiatRatesAlternate() async {
+    print("[http] get alternate fiat rates");
+
+    Response res = await get("http://data.fixer.io/api/latest?access_key=${Config.fixerApiKey}&symbols=CRC,GTQ,USD");
+
+    if (res.statusCode == 200) {
+      Map<String, dynamic> body = res.parseJson();
+      return FiatRateModel.fromJsonFixer(body);
+    } else {
+      print("Cannot fetch alternate rates..." + res.body.toString());
+      return FiatRateModel(null, base: null, error: true);
+    }
+  }
 
   Future<BalanceModel> getTelosBalance() async {
     print('[http] get telos balance');

--- a/lib/v2/datasource/remote/api/rates_repository.dart
+++ b/lib/v2/datasource/remote/api/rates_repository.dart
@@ -16,4 +16,27 @@ class RatesRepository extends NetworkRepository {
             }))
         .catchError((error) => mapHttpError(error));
   }
+  
+  // TODO-NIK code below needs to be put in a future with a wait all
+
+  // TODO before we did all 3 calls in 1 - we should still do that... get USD tate, get both fiat rates all at the same time
+
+  // TODO Not sure how to do that in the new architecture
+
+  // See rate_notifier - all 3 calls in 1 future
+
+  //   Future<FiatRateModel> getFiatRatesAlternate() async {
+  //   print("[http] get alternate fiat rates");
+
+  //   Response res = await get("http://data.fixer.io/api/latest?access_key=${Config.fixerApiKey}&symbols=CRC,GTQ,USD");
+
+  //   if (res.statusCode == 200) {
+  //     Map<String, dynamic> body = res.parseJson();
+  //     return FiatRateModel.fromJsonFixer(body);
+  //   } else {
+  //     print("Cannot fetch alternate rates..." + res.body.toString());
+  //     return FiatRateModel(null, base: null, error: true);
+  //   }
+  // }
+
 }

--- a/lib/v2/datasource/remote/api/rates_repository.dart
+++ b/lib/v2/datasource/remote/api/rates_repository.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/constants/config.dart';
 import 'package:seeds/v2/datasource/remote/api/network_repository.dart';
 import 'package:seeds/v2/datasource/remote/model/fiat_rate_model.dart';
 
@@ -16,12 +17,18 @@ class RatesRepository extends NetworkRepository {
             }))
         .catchError((error) => mapHttpError(error));
   }
-  
-  // TODO-NIK code below needs to be put in a future with a wait all
 
-  // TODO before we did all 3 calls in 1 - we should still do that... get USD tate, get both fiat rates all at the same time
+  Future<Result> getFiatRatesAlternate() {
+    print("[http] get fiat rates from fixer");
 
-  // TODO Not sure how to do that in the new architecture
+    return http
+        .get("http://data.fixer.io/api/latest?access_key=${Config.fixerApiKey}&symbols=CRC,GTQ,USD")
+        .then((http.Response response) => mapHttpResponse(response, (dynamic body) {
+              return FiatRateModel.fromJsonFixer(body);
+            }))
+        .catchError((error) => mapHttpError(error));
+  }
+
 
   // See rate_notifier - all 3 calls in 1 future
 

--- a/lib/v2/datasource/remote/model/fiat_rate_model.dart
+++ b/lib/v2/datasource/remote/model/fiat_rate_model.dart
@@ -1,25 +1,64 @@
 class FiatRateModel {
-  final Map<String, double> ratesPerUSD;
+  Map<String, double> rates;
+  String base;
+  final bool error;
 
-  FiatRateModel(this.ratesPerUSD);
+  List<String> get currencies {
+    var list = List<String>.from(rates.keys);
+    list.sort();
+    return list;
+  }
+
+  FiatRateModel(this.rates, {this.base = "USD", this.error = false});
 
   factory FiatRateModel.fromJson(Map<String, dynamic> json) {
     if (json != null && json.isNotEmpty) {
-      return FiatRateModel(Map<String, double>.from(json["rates"]));
+      return FiatRateModel(new Map<String, double>.from(json["rates"]));
     } else {
-      return FiatRateModel(null);
+      return FiatRateModel(null, error: true);
     }
   }
 
+  factory FiatRateModel.fromJsonFixer(Map<String, dynamic> json) {
+    if (json != null && json.isNotEmpty) {
+      var model = FiatRateModel(new Map<String, double>.from(json["rates"]), base: json["base"]);
+      model.rebase("USD");
+      return model;
+    } else {
+      return FiatRateModel(null, error: true);
+    }
+  }
+      
   double usdTo(double usdValue, String currency) {
-    double rate = ratesPerUSD[currency];
+    if (base != "USD") {
+      throw ArgumentError("not implemented");
+    } 
+    double rate = rates[currency];
     assert(rate != null);
     return usdValue * rate;
   }
-
+      
   double toUSD(double currencyValue, String currency) {
-    double rate = ratesPerUSD[currency];
+    if (base != "USD") {
+      throw ArgumentError("not implemented");
+    } 
+    double rate = rates[currency];
     assert(rate != null);
     return rate > 0 ? currencyValue / rate : 0;
   }
+      
+  void rebase(String symbol) {
+    var rate = rates[symbol];
+    if (rate != null) {
+      base = symbol;
+      rates = rates.map((key, value) => MapEntry(key, value / rate));
+    } else {
+      print("error - can't rebase to " + symbol);
+    }
+  }
+
+  void merge(FiatRateModel other) {
+    if (!other.error) rates.addAll(other.rates);
+  }
+
 }

--- a/lib/v2/screens/profile_screens/set_currency/interactor/mappers/rates_state_mapper.dart
+++ b/lib/v2/screens/profile_screens/set_currency/interactor/mappers/rates_state_mapper.dart
@@ -9,7 +9,17 @@ class RateStateMapper extends StateMapper {
       return currentState.copyWith(pageState: PageState.failure, errorMessage: result.asError.error.toString());
     } else {
       // System available currencies (33 at this moment)
-      final loaded = List<String>.from(result.asValue.value.ratesPerUSD.keys);
+      final loaded = List<String>.from(result.asValue.value.rates.keys);
+
+      // TODO-NIK: The code above was throwing at runtime because I had renamed ratesPerUSD to "rates"
+      // Can we somehow change this so that this would get caught at compile time?
+      // I am guessing it's because this is a non-specific class here so the compiler is unaware of the class
+      // of the object it's calling the member of.
+      // I also don't like direct member access, that is unclearn
+      // I did a quick test replacing it with the - already existing - accessor "currencies()" but that did
+      // not work  -Nik
+
+
       // All most_traded_currencies (93 at this moment) to a Currency objects
       final allCurrencies = currencies.map((currency) => Currency.from(json: currency)).toList();
       // Get only system available currencies from allCurrencies

--- a/lib/v2/screens/profile_screens/set_currency/interactor/usecases/get_fiat_rates_use_case.dart
+++ b/lib/v2/screens/profile_screens/set_currency/interactor/usecases/get_fiat_rates_use_case.dart
@@ -7,7 +7,12 @@ export 'package:async/src/result/result.dart';
 class GetFiatRatesUseCase {
   final RatesRepository _ratesRepository = RatesRepository();
 
-  Future<Result> run() {
-    return _ratesRepository.getFiatRates();
+  Future<List<Result>> run() {
+    var futures = [
+      _ratesRepository.getFiatRates(),
+      _ratesRepository.getFiatRatesAlternate(),
+    ];
+    return Future.wait(futures);
   }
+
 }

--- a/lib/v2/screens/profile_screens/set_currency/interactor/viewmodels/set_currency_bloc.dart
+++ b/lib/v2/screens/profile_screens/set_currency/interactor/viewmodels/set_currency_bloc.dart
@@ -12,7 +12,7 @@ class SetCurrencyBloc extends Bloc<SetCurrencyEvent, SetCurrencyState> {
   Stream<SetCurrencyState> mapEventToState(SetCurrencyEvent event) async* {
     if (event is LoadCurrencies) {
       yield state.copyWith(pageState: PageState.loading);
-      Result result = await GetFiatRatesUseCase().run();
+      var result = await GetFiatRatesUseCase().run();
       yield RateStateMapper().mapResultToState(state, result);
     }
     if (event is OnQueryChanged) {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://github.com/JoinSEEDS/seeds_light_wallet/issues/478

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [ ] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Draft pull request 

TODO=NIK notes to issues I don't know how to solve

#### 1 - RatesRepository
RatesRepository is non obvious to change - how to I make this a "wait all" which waits for all 3 rate conversion calls and makes them all in parallel? Currenly it's not even doing 2, it's only getting Fiat rates.

Does that mean additional repositories and then one container repository that waits for all 3 results?

Or adding it to this repository?

#### 2 - RateStateMapper
Has a generic object variable access that was not caught when I changed the member name

This is a problem. Compiler needs to catch all name changes, and this object should be using the accessor method, not call into the member variable directly

Just flagging this as a generic issue I am sure also happens in other cases

### 🙈 Screenshots

_For all UI changes_

| description 1 | description 2 |
| --- | --- |
| img1 | img2 |

### 👯‍♀️ Paired with

_@github-handle or "nobody" if you did not pair._
