### PR TITLE
supporting other tokens than Seeds on the main dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ pubspec\.lock
 \.flutter-plugins-dependencies
 ios/Podfile.lock
 dartesr/
+ios/Flutter/Flutter.podspec

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -178,6 +178,8 @@ class TransactionModel {
   final String memo;
   final String timestamp;
   final String transactionId;
+  
+  String get symbol { return quantity.split(" ")[1]; }
 
   TransactionModel(this.from, this.to, this.quantity, this.memo, this.timestamp,
       this.transactionId);

--- a/lib/utils/string_extension.dart
+++ b/lib/utils/string_extension.dart
@@ -10,5 +10,8 @@ extension StringExtension on String{
       return null;
     }
   }
+  
+  String get symbolFromAmount { return split(" ")[1]; }
+
 }
 

--- a/lib/widgets/v2_widgets/dashboard_widgets/transaction_info_card.dart
+++ b/lib/widgets/v2_widgets/dashboard_widgets/transaction_info_card.dart
@@ -77,7 +77,7 @@ class TransactionInfoCard extends StatelessWidget {
                           Expanded(
                               child: Text(timesTampToTimeAgo(timestamp),
                                   style: Theme.of(context).textTheme.subtitle2OpacityEmphasis)),
-                          Text('SEEDS'.i18n, style: Theme.of(context).textTheme.subtitle2OpacityEmphasis)
+                          Text(amount.symbolFromAmount, style: Theme.of(context).textTheme.subtitle2OpacityEmphasis)
                         ],
                       ),
                     ],


### PR DESCRIPTION
replaced hard coded "SEEDS" with the actual token in the transaction

### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

No issue was reported. 

The problem was when we issued TESTS tokens, they showed up as SEEDS tokens in the light wallet. 

Because SEEDS was hard-coded as the name. 

The solution is simple, as the token actually is part of the 'amount' string which we already have. We just take it from there.

Side-note: 'SEEDS' was also internationalized, which was incorrect. It's a symbol, like 'USD' it does not need to be translated.

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer


### 🙈 Screenshots

Transactions list with TESTS

![image](https://user-images.githubusercontent.com/65412/112784625-be6f9a80-9084-11eb-9adb-0f9b23752698.jpeg)


### 👯‍♀️ Paired with

nobody