### PR TITLE
removed toolbox library

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:flutter_toolbox/flutter_toolbox.dart';
 import 'package:hive/hive.dart';
 import 'package:i18n_extension/i18n_widget.dart';
 import 'package:path_provider/path_provider.dart';
@@ -26,6 +25,7 @@ import 'package:seeds/providers/services/firebase/push_notification_service.dart
 import 'package:seeds/screens/app/app.dart';
 import 'package:seeds/screens/onboarding/join_process.dart';
 import 'package:seeds/screens/onboarding/onboarding.dart';
+import 'package:seeds/utils/old_toolbox/toolbox_app.dart';
 import 'package:seeds/widgets/passcode.dart';
 import 'package:seeds/widgets/splash_screen.dart';
 import 'package:sentry/sentry.dart' as Sentry;

--- a/lib/screens/app/ecosystem/proposals/proposal_details.dart
+++ b/lib/screens/app/ecosystem/proposals/proposal_details.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_fluid_slider/flutter_fluid_slider.dart';
-import 'package:flutter_toolbox/flutter_toolbox.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:seeds/constants/app_colors.dart';
@@ -10,6 +9,8 @@ import 'package:seeds/providers/notifiers/voted_notifier.dart';
 import 'package:seeds/providers/services/eos_service.dart';
 import 'package:seeds/providers/services/http_service.dart';
 import 'package:seeds/screens/app/ecosystem/proposals/proposal_header_details.dart';
+import 'package:seeds/utils/old_toolbox/net_image.dart';
+import 'package:seeds/utils/old_toolbox/toast.dart';
 import 'package:seeds/widgets/seeds_button.dart';
 import 'package:url_launcher/url_launcher.dart' as UrlLauncher;
 import 'package:seeds/i18n/proposals.i18n.dart';
