### PR TITLE
Bugfix/eos dependencies and ios fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ A payment platform and financial ecosystem to empower humanity and heal our plan
 git clone https://github.com/7flash/flutter_seeds_wallet.git
 cd flutter_seeds_wallet
 flutter pub get
-flutter run
+flutter run lib/v2/main.dart --no-sound-null-safety
 ```
+
+### Sound null safety is off
+Run with ```--no-sound-null-safety``` flags as there are some external libraries that are not null safe
 
 ## Dev configuration
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -37,5 +37,8 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '9.0'
+    end
   end
 end

--- a/lib/providers/notifiers/connection_notifier.dart
+++ b/lib/providers/notifiers/connection_notifier.dart
@@ -26,7 +26,6 @@ class ConnectionNotifier extends ChangeNotifier {
     'https://telos.eosphere.io',
     'https://telos.caleos.io',
     'https://api.eos.miami',
-    'https://hyperion.telosgermany.io',
   ];
 
   void init() {

--- a/lib/v2/datasource/local/qr_code_service.dart
+++ b/lib/v2/datasource/local/qr_code_service.dart
@@ -1,4 +1,5 @@
 import 'package:async/async.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:dart_esr/dart_esr.dart';
 import 'package:seeds/v2/datasource/local/models/scan_qr_code_result_data.dart';
 import 'package:seeds/v2/datasource/local/qr_code_service.dart';

--- a/lib/v2/datasource/remote/api/eos_repository.dart
+++ b/lib/v2/datasource/remote/api/eos_repository.dart
@@ -1,4 +1,5 @@
 import 'package:async/async.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:eosdart/eosdart.dart';
 import 'package:seeds/constants/config.dart';
 import 'package:seeds/v2/datasource/local/settings_storage.dart';

--- a/lib/v2/datasource/remote/api/profile_repository.dart
+++ b/lib/v2/datasource/remote/api/profile_repository.dart
@@ -1,4 +1,5 @@
 import 'package:async/async.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/v2/datasource/remote/api/eos_repository.dart';

--- a/lib/v2/datasource/remote/api/send_eos_transaction_repository.dart
+++ b/lib/v2/datasource/remote/api/send_eos_transaction_repository.dart
@@ -1,4 +1,5 @@
 import 'package:async/async.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:eosdart/eosdart.dart';
 import 'package:seeds/v2/datasource/remote/api/eos_repository.dart';
 

--- a/lib/v2/screens/import_key/interactor/usecases/check_private_key_use_case.dart
+++ b/lib/v2/screens/import_key/interactor/usecases/check_private_key_use_case.dart
@@ -9,8 +9,9 @@ class CheckPrivateKeyUseCase {
       EOSPrivateKey eosPrivateKey = EOSPrivateKey.fromString(privateKey);
       EOSPublicKey eosPublicKey = eosPrivateKey.toEOSPublicKey();
       return eosPublicKey.toString();
-    } catch (e) {
-      print("Error EOSPrivateKey.fromString");
+    } catch (e, s) {
+      print("Error EOSPrivateKey.fromString ${e}");
+      print(s);
       return null;
     }
   }

--- a/lib/v2/screens/import_key/interactor/usecases/check_private_key_use_case.dart
+++ b/lib/v2/screens/import_key/interactor/usecases/check_private_key_use_case.dart
@@ -1,3 +1,4 @@
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:eosdart_ecc/eosdart_ecc.dart';
 
 export 'package:async/src/result/error.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,10 +52,14 @@ dependencies:
   image_picker: ^0.7.4
   oktoast: ^3.0.0
   eosdart:
-    git: git://github.com/JoinSEEDS/eosdart.git
+    git: 
+      url: https://github.com/JoinSEEDS/eosdart.git
+      ref: flutter_2_nns
   dart_esr:
     git:
       url: https://github.com/JoinSEEDS/dart-esr.git
+      ref: flutter_2_nns
+      
   webview_flutter: ^2.0.2
   rubber: ^1.0.0
   path_provider: ^2.0.1


### PR DESCRIPTION
Fixes 2 bugs, no more null safety for eosdart, dart_esr, and eosdart_ecc

1 - Import private key failed for some keys - likely due to a change in the pointycastle dependent library which we upgraded to 3.x for null safety
2 - iOS failed because some pods were generated with an iOS 8 deployment target. Overriding to 9. \

I created flutter_2_nss branches in all 3 libraries' forks in our repo, which depend on each other. 

They have updates so they are compatible with the dependencies in the main project, but leave pointycastle at 1.x and have no null safety fixes. 