### PR TITLE
Bugs fixed: update profile call and no pop ultil profile on image avatar selected

### DIFF
--- a/lib/v2/datasource/remote/api/profile_repository.dart
+++ b/lib/v2/datasource/remote/api/profile_repository.dart
@@ -35,13 +35,13 @@ class ProfileRepository extends NetworkRepository with EosRepository {
   }
 
   Future<Result> updateProfile({
-    String? nickname,
-    String? image,
-    String? story,
-    String? roles,
-    String? skills,
-    String? interests,
-    String? accountName,
+    required String nickname,
+    required String image,
+    required String story,
+    required String roles,
+    required String skills,
+    required String interests,
+    required String accountName,
   }) async {
     print('[eos] update profile');
 

--- a/lib/v2/screens/profile_screens/edit_name/interactor/usecases/update_profile_use_case.dart
+++ b/lib/v2/screens/profile_screens/edit_name/interactor/usecases/update_profile_use_case.dart
@@ -9,12 +9,12 @@ class UpdateProfileUseCase {
   Future<Result> run({required String? newName, required ProfileModel profile}) {
     return _profileRepository.updateProfile(
       accountName: settingsStorage.accountName,
-      nickname: newName,
-      image: profile.image,
-      story: profile.story,
-      roles: profile.roles,
-      skills: profile.skills,
-      interests: profile.interests,
+      nickname: newName ?? '',
+      image: profile.image ?? '',
+      story: profile.story ?? '',
+      roles: profile.roles ?? '',
+      skills: profile.skills ?? '',
+      interests: profile.interests ?? '',
     );
   }
 }

--- a/lib/v2/screens/profile_screens/profile/components/edit_profile_pic_bottom_sheet/edit_profile_pic_bottom_sheet.dart
+++ b/lib/v2/screens/profile_screens/profile/components/edit_profile_pic_bottom_sheet/edit_profile_pic_bottom_sheet.dart
@@ -14,7 +14,7 @@ class EditProfilePicBottomSheet extends StatelessWidget {
       child: BlocConsumer<PickImageBloc, PickImageState>(
         listenWhen: (previous, current) => previous.file != current.file,
         listener: (context, state) {
-          // When the system explore files is open, the wallet app
+          // When the system explore files is open or the camera is open, the wallet app
           // goes into the background (paused) and this triggers the verification screen.
           // thus, we need fire an extra pop.
           Navigator.of(context).pop(); // <--- to remove verify screen

--- a/lib/v2/screens/profile_screens/profile/components/edit_profile_pic_bottom_sheet/edit_profile_pic_bottom_sheet.dart
+++ b/lib/v2/screens/profile_screens/profile/components/edit_profile_pic_bottom_sheet/edit_profile_pic_bottom_sheet.dart
@@ -13,7 +13,13 @@ class EditProfilePicBottomSheet extends StatelessWidget {
       create: (_) => PickImageBloc(),
       child: BlocConsumer<PickImageBloc, PickImageState>(
         listenWhen: (previous, current) => previous.file != current.file,
-        listener: (context, state) => Navigator.of(context).pop(state.file),
+        listener: (context, state) {
+          // When the system explore files is open, the wallet app
+          // goes into the background (paused) and this triggers the verification screen.
+          // thus, we need fire an extra pop.
+          Navigator.of(context).pop(); // <--- to remove verify screen
+          Navigator.of(context).pop(state.file);
+        },
         builder: (context, _) {
           return Column(
             mainAxisSize: MainAxisSize.min,

--- a/lib/v2/screens/profile_screens/profile/interactor/usecases/update_profile_image_use_case.dart
+++ b/lib/v2/screens/profile_screens/profile/interactor/usecases/update_profile_image_use_case.dart
@@ -9,12 +9,12 @@ class UpdateProfileImageUseCase {
   Future<Result> run({required String imageUrl, required ProfileModel profile}) {
     return _profileRepository.updateProfile(
       accountName: settingsStorage.accountName,
-      nickname: profile.nickname,
+      nickname: profile.nickname ?? '',
       image: imageUrl,
-      story: profile.story,
-      roles: profile.roles,
-      skills: profile.skills,
-      interests: profile.interests,
+      story: profile.story ?? '',
+      roles: profile.roles ?? '',
+      skills: profile.skills ?? '',
+      interests: profile.interests ?? '',
     );
   }
 }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

No issues

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

1. Apparently after the migration to null safety put the parameters of the updateProfile call as nullables and not required, this caused null values ​​to be sent in the transaction instead of empty strings. To resolve this I made these params required.

2. The image was not returned from the get image widget to the profile screen because it only made one pop instruction, it not works anymore, it happens that when the system file explorer or the camera starts the app goes to background and this triggers the verification screen. To resolve this an extra pop instruction was added.

### 👯‍♀️ Paired with

"nobody"