@@ -215,7 +216,7 @@ class ProposalDetailsPageState extends State<ProposalDetailsPage> {
                                           id: proposal.id,
                                           amount: _vote.toInt());
                                 } catch (e) {
-                                  d("e = $e");
+                                  print("e = $e");
                                   errorToast(
                                       "Unexpected error, please try again"
                                           .i18n);

--- a/lib/screens/app/ecosystem/proposals/proposal_header_details.dart
+++ b/lib/screens/app/ecosystem/proposals/proposal_header_details.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_toolbox/flutter_toolbox.dart';
 import 'package:intl/intl.dart';
 import 'package:percent_indicator/percent_indicator.dart';
 import 'package:seeds/models/models.dart';
 import 'package:seeds/providers/notifiers/voted_notifier.dart';
+import 'package:seeds/utils/old_toolbox/net_image.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:seeds/i18n/proposals.i18n.dart';
 

--- a/lib/screens/app/ecosystem/proposals/proposals.dart
+++ b/lib/screens/app/ecosystem/proposals/proposals.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_toolbox/flutter_toolbox.dart';
 import 'package:seeds/models/models.dart';
 import 'package:seeds/providers/services/http_service.dart';
 import 'package:seeds/providers/services/navigation_service.dart';
 import 'package:seeds/screens/app/ecosystem/proposals/proposal_header_details.dart';
 import 'package:seeds/i18n/proposals.i18n.dart';
+import 'package:seeds/utils/old_toolbox/paginated_list_view.dart';
 
 class Proposals extends StatefulWidget {
   @override

--- a/lib/screens/app/guardians/guardian_invite.dart
+++ b/lib/screens/app/guardians/guardian_invite.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_toolbox/flutter_toolbox.dart';
 import 'package:seeds/i18n/guardians.i18n.dart';
 import 'package:seeds/models/models.dart';
 import 'package:seeds/providers/notifiers/settings_notifier.dart';
 import 'package:seeds/providers/services/firebase/firebase_database_service.dart';
 import 'package:seeds/providers/services/navigation_service.dart';
 import 'package:seeds/screens/shared/user_tile.dart';
+import 'package:seeds/utils/old_toolbox/toast.dart';
 import 'package:seeds/widgets/main_button.dart';
 
 class InviteGuardians extends StatefulWidget {

--- a/lib/screens/app/guardians/my_guardians_tab.dart
+++ b/lib/screens/app/guardians/my_guardians_tab.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_toolbox/flutter_toolbox.dart';
 import 'package:seeds/constants/app_colors.dart';
 import 'package:seeds/models/firebase/guardian.dart';
 import 'package:seeds/models/firebase/guardian_status.dart';
@@ -11,6 +10,7 @@ import 'package:seeds/providers/services/firebase/firebase_database_service.dart
 import 'package:seeds/providers/services/guardian_services.dart';
 import 'package:seeds/screens/app/guardians/my_guardian_users_list.dart';
 import 'package:seeds/screens/app/guardians/my_guardians_tutorial.dart';
+import 'package:seeds/utils/old_toolbox/toast.dart';
 import 'package:seeds/widgets/main_button.dart';
 import 'package:seeds/widgets/transaction_avatar.dart';
 

--- a/lib/screens/app/guardians/select_guardians.dart
+++ b/lib/screens/app/guardians/select_guardians.dart
@@ -1,7 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_toolbox/flutter_toolbox.dart';
 import 'package:liquid_pull_to_refresh/liquid_pull_to_refresh.dart';
 import 'package:provider/provider.dart';
 import 'package:seeds/constants/app_colors.dart';
@@ -12,6 +11,7 @@ import 'package:seeds/providers/services/firebase/firebase_database_service.dart
 import 'package:seeds/providers/services/navigation_service.dart';
 import 'package:seeds/screens/shared/shimmer_tile.dart';
 import 'package:seeds/screens/shared/user_tile.dart';
+import 'package:seeds/utils/old_toolbox/toast.dart';
 import 'package:seeds/widgets/main_button.dart';
 import 'package:seeds/i18n/guardians.i18n.dart';
 

--- a/lib/screens/app/wallet/dashboard.dart
+++ b/lib/screens/app/wallet/dashboard.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_toolbox/flutter_toolbox.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:seeds/constants/app_colors.dart';
@@ -18,6 +17,7 @@ import 'package:seeds/providers/services/guardian_services.dart';
 // import 'package:seeds/providers/services/http_service.dart';
 import 'package:seeds/providers/services/navigation_service.dart';
 import 'package:seeds/providers/useCases/dashboard_usecases.dart';
+import 'package:seeds/utils/old_toolbox/toast.dart';
 import 'package:seeds/utils/string_extension.dart';
 import 'package:seeds/widgets/empty_button.dart';
 import 'package:seeds/widgets/main_button.dart';

--- a/lib/screens/onboarding/show_onboarding_choice.dart
+++ b/lib/screens/onboarding/show_onboarding_choice.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_toolbox/flutter_toolbox.dart';
 import 'package:seeds/constants/app_colors.dart';
 import 'package:seeds/constants/config.dart';
 import 'package:seeds/providers/services/firebase/firebase_remote_config.dart';
+import 'package:seeds/utils/old_toolbox/toast.dart';
 import 'package:seeds/widgets/main_button.dart';
-import 'package:url_launcher/url_launcher.dart' as UrlLauncher;
+import 'package:url_launcher/url_launcher.dart';
 import 'package:seeds/i18n/show_onboarding_choice.i18n.dart';
 
 class ShowOnboardingChoice extends StatelessWidget {
@@ -84,7 +84,7 @@ class ShowOnboardingChoice extends StatelessWidget {
                   ),
                 ),
                 onPressed: () =>
-                    UrlLauncher.launch(Config.termsAndConditionsUrl),
+                    launch(Config.termsAndConditionsUrl),
               ),
               FlatButton(
                 color: Colors.transparent,
@@ -95,7 +95,7 @@ class ShowOnboardingChoice extends StatelessWidget {
                     fontSize: 13,
                   ),
                 ),
-                onPressed: () => UrlLauncher.launch(Config.privacyPolicyUrl),
+                onPressed: () => launch(Config.privacyPolicyUrl),
               ),
             ],
           ),
@@ -103,6 +103,14 @@ class ShowOnboardingChoice extends StatelessWidget {
       ),
     );
   }
