### PR TITLE
Removing hard-coded $ sign from fiat currencies

### DIFF
--- a/lib/v2/components/amount_entry/interactor/mappers/handle_info_row_text.dart
+++ b/lib/v2/components/amount_entry/interactor/mappers/handle_info_row_text.dart
@@ -11,6 +11,6 @@ String handleInfoRowText({
     case CurrencyInput.FIAT:
       return fiatToSeeds + " " + currencySeedsCode;
     case CurrencyInput.SEEDS:
-      return "\$" + seedsToFiat + " " + settingsStorage.selectedFiatCurrency.toString();
+      return seedsToFiat + " " + settingsStorage.selectedFiatCurrency.toString();
   }
 }

--- a/lib/v2/components/balance_row.dart
+++ b/lib/v2/components/balance_row.dart
@@ -37,7 +37,7 @@ class BalanceRow extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(top: 4.0),
           child: Row(mainAxisAlignment: MainAxisAlignment.end, children: [
-            Text("\$" + fiatAmount + " " + settingsStorage.selectedFiatCurrency,
+            Text(fiatAmount + " " + settingsStorage.selectedFiatCurrency,
                 style: Theme.of(context).textTheme.subtitle2OpacityEmphasis)
           ]),
         )

--- a/lib/v2/screens/transfer/send/send_confirmation/components/send_transaction_success_dialog.dart
+++ b/lib/v2/screens/transfer/send/send_confirmation/components/send_transaction_success_dialog.dart
@@ -56,7 +56,7 @@ class SendTransactionSuccessDialog extends StatelessWidget {
               ],
               mainAxisAlignment: MainAxisAlignment.center,
             ),
-            Text(fiatAmount != null ? "\$" + fiatAmount! : "",
+            Text(fiatAmount != null ? fiatAmount! : "",
                 style: Theme.of(context).textTheme.subtitle2),
             const SizedBox(height: 30.0),
             DialogRow(imageUrl: toImage, account: toAccount, name: toName, toOrFromText: "To"),

--- a/lib/v2/screens/transfer/send/send_enter_data/components/send_confirmation_dialog.dart
+++ b/lib/v2/screens/transfer/send/send_enter_data/components/send_confirmation_dialog.dart
@@ -56,7 +56,7 @@ class SendConfirmationDialog extends StatelessWidget {
           ],
           mainAxisAlignment: MainAxisAlignment.center,
         ),
-        Text(fiatAmount != null ? "\$" + fiatAmount! : "",
+        Text(fiatAmount != null ? fiatAmount! : "",
             style: Theme.of(context).textTheme.subtitle2),
         const SizedBox(height: 30.0),
         DialogRow(imageUrl: toImage, account: toAccount, name: toName, toOrFromText: "To"),


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

This is the GH issue and fix, since it's a trivial change.

We are currently showing a $ sign for the fiat currency - but many fiat currencies use different symbols - 

Could be EUR, or THB, or whatever else, so we can't have a hard coded $ sign in front of fiat currency.

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Trivial change

### 🙈 Screenshots

### 👯‍♀️ Paired with

nobody