### PR TITLE
Initial set up for snackbars

### DIFF
--- a/lib/v2/components/snack_bar_info.dart
+++ b/lib/v2/components/snack_bar_info.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class SnackBarInfo extends SnackBar {
+  SnackBarInfo({Key? key, required String title, required BuildContext context})
+      : super(
+          key: key,
+          content: Row(
+            children: [
+              Expanded(
+                child: Text(title, textAlign: TextAlign.center, style: Theme.of(context).textTheme.subtitle2),
+              ),
+              InkWell(
+                child: const Icon(Icons.close),
+                onTap: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(),
+              ),
+            ],
+          ),
+        );
+}

--- a/lib/v2/design/app_theme.dart
+++ b/lib/v2/design/app_theme.dart
@@ -11,6 +11,7 @@ class SeedsAppTheme {
       canvasColor: AppColors.primary,
       appBarTheme: const AppBarTheme(elevation: 0.0),
       inputDecorationTheme: SeedsInputDecorationTheme.lightTheme,
+      snackBarTheme: const SnackBarThemeData(backgroundColor: AppColors.grey, behavior: SnackBarBehavior.floating),
     );
   }
 
@@ -23,6 +24,7 @@ class SeedsAppTheme {
       canvasColor: AppColors.primary,
       appBarTheme: const AppBarTheme(elevation: 0.0),
       inputDecorationTheme: SeedsInputDecorationTheme.darkTheme,
+      snackBarTheme: const SnackBarThemeData(backgroundColor: AppColors.grey, behavior: SnackBarBehavior.floating),
     );
   }
 }

--- a/lib/v2/screens/explore_screens/invite/interactor/mappers/create_invite_result_state_mapper.dart
+++ b/lib/v2/screens/explore_screens/invite/interactor/mappers/create_invite_result_state_mapper.dart
@@ -6,12 +6,18 @@ import 'package:seeds/v2/screens/explore_screens/invite/interactor/viewmodels/in
 class CreateInviteResultStateMapper extends StateMapper {
   InviteState mapResultsToState(InviteState currentState, List<Result> results) {
     if (areAllResultsError(results)) {
-      return currentState.copyWith(pageState: PageState.failure, errorMessage: 'Error creating invite');
+      // The 2 calls are error --> ransaction fail show snackbar fail
+      print('Error transaction hash not retrieved');
+      return currentState.copyWith(
+        pageState: PageState.success,
+        pageCommand: ShowTransactionFailSnackBar(),
+        isCreateInviteButtonEnabled: false,
+      );
     } else {
       print('CreateInviteResultStateMapper mapResultsToState length = ${results.length}');
+      // Check if the error is in the transaction
       results.retainWhere((Result element) => element.isValue);
       var values = results.map((Result element) => element.asValue!.value).toList();
-
       TransactionResponse? response = values.firstWhere((i) => i is TransactionResponse, orElse: () => null);
 
       if (response != null && response.transactionId.isNotEmpty) {

--- a/lib/v2/screens/explore_screens/invite/interactor/mappers/create_invite_result_state_mapper.dart
+++ b/lib/v2/screens/explore_screens/invite/interactor/mappers/create_invite_result_state_mapper.dart
@@ -24,8 +24,13 @@ class CreateInviteResultStateMapper extends StateMapper {
           dynamicSecretLink: dynamicSecretLink.toString(),
         );
       } else {
-        // Transaction fails --> close screen and show snackbar fail
-        return currentState.copyWith(pageCommand: ShowTransactionFailSnackBar());
+        // Transaction fail show snackbar fail
+        print('Error transaction hash not retrieved');
+        return currentState.copyWith(
+          pageState: PageState.success,
+          pageCommand: ShowTransactionFailSnackBar(),
+          isCreateInviteButtonEnabled: false,
+        );
       }
     }
   }

--- a/lib/v2/screens/explore_screens/invite/interactor/mappers/create_invite_result_state_mapper.dart
+++ b/lib/v2/screens/explore_screens/invite/interactor/mappers/create_invite_result_state_mapper.dart
@@ -6,7 +6,7 @@ import 'package:seeds/v2/screens/explore_screens/invite/interactor/viewmodels/in
 class CreateInviteResultStateMapper extends StateMapper {
   InviteState mapResultsToState(InviteState currentState, List<Result> results) {
     if (areAllResultsError(results)) {
-      // The 2 calls are error --> ransaction fail show snackbar fail
+      // The 2 calls are error --> transaction fail show snackbar fail
       print('Error transaction hash not retrieved');
       return currentState.copyWith(
         pageState: PageState.success,

--- a/lib/v2/screens/explore_screens/invite/invite_screen.dart
+++ b/lib/v2/screens/explore_screens/invite/invite_screen.dart
@@ -7,7 +7,6 @@ import 'package:seeds/v2/components/balance_row.dart';
 import 'package:seeds/v2/components/flat_button_long.dart';
 import 'package:seeds/v2/components/full_page_error_indicator.dart';
 import 'package:seeds/v2/components/full_page_loading_indicator.dart';
-import 'package:seeds/v2/constants/app_colors.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
 import 'package:seeds/v2/domain-shared/ui_constants.dart';
 import 'package:seeds/v2/design/app_theme.dart';
@@ -40,15 +39,22 @@ class InviteScreen extends StatelessWidget {
               );
             }
             if (state.pageCommand is ShowTransactionFailSnackBar) {
-              Navigator.of(context).pop();
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  behavior: SnackBarBehavior.floating,
-                  backgroundColor: AppColors.grey,
-                  content: Text(
-                    'Invite creation failed, try again',
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.subtitle2,
+                  content: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          'Invite creation failed, try again',
+                          textAlign: TextAlign.center,
+                          style: Theme.of(context).textTheme.subtitle2,
+                        ),
+                      ),
+                      InkWell(
+                        child: const Icon(Icons.close),
+                        onTap: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(),
+                      ),
+                    ],
                   ),
                 ),
               );

--- a/lib/v2/screens/explore_screens/invite/invite_screen.dart
+++ b/lib/v2/screens/explore_screens/invite/invite_screen.dart
@@ -7,6 +7,7 @@ import 'package:seeds/v2/components/balance_row.dart';
 import 'package:seeds/v2/components/flat_button_long.dart';
 import 'package:seeds/v2/components/full_page_error_indicator.dart';
 import 'package:seeds/v2/components/full_page_loading_indicator.dart';
+import 'package:seeds/v2/components/snack_bar_info.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
 import 'package:seeds/v2/domain-shared/ui_constants.dart';
 import 'package:seeds/v2/design/app_theme.dart';
@@ -40,23 +41,7 @@ class InviteScreen extends StatelessWidget {
             }
             if (state.pageCommand is ShowTransactionFailSnackBar) {
               ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          'Invite creation failed, try again',
-                          textAlign: TextAlign.center,
-                          style: Theme.of(context).textTheme.subtitle2,
-                        ),
-                      ),
-                      InkWell(
-                        child: const Icon(Icons.close),
-                        onTap: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(),
-                      ),
-                    ],
-                  ),
-                ),
+                SnackBarInfo(title: 'Invite creation failed, try again.', context: context),
               );
             }
           },

--- a/lib/v2/screens/explore_screens/plant_seeds/components/plant_seeds_success_dialog.dart
+++ b/lib/v2/screens/explore_screens/plant_seeds/components/plant_seeds_success_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:seeds/v2/components/custom_dialog.dart';
+import 'package:seeds/v2/datasource/local/settings_storage.dart';
 import 'package:seeds/v2/design/app_theme.dart';
 import 'package:seeds/v2/domain-shared/ui_constants.dart';
 import 'package:seeds/i18n/plant_seeds.i18n.dart';
@@ -12,39 +13,46 @@ class PlantSeedsSuccessDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CustomDialog(
-      icon: SvgPicture.asset('assets/images/security/success_outlined_icon.svg'),
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              '${BlocProvider.of<PlantSeedsBloc>(context).state.quantity}',
-              style: Theme.of(context).textTheme.headline4Black,
-            ),
-            Padding(
-              padding: const EdgeInsets.only(top: 12, left: 4),
-              child: Text(currencySeedsCode, style: Theme.of(context).textTheme.subtitle2OpacityEmphasisBlack),
-            ),
-          ],
-        ),
-        const SizedBox(height: 16.0),
-        Text(
-          BlocProvider.of<PlantSeedsBloc>(context).state.fiatAmount,
-          style: Theme.of(context).textTheme.subtitle2OpacityEmphasisBlack,
-        ),
-        const SizedBox(height: 30.0),
-        Text(
-          'Congratulations\nYour seeds were planted successfully!'.i18n,
-          textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.buttonBlack,
-        ),
-      ],
-      singleLargeButtonTitle: 'Close'.i18n,
-      onSingleLargeButtonPressed: () {
+    return WillPopScope(
+      onWillPop: () async {
         Navigator.of(context).pop();
         Navigator.of(context).pop();
+        return true;
       },
+      child: CustomDialog(
+        icon: SvgPicture.asset('assets/images/security/success_outlined_icon.svg'),
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                '${BlocProvider.of<PlantSeedsBloc>(context).state.quantity}',
+                style: Theme.of(context).textTheme.headline4Black,
+              ),
+              Padding(
+                padding: const EdgeInsets.only(top: 12, left: 4),
+                child: Text(currencySeedsCode, style: Theme.of(context).textTheme.subtitle2OpacityEmphasisBlack),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16.0),
+          Text(
+            '\$ ${BlocProvider.of<PlantSeedsBloc>(context).state.fiatAmount} ${settingsStorage.selectedFiatCurrency}',
+            style: Theme.of(context).textTheme.subtitle2OpacityEmphasisBlack,
+          ),
+          const SizedBox(height: 30.0),
+          Text(
+            'Congratulations\nYour seeds were planted successfully!'.i18n,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.buttonBlack,
+          ),
+        ],
+        singleLargeButtonTitle: 'Close'.i18n,
+        onSingleLargeButtonPressed: () {
+          Navigator.of(context).pop();
+          Navigator.of(context).pop();
+        },
+      ),
     );
   }
 }

--- a/lib/v2/screens/explore_screens/plant_seeds/interactor/mappers/plant_seeds_result_mapper.dart
+++ b/lib/v2/screens/explore_screens/plant_seeds/interactor/mappers/plant_seeds_result_mapper.dart
@@ -1,4 +1,3 @@
-import 'package:seeds/v2/datasource/remote/model/transaction_response.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
 import 'package:seeds/v2/domain-shared/result_to_state_mapper.dart';
 import 'package:seeds/v2/screens/explore_screens/plant_seeds/interactor/viewmodels/plant_seeds_state.dart';
@@ -6,22 +5,16 @@ import 'package:seeds/v2/screens/explore_screens/plant_seeds/interactor/viewmode
 class PlantSeedsResultMapper extends StateMapper {
   PlantSeedsState mapResultToState(PlantSeedsState currentState, Result result) {
     if (result.isError) {
-      return currentState.copyWith(pageState: PageState.failure, errorMessage: result.asError!.error.toString());
+      // Transaction fail show snackbar fail
+      print('Error transaction hash not retrieved');
+      return currentState.copyWith(
+        pageState: PageState.success,
+        pageCommand: ShowTransactionFailSnackBar(),
+        isPlantSeedsButtonEnabled: false,
+      );
     } else {
-      var response = result.asValue!.value as TransactionResponse;
-
-      if (response.transactionId.isNotEmpty) {
-        // Transaction success show plant seeds success dialog
-        return currentState.copyWith(pageState: PageState.success, pageCommand: ShowPlantSeedsSuccessDialog());
-      } else {
-        // Transaction fail show snackbar fail
-        print('Error transaction hash not retrieved');
-        return currentState.copyWith(
-          pageState: PageState.success,
-          pageCommand: ShowTransactionFailSnackBar(),
-          isPlantSeedsButtonEnabled: false,
-        );
-      }
+      // Transaction success show plant seeds success dialog
+      return currentState.copyWith(pageState: PageState.success, pageCommand: ShowPlantSeedsSuccessDialog());
     }
   }
 }

--- a/lib/v2/screens/explore_screens/plant_seeds/interactor/mappers/plant_seeds_result_mapper.dart
+++ b/lib/v2/screens/explore_screens/plant_seeds/interactor/mappers/plant_seeds_result_mapper.dart
@@ -11,11 +11,15 @@ class PlantSeedsResultMapper extends StateMapper {
       var response = result.asValue!.value as TransactionResponse;
 
       if (response.transactionId.isNotEmpty) {
-        return currentState.copyWith(pageState: PageState.success, showPlantedSuccess: true);
+        // Transaction success show plant seeds success dialog
+        return currentState.copyWith(pageState: PageState.success, pageCommand: ShowPlantSeedsSuccessDialog());
       } else {
+        // Transaction fail show snackbar fail
+        print('Error transaction hash not retrieved');
         return currentState.copyWith(
-          pageState: PageState.failure,
-          errorMessage: 'Error transaction hash not retrieved',
+          pageState: PageState.success,
+          pageCommand: ShowTransactionFailSnackBar(),
+          isPlantSeedsButtonEnabled: false,
         );
       }
     }

--- a/lib/v2/screens/explore_screens/plant_seeds/interactor/viewmodels/plant_seeds_state.dart
+++ b/lib/v2/screens/explore_screens/plant_seeds/interactor/viewmodels/plant_seeds_state.dart
@@ -1,11 +1,17 @@
 import 'package:equatable/equatable.dart';
 import 'package:seeds/v2/blocs/rates/viewmodels/rates_state.dart';
 import 'package:seeds/v2/datasource/remote/model/balance_model.dart';
+import 'package:seeds/v2/domain-shared/page_command.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
+
+class ShowPlantSeedsSuccessDialog extends PageCommand {}
+
+class ShowTransactionFailSnackBar extends PageCommand {}
 
 /// --- STATE
 class PlantSeedsState extends Equatable {
   final PageState pageState;
+  final PageCommand? pageCommand;
   final RatesState ratesState;
   final bool isAutoFocus;
   final String fiatAmount;
@@ -16,11 +22,11 @@ class PlantSeedsState extends Equatable {
   final bool isPlantSeedsButtonEnabled;
   final double quantity;
   final bool showAlert;
-  final bool showPlantedSuccess;
   final String? errorMessage;
 
   const PlantSeedsState({
     required this.pageState,
+    this.pageCommand,
     required this.ratesState,
     required this.isAutoFocus,
     required this.fiatAmount,
@@ -31,13 +37,13 @@ class PlantSeedsState extends Equatable {
     required this.isPlantSeedsButtonEnabled,
     required this.quantity,
     required this.showAlert,
-    required this.showPlantedSuccess,
     this.errorMessage,
   });
 
   @override
   List<Object?> get props => [
         pageState,
+        pageCommand,
         ratesState,
         isAutoFocus,
         fiatAmount,
@@ -48,12 +54,12 @@ class PlantSeedsState extends Equatable {
         isPlantSeedsButtonEnabled,
         quantity,
         showAlert,
-        showPlantedSuccess,
         errorMessage,
       ];
 
   PlantSeedsState copyWith({
     PageState? pageState,
+    PageCommand? pageCommand,
     RatesState? ratesState,
     bool? isAutoFocus,
     String? fiatAmount,
@@ -64,11 +70,11 @@ class PlantSeedsState extends Equatable {
     bool? isPlantSeedsButtonEnabled,
     double? quantity,
     bool? showAlert,
-    bool? showPlantedSuccess,
     String? errorMessage,
   }) {
     return PlantSeedsState(
       pageState: pageState ?? this.pageState,
+      pageCommand: pageCommand,
       ratesState: ratesState ?? this.ratesState,
       isAutoFocus: isAutoFocus ?? this.isAutoFocus,
       fiatAmount: fiatAmount ?? this.fiatAmount,
@@ -79,7 +85,6 @@ class PlantSeedsState extends Equatable {
       isPlantSeedsButtonEnabled: isPlantSeedsButtonEnabled ?? this.isPlantSeedsButtonEnabled,
       quantity: quantity ?? this.quantity,
       showAlert: showAlert ?? this.showAlert,
-      showPlantedSuccess: showPlantedSuccess ?? this.showPlantedSuccess,
       errorMessage: errorMessage ?? this.errorMessage,
     );
   }
@@ -93,7 +98,6 @@ class PlantSeedsState extends Equatable {
       isPlantSeedsButtonEnabled: false,
       quantity: 0,
       showAlert: false,
-      showPlantedSuccess: false,
     );
   }
 }

--- a/lib/v2/screens/explore_screens/plant_seeds/plant_seeds_screen.dart
+++ b/lib/v2/screens/explore_screens/plant_seeds/plant_seeds_screen.dart
@@ -8,6 +8,7 @@ import 'package:seeds/v2/components/divider_jungle.dart';
 import 'package:seeds/v2/components/flat_button_long.dart';
 import 'package:seeds/v2/components/full_page_error_indicator.dart';
 import 'package:seeds/v2/components/full_page_loading_indicator.dart';
+import 'package:seeds/v2/components/snack_bar_info.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
 import 'package:seeds/v2/domain-shared/ui_constants.dart';
 import 'package:seeds/i18n/plant_seeds.i18n.dart';
@@ -44,23 +45,7 @@ class PlantSeedsScreen extends StatelessWidget {
             }
             if (state.pageCommand is ShowTransactionFailSnackBar) {
               ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          'Plant failed, try again.',
-                          textAlign: TextAlign.center,
-                          style: Theme.of(context).textTheme.subtitle2,
-                        ),
-                      ),
-                      InkWell(
-                        child: const Icon(Icons.close),
-                        onTap: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(),
-                      ),
-                    ],
-                  ),
-                ),
+                SnackBarInfo(title: 'Plant failed, try again.', context: context),
               );
             }
           },

--- a/lib/v2/screens/explore_screens/plant_seeds/plant_seeds_screen.dart
+++ b/lib/v2/screens/explore_screens/plant_seeds/plant_seeds_screen.dart
@@ -27,19 +27,42 @@ class PlantSeedsScreen extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(title: Text('Plant'.i18n, style: Theme.of(context).textTheme.headline7)),
         body: BlocConsumer<PlantSeedsBloc, PlantSeedsState>(
-          listenWhen: (_, current) => current.showPlantedSuccess,
+          listenWhen: (_, current) => current.pageCommand != null,
           listener: (context, state) {
-            _exploreBloc?.add(OnPlantedSeedsValueUpdate(plantedSeeds: state.quantity));
-            showDialog<void>(
-              context: context,
-              barrierDismissible: false,
-              builder: (_) {
-                return BlocProvider.value(
-                  value: BlocProvider.of<PlantSeedsBloc>(context),
-                  child: const PlantSeedsSuccessDialog(),
-                );
-              },
-            );
+            if (state.pageCommand is ShowPlantSeedsSuccessDialog) {
+              _exploreBloc?.add(OnPlantedSeedsValueUpdate(plantedSeeds: state.quantity));
+              showDialog<void>(
+                context: context,
+                barrierDismissible: false,
+                builder: (_) {
+                  return BlocProvider.value(
+                    value: BlocProvider.of<PlantSeedsBloc>(context),
+                    child: const PlantSeedsSuccessDialog(),
+                  );
+                },
+              );
+            }
+            if (state.pageCommand is ShowTransactionFailSnackBar) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          'Plant failed, try again.',
+                          textAlign: TextAlign.center,
+                          style: Theme.of(context).textTheme.subtitle2,
+                        ),
+                      ),
+                      InkWell(
+                        child: const Icon(Icons.close),
+                        onTap: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }
           },
           builder: (context, PlantSeedsState state) {
             switch (state.pageState) {

--- a/lib/v2/screens/verification/components/verify_passcode.dart
+++ b/lib/v2/screens/verification/components/verify_passcode.dart
@@ -49,7 +49,6 @@ class _VerifyPasscodeState extends State<VerifyPasscode> {
               BlocProvider.of<VerificationBloc>(context).add(const ResetShowSnack());
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  behavior: SnackBarBehavior.floating,
                   backgroundColor: AppColors.canopy,
                   content: Text(
                     'Pincode does not match',


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)


### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Added:

- The failed transaction snackbars for plant and invite.
- A global configuration of the snackbar theme.
- SnackBarInfo global component

To Mock failure:

Invite Bloc 
```
    if (event is OnCreateInviteButtonTapped) {
      String mnemonicSecretCode = generateMnemonic();
      yield state.copyWith(pageState: PageState.loading, isAutoFocus: false, mnemonicSecretCode: mnemonicSecretCode);
      // List<Result> results = await CreateInviteUseCase().run(amount: state.quantity, mnemonic: mnemonicSecretCode);
      // yield CreateInviteResultStateMapper().mapResultsToState(state, results);
      await Future.delayed(const Duration(seconds: 1));
      yield state.copyWith(
          pageState: PageState.success, pageCommand: ShowTransactionFailSnackBar(), isCreateInviteButtonEnabled: false);
    }
```
Plant Bloc
```
    if (event is OnPlantSeedsButtonTapped) {
      yield state.copyWith(pageState: PageState.loading, isAutoFocus: false);
      // Result result = await PlantSeedsUseCase().run(amount: state.quantity);
      // yield PlantSeedsResultMapper().mapResultToState(state, result);
            await Future.delayed(const Duration(seconds: 1));
      yield state.copyWith(
          pageState: PageState.success, pageCommand: ShowTransactionFailSnackBar(), isPlantSeedsButtonEnabled: false);
    }

```

### 🙈 Screenshots

| invite | plant |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/42857405/119879134-805dee00-bef0-11eb-9bba-0576bea0e948.jpg" width="300"> | <img src="https://user-images.githubusercontent.com/42857405/119879175-8fdd3700-bef0-11eb-86b1-766f97836632.jpg" width="300">


### 👯‍♀️ Paired with
"nobody"