+
+Future<void> safeLaunch(String urlString) async {
+  if (await canLaunch(urlString)) {
+    await launch(urlString);
+  } else {
+    errorToast("Couldn't open this url $urlString");
+  }
+}
 
   @override
   Widget build(BuildContext context) {

--- a/lib/utils/old_toolbox/common.dart
+++ b/lib/utils/old_toolbox/common.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pagewise/flutter_pagewise.dart';
+import 'package:seeds/utils/old_toolbox/toolbox_config.dart';
+
+NoItemsFoundBuilder noItemsFoundBuilder(
+  BuildContext context, {
+  @required NoItemsFoundBuilder noItemsFoundBuilder,
+  @required Widget noItemsFoundWidget,
+}) {
+  final defaultNoItemsFoundBuilder = noItemsFoundWidget == null
+      ? null
+      : (BuildContext context) {
+          final height = MediaQuery.of(context).size.height - kToolbarHeight;
+          return SizedBox(
+            height: height,
+            child: Center(
+              child: noItemsFoundWidget,
+            ),
+          );
+        };
+
+  final localNoItemFound = noItemsFoundBuilder ?? defaultNoItemsFoundBuilder;
+
+  final config = ToolboxConfig.of(context);
+  final globalNoItemFound = config.noItemsFoundBuilder ??
+      _buildNoItemFoundBuilder(config.noItemsFoundWidget);
+
+  return localNoItemFound ?? globalNoItemFound;
+}
+
+NoItemsFoundBuilder _buildNoItemFoundBuilder(Widget noItemsFoundWidget) {
+  return (BuildContext context) {
+    // remove the height of the appBar and some to make sure
+    // the noItemsFoundWidget don't scroll
+    final height = MediaQuery.of(context).size.height - kToolbarHeight * 3;
+    return SizedBox(
+      height: height,
+      child: Center(
+        child: noItemsFoundWidget,
+      ),
+    );
+  };
+}

--- a/lib/utils/old_toolbox/net_image.dart
+++ b/lib/utils/old_toolbox/net_image.dart
@@ -1,0 +1,263 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:photo_view/photo_view.dart';
+
+class NetImage extends StatelessWidget {
+  NetImage(
+    this.imageUrl, {
+    Key key,
+    this.imageBuilder,
+    this.placeholder,
+    this.errorWidget,
+    this.fadeOutDuration: const Duration(milliseconds: 300),
+    this.fadeOutCurve: Curves.easeOut,
+    this.fadeInDuration: const Duration(milliseconds: 700),
+    this.fadeInCurve: Curves.easeIn,
+    this.width,
+    this.height,
+    this.fit,
+    this.alignment: Alignment.center,
+    this.repeat: ImageRepeat.noRepeat,
+    this.matchTextDirection = false,
+    this.httpHeaders,
+    this.cacheManager,
+    this.useOldImageOnUrlChange = false,
+    this.color,
+    this.colorBlendMode,
+    this.fullScreen = false,
+    this.hero = false,
+    this.borderRadius,
+    this.onTap,
+  });
+
+  /// Option to use cachemanager with other settings
+  final BaseCacheManager cacheManager;
+
+  /// The target image that is displayed.
+  final String imageUrl;
+
+  /// Optional builder to further customize the display of the image.
+  final ImageWidgetBuilder imageBuilder;
+
+  /// Widget displayed while the target [imageUrl] is loading.
+  final PlaceholderWidgetBuilder placeholder;
+
+  /// Widget displayed while the target [imageUrl] failed loading.
+  final LoadingErrorWidgetBuilder errorWidget;
+
+  /// The duration of the fade-out animation for the [placeholder].
+  final Duration fadeOutDuration;
+
+  /// The curve of the fade-out animation for the [placeholder].
+  final Curve fadeOutCurve;
+
+  /// The duration of the fade-in animation for the [imageUrl].
+  final Duration fadeInDuration;
+
+  /// The curve of the fade-in animation for the [imageUrl].
+  final Curve fadeInCurve;
+
+  /// If non-null, require the image to have this width.
+  ///
+  /// If null, the image will pick a size that best preserves its intrinsic
+  /// aspect ratio. This may result in a sudden change if the size of the
+  /// placeholder widget does not match that of the target image. The size is
+  /// also affected by the scale factor.
+  final double width;
+
+  /// If non-null, require the image to have this height.
+  ///
+  /// If null, the image will pick a size that best preserves its intrinsic
+  /// aspect ratio. This may result in a sudden change if the size of the
+  /// placeholder widget does not match that of the target image. The size is
+  /// also affected by the scale factor.
+  final double height;
+
+  /// How to inscribe the image into the space allocated during layout.
+  ///
+  /// The default varies based on the other fields. See the discussion at
+  /// [paintImage].
+  final BoxFit fit;
+
+  /// How to align the image within its bounds.
+  ///
+  /// The alignment aligns the given position in the image to the given position
+  /// in the layout bounds. For example, a [Alignment] alignment of (-1.0,
+  /// -1.0) aligns the image to the top-left corner of its layout bounds, while a
+  /// [Alignment] alignment of (1.0, 1.0) aligns the bottom right of the
+  /// image with the bottom right corner of its layout bounds. Similarly, an
+  /// alignment of (0.0, 1.0) aligns the bottom middle of the image with the
+  /// middle of the bottom edge of its layout bounds.
+  ///
+  /// If the [alignment] is [TextDirection]-dependent (i.e. if it is a
+  /// [AlignmentDirectional]), then an ambient [Directionality] widget
+  /// must be in scope.
+  ///
+  /// Defaults to [Alignment.center].
+  ///
+  /// See also:
+  ///
+  ///  * [Alignment], a class with convenient constants typically used to
+  ///    specify an [AlignmentGeometry].
+  ///  * [AlignmentDirectional], like [Alignment] for specifying alignments
+  ///    relative to text direction.
+  final AlignmentGeometry alignment;
+
+  /// How to paint any portions of the layout bounds not covered by the image.
+  final ImageRepeat repeat;
+
+  /// Whether to paint the image in the direction of the [TextDirection].
+  ///
+  /// If this is true, then in [TextDirection.ltr] contexts, the image will be
+  /// drawn with its origin in the top left (the "normal" painting direction for
+  /// children); and in [TextDirection.rtl] contexts, the image will be drawn with
+  /// a scaling factor of -1 in the horizontal direction so that the origin is
+  /// in the top right.
+  ///
+  /// This is occasionally used with children in right-to-left environments, for
+  /// children that were designed for left-to-right locales. Be careful, when
+  /// using this, to not flip children with integral shadows, text, or other
+  /// effects that will look incorrect when flipped.
+  ///
+  /// If this is true, there must be an ambient [Directionality] widget in
+  /// scope.
+  final bool matchTextDirection;
+
+  // Optional headers for the http request of the image url
+  final Map<String, String> httpHeaders;
+
+  /// When set to true it will animate from the old image to the new image
+  /// if the url changes.
+  final bool useOldImageOnUrlChange;
+
+  /// If non-null, this color is blended with each image pixel using [colorBlendMode].
+  final Color color;
+
+  /// Used to combine [color] with this image.
+  ///
+  /// The default is [BlendMode.srcIn]. In terms of the blend mode, [color] is
+  /// the source and this image is the destination.
+  ///
+  /// See also:
+  ///
+  ///  * [BlendMode], which includes an illustration of the effect of each blend mode.
+  final BlendMode colorBlendMode;
+
+  /// default false.
+  final bool fullScreen;
+
+  /// Adds hero animation, uses the url as the hero tag.
+  /// [fullScreen] needs to be true for this to work.
+  /// default false.
+  final bool hero;
+
+  /// defaults to 0
+  final BorderRadius borderRadius;
+
+  /// Called when the user taps this part of the image.
+  final GestureTapCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final _errorWidget = errorWidget ?? (_, __, ___) => Icon(Icons.image);
+
+    if (imageUrl?.isNotEmpty != true) return _errorWidget(context, '', null);
+
+    final cachedNetworkImage = CachedNetworkImage(
+      imageUrl: imageUrl,
+      placeholder:
+          placeholder ?? (_, __) => Center(child: CircularProgressIndicator()),
+      errorWidget: _errorWidget,
+      imageBuilder: imageBuilder,
+      fadeOutDuration: fadeOutDuration,
+      fadeOutCurve: fadeOutCurve,
+      fadeInDuration: fadeInDuration,
+      fadeInCurve: fadeInCurve,
+      width: width,
+      height: height,
+      fit: fit,
+      alignment: alignment,
+      repeat: repeat,
+      matchTextDirection: matchTextDirection,
+      httpHeaders: httpHeaders,
+      cacheManager: cacheManager,
+      useOldImageOnUrlChange: useOldImageOnUrlChange,
+      color: color,
+      colorBlendMode: colorBlendMode,
+      key: key,
+    );
+
+    return SizedBox(
+      width: width,
+      height: height,
+      child: ClipRRect(
+        borderRadius: borderRadius ?? BorderRadius.circular(0),
+        child: Stack(
+          children: <Widget>[
+            fullScreen && hero
+                ? Hero(
+                    tag: imageUrl,
+                    child: cachedNetworkImage,
+                  )
+                : cachedNetworkImage,
+            Positioned.fill(
+              child: Material(
+                type: MaterialType.transparency,
+                child: InkWell(
+                  onTap: onTap != null
+                      ? onTap
+                      : fullScreen ? () => _openFullScreen(context) : null,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future _openFullScreen(BuildContext context) {
+    return push(context, FullScreenImage(imageUrl));
+  }
+}
+
+Future push(BuildContext context, Widget widget, {bool setName = true}) =>
+    Navigator.of(context).push(materialRoute(widget, setName: setName));
+
+MaterialPageRoute materialRoute(Widget widget, {bool setName = true}) =>
+    MaterialPageRoute(
+      builder: (context) => widget,
+      settings: setName ? RouteSettings(name: widget.toString()) : null,
+    );
+
+class FullScreenImage extends StatelessWidget {
+  FullScreenImage(this.imageUrl);
+
+  final String imageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: Key(imageUrl),
+      direction: DismissDirection.vertical,
+      onDismissed: (direction) => Navigator.of(context).pop(),
+      child: Dismissible(
+        key: Key(imageUrl),
+        onDismissed: (direction) => Navigator.of(context).pop(),
+        child: Scaffold(
+          appBar: AppBar(
+            backgroundColor: Colors.black,
+            leading: CloseButton(),
+          ),
+          backgroundColor: Colors.black,
+          body: PhotoView(
+            imageProvider: NetworkImage(imageUrl),
+            heroAttributes: PhotoViewHeroAttributes(tag: imageUrl),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/old_toolbox/paginated_list_view.dart
+++ b/lib/utils/old_toolbox/paginated_list_view.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pagewise/flutter_pagewise.dart';
+
+import 'common.dart';
+
+class PaginatedListView<T> extends StatefulWidget {
+  final ItemBuilder<T> itemBuilder;
+  final PageFuture<T> pageFuture;
+  final int pageSize;
+  final EdgeInsetsGeometry padding;
+  final NoItemsFoundBuilder noItemsFoundBuilder;
+  final Widget noItemsFoundWidget;
+  final PagewiseLoadController<T> pageLoadController;
+
+  /// default is false
+  ///
+  /// set to true if the future will change.
+  final bool mutable;
+
+  /// default is false
+  ///
+  /// set to true if the future will change.
+  final bool showRefreshIndicator;
+
+  final Axis scrollDirection;
+  final bool shrinkWrap;
+
+  const PaginatedListView({
+    Key key,
+    @required this.itemBuilder,
+    @required this.pageFuture,
+    this.pageSize = 10,
+    this.padding,
+    this.noItemsFoundBuilder,
+    this.noItemsFoundWidget,
+    this.pageLoadController,
+    this.mutable = false,
+    this.showRefreshIndicator = false,
+    this.scrollDirection = Axis.vertical,
+    this.shrinkWrap = false,
+  }) : super(key: key);
+
+  @override
+  _PaginatedListViewState<T> createState() => _PaginatedListViewState<T>();
+}
+
+class _PaginatedListViewState<T> extends State<PaginatedListView<T>> {
+  bool _reload = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.showRefreshIndicator
+        ? RefreshIndicator(
+            onRefresh: () async {
+              await widget.pageFuture(1);
+              setState(() => _reload = true);
+            },
+            child: buildListView(),
+          )
+        : buildListView();
+  }
+
+  Widget buildListView() {
+    final mutable = widget.mutable ||
+//        widget.showRefreshIndicator || removed as there it serve no purpose leave here just in case there is a side effect
+        _reload ||
+        widget.pageLoadController != null;
+
+    _reload = false;
+
+    final PageFuture<T> pageFuture =
+        (int pageIndex) => widget.pageFuture(pageIndex + 1);
+
+    final pageLoadController = widget.pageLoadController ??
+        PagewiseLoadController(
+          pageSize: widget.pageSize,
+          pageFuture: pageFuture,
+        );
+
+    return PagewiseListView<T>(
+      itemBuilder: widget.itemBuilder,
+      padding: widget.padding,
+      noItemsFoundBuilder: noItemsFoundBuilder(
+        context,
+        noItemsFoundBuilder: widget.noItemsFoundBuilder,
+        noItemsFoundWidget: widget.noItemsFoundWidget,
+      ),
+      pageLoadController: mutable ? pageLoadController : null,
+      pageSize: mutable ? null : widget.pageSize,
+      pageFuture: mutable ? null : pageFuture,
+      scrollDirection: widget.scrollDirection,
+      shrinkWrap: widget.shrinkWrap,
+    );
+  }
+}

--- a/lib/utils/old_toolbox/toast.dart
+++ b/lib/utils/old_toolbox/toast.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:oktoast/oktoast.dart';
+
+const int LONG_DELAY = 3500;
+const LONG_DURATION = const Duration(milliseconds: LONG_DELAY);
+
+errorToast(String msg) {
+  showToast(
+    msg,
+    duration: LONG_DURATION,
+    backgroundColor: Colors.red,
+    textStyle: TextStyle(color: Colors.white),
+  );
+}
+
+successToast(String msg) {
+  showToast(
+    msg,
+    duration: LONG_DURATION,
+    backgroundColor: Colors.green,
+    textStyle: TextStyle(color: Colors.white),
+  );
+}
+
+toast(String msg) {
+  showToast(
+    msg,
+    duration: LONG_DURATION,
+  );
+}

--- a/lib/utils/old_toolbox/toolbox_app.dart
+++ b/lib/utils/old_toolbox/toolbox_app.dart
@@ -1,0 +1,58 @@
+import 'dart:collection';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_pagewise/flutter_pagewise.dart';
+import 'package:oktoast/oktoast.dart';
+import 'package:provider/provider.dart';
+import 'package:seeds/utils/old_toolbox/toolbox_config.dart';
+
+LinkedHashMap<_ToolboxAppState, BuildContext> contextMap = LinkedHashMap();
+
+class ToolboxApp extends StatefulWidget {
+  const ToolboxApp({
+    Key key,
+    @required this.child,
+    this.noItemsFoundBuilder,
+    this.noItemsFoundWidget,
+  }) : super(key: key);
+
+  /// Usually should be [MaterialApp] or [CupertinoApp].
+  final Widget child;
+
+  final NoItemsFoundBuilder noItemsFoundBuilder;
+  final Widget noItemsFoundWidget;
+
+  @override
+  _ToolboxAppState createState() => _ToolboxAppState();
+}
+
+class _ToolboxAppState extends State<ToolboxApp> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    contextMap.remove(this);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    contextMap[this] = context;
+
+    return OKToast(
+      textPadding: EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+      position: ToastPosition.bottom,
+      radius: 50,
+      child: Provider.value(
+        value: ToolboxConfig(
+          noItemsFoundBuilder: widget.noItemsFoundBuilder,
+          noItemsFoundWidget: widget.noItemsFoundWidget,
+        ),
+        child: widget.child,
+      ),
+    );
+  }
+}

--- a/lib/utils/old_toolbox/toolbox_config.dart
+++ b/lib/utils/old_toolbox/toolbox_config.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pagewise/flutter_pagewise.dart';
+import 'package:provider/provider.dart';
+
+class ToolboxConfig {
+  ToolboxConfig({
+    this.noItemsFoundBuilder,
+    this.noItemsFoundWidget,
+  });
+
+  final NoItemsFoundBuilder noItemsFoundBuilder;
+  final Widget noItemsFoundWidget;
+
+  static ToolboxConfig of(BuildContext context) =>
+      Provider.of<ToolboxConfig>(context);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,8 +17,8 @@ dependencies:
     sdk: flutter
   i18n_extension: ^1.3.7
   cupertino_icons: ^0.1.3
-  flutter_toolbox: ^4.6.2
   http: ^0.12.0+4
+  url_launcher: ^5.4.1
   shared_preferences: ^0.5.6+1
   flutter_secure_storage: ^3.3.2
   local_auth: ^0.6.2+3
@@ -60,6 +60,7 @@ dependencies:
   path_provider: ^1.6.24
   dotted_border: ^1.0.6
   intl_phone_number_input: ^0.6.0
+  flutter_pagewise: ^1.2.3
   qr_code_scanner:
     git:
       url: git://github.com/triply-at/qr_code_scanner.git


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

POC how to remove toolbox library. 

Very easy. 

For some reason my dart code analysis does not work on the main branch s  o there, can't do it.


### ✅ Checklist

- [x] Code migrated

### 🕵️‍♂️ Notes for Code Reviewer

Code was simply moved from the library to the main app

1 dependency in the lib was moved over to pubspec: url_launcher

1 built-in code repo was moved to pubspec: flutter_pagewise
This one, was just added as source files to the repo from humazed. 

Some very small utility functions I moved directly into the file. 

All migrated classes are in lib/utils/old_toolbox

### 🙈 Screenshots


### 👯‍♀️ Paired with

nobody