### PR TITLE
Load rates logic updated

### DIFF
--- a/lib/screens/app/wallet/dashboard/dashboard.dart
+++ b/lib/screens/app/wallet/dashboard/dashboard.dart
@@ -150,7 +150,7 @@ class _DashboardState extends State<Dashboard> {
   }
 
   Future<void> refreshData() async {
-    BlocProvider.of<RatesBloc>(context)..add(const FetchRates());
+    BlocProvider.of<RatesBloc>(context)..add(const OnFetchRates());
 
     _walletHeaderKey.currentState?.reload();
 

--- a/lib/v2/blocs/rates/viewmodels/rates_bloc.dart
+++ b/lib/v2/blocs/rates/viewmodels/rates_bloc.dart
@@ -5,14 +5,16 @@ import 'package:seeds/v2/blocs/rates/usecases/get_rates_use_case.dart';
 
 /// --- BLOC
 class RatesBloc extends Bloc<RatesEvent, RatesState> {
-  DateTime lastUpdated = DateTime.now().subtract(const Duration(hours: 1));
+  DateTime lastUpdated = DateTime.now();
 
   RatesBloc() : super(RatesState.initial());
 
   @override
   Stream<RatesState> mapEventToState(RatesEvent event) async* {
-    if (event is FetchRates) {
-      if (DateTime.now().isAfter(lastUpdated.add(const Duration(hours: 1)))) {
+    if (event is OnFetchRates) {
+      print('Remaining minutes to fetch rates again: ${lastUpdated.difference(DateTime.now()).inMinutes}');
+      if (DateTime.now().isAfter(lastUpdated)) {
+        lastUpdated = lastUpdated.add(const Duration(hours: 1));
         var results = await GetRatesUseCase().run();
         yield RatesStateMapper().mapResultToState(state, results);
       }

--- a/lib/v2/blocs/rates/viewmodels/rates_event.dart
+++ b/lib/v2/blocs/rates/viewmodels/rates_event.dart
@@ -9,8 +9,8 @@ abstract class RatesEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class FetchRates extends RatesEvent {
-  const FetchRates();
+class OnFetchRates extends RatesEvent {
+  const OnFetchRates();
   @override
-  String toString() => 'FetchRates';
+  String toString() => 'OnFetchRates';
 }

--- a/lib/v2/screens/app/app.dart
+++ b/lib/v2/screens/app/app.dart
@@ -6,6 +6,7 @@ import 'package:seeds/providers/notifiers/connection_notifier.dart';
 import 'package:seeds/screens/app/ecosystem/ecosystem.dart';
 import 'package:seeds/screens/app/wallet/wallet.dart';
 import 'package:seeds/v2/blocs/authentication/viewmodels/bloc.dart';
+import 'package:seeds/v2/blocs/rates/viewmodels/bloc.dart';
 import 'package:seeds/v2/components/full_page_loading_indicator.dart';
 import 'package:seeds/v2/components/notification_badge.dart';
 import 'package:seeds/v2/components/snack_bar_info.dart';
@@ -56,6 +57,7 @@ class _AppState extends State<App> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    BlocProvider.of<RatesBloc>(context).add(const OnFetchRates());
     WidgetsBinding.instance?.addObserver(this);
   }
 
@@ -72,6 +74,7 @@ class _AppState extends State<App> with WidgetsBindingObserver {
         break;
       case AppLifecycleState.resumed:
         Provider.of<ConnectionNotifier>(context, listen: false).discoverEndpoints();
+        BlocProvider.of<RatesBloc>(context).add(const OnFetchRates());
         break;
       case AppLifecycleState.detached:
         break;

--- a/lib/v2/screens/dashboard/interactor/viewmodels/wallet_bloc.dart
+++ b/lib/v2/screens/dashboard/interactor/viewmodels/wallet_bloc.dart
@@ -9,7 +9,7 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
 
   @override
   Stream<WalletState> mapEventToState(WalletEvent event) async* {
-    if (event is RefreshDataEvent) {
+    if (event is OnLoadWalletData) {
       yield state.copyWith(pageState: PageState.loading);
       yield state.copyWith(pageState: PageState.success);
     }

--- a/lib/v2/screens/dashboard/interactor/viewmodels/wallet_event.dart
+++ b/lib/v2/screens/dashboard/interactor/viewmodels/wallet_event.dart
@@ -9,8 +9,8 @@ abstract class WalletEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class RefreshDataEvent extends WalletEvent {
-  const RefreshDataEvent();
+class OnLoadWalletData extends WalletEvent {
+  const OnLoadWalletData();
   @override
-  String toString() => 'RefreshDataEvent';
+  String toString() => 'OnLoadWalletData';
 }

--- a/lib/v2/screens/dashboard/wallet_screen.dart
+++ b/lib/v2/screens/dashboard/wallet_screen.dart
@@ -23,7 +23,6 @@ class WalletScreen extends StatefulWidget {
 }
 
 class _WalletScreenState extends State<WalletScreen> with AutomaticKeepAliveClientMixin {
-
   @override
   bool get wantKeepAlive => true;
 
@@ -31,13 +30,13 @@ class _WalletScreenState extends State<WalletScreen> with AutomaticKeepAliveClie
   Widget build(BuildContext context) {
     super.build(context);
     return BlocProvider(
-      create: (_) => WalletBloc()..add(const RefreshDataEvent()),
+      create: (_) => WalletBloc()..add(const OnLoadWalletData()),
       child: BlocBuilder<WalletBloc, WalletState>(
         builder: (context, state) {
           return RefreshIndicator(
             onRefresh: () async {
-              BlocProvider.of<RatesBloc>(context).add(const FetchRates());
-              BlocProvider.of<WalletBloc>(context).add(const RefreshDataEvent());
+              BlocProvider.of<RatesBloc>(context).add(const OnFetchRates());
+              BlocProvider.of<WalletBloc>(context).add(const OnLoadWalletData());
             },
             child: Scaffold(
               appBar: buildAppBar(context) as PreferredSizeWidget?,
@@ -121,5 +120,4 @@ class _WalletScreenState extends State<WalletScreen> with AutomaticKeepAliveClie
   Widget buildTransactions() {
     return const SizedBox.shrink();
   }
-
 }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Rates are fetched when:

1. First time App widget is mounted.
2. On pull to refresh (WalletScreen).
3. When the app returns from background.

**Escenaries 2 and 3 can be fired but the real refresh call only happens when the 1 hour waiting logic to refresh is meet.**

### 👯‍♀️ Paired with

"nobody"
