### PR TITLE
Use platform currency on startup

### DIFF
--- a/lib/screens/app/wallet/dashboard/dashboard.dart
+++ b/lib/screens/app/wallet/dashboard/dashboard.dart
@@ -146,12 +146,6 @@ class _DashboardState extends State<Dashboard> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     refreshData();
-    if (SettingsNotifier.of(context).selectedFiatCurrency.isEmpty) {
-      Locale locale = Localizations.localeOf(context);
-      var format = NumberFormat.simpleCurrency(locale: locale.toString());
-      // SettingsNotifier.of(context).saveSelectedFiatCurrency(format.currencyName);
-      settingsStorage.saveSelectedFiatCurrency(format.currencyName!);
-    }
   }
 
   Future<void> refreshData() async {

--- a/lib/v2/datasource/local/settings_storage.dart
+++ b/lib/v2/datasource/local/settings_storage.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _SettingsStorage {
@@ -46,7 +49,7 @@ class _SettingsStorage {
 
   int get backupReminderCount => _backupReminderCount ?? 0;
 
-  String get selectedFiatCurrency => _preferences.getString(SELECTED_FIAT_CURRENCY) ?? 'USD';
+  String get selectedFiatCurrency => _preferences.getString(SELECTED_FIAT_CURRENCY) ?? getPlatformCurrency();
 
   bool get inRecoveryMode => _preferences.getBool(IN_RECOVERY_MODE) ?? false;
 
@@ -235,6 +238,11 @@ class _SettingsStorage {
     _backupLatestReminder = 0;
     _secureStorage.delete(key: BACKUP_REMINDER_COUNT);
     _backupReminderCount = 0;
+  }
+
+  String getPlatformCurrency() {
+    var format = NumberFormat.simpleCurrency(locale: Platform.localeName);
+    return format.currencyName ?? 'USD';
   }
 }
 


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Migration from old dashboard hack code, to much better code 

We will be replacing the whole dashboard screen with a wallet screen so moving this functionality to where it belongs. 

### ✅ Checklist

- [x] I have tested all my changes.

I tested by creating a mexican locale android emulator, and running the app there for the first time. Worked!

### 🕵️‍♂️ Notes for Code Reviewer

The feature in V1 was that when a user installs the app, the default Fiat currency is set to the currency of their phone. 

In V1 we used a hack in the UX to make this happen, I now found a non-hack way to do it, using "Platform.locale" 

### 🙈 Screenshots


### 👯‍♀️ Paired with

nobody