### PR TITLE
Create account returns to main screen

### DIFF
--- a/lib/v2/blocs/authentication/viewmodels/authentication_bloc.dart
+++ b/lib/v2/blocs/authentication/viewmodels/authentication_bloc.dart
@@ -30,6 +30,12 @@ class AuthenticationBloc extends Bloc<AuthenticationEvent, AuthenticationState> 
       // Set fcm token must be last instruction to allow login, even if there is an error here.
       await FirebaseMessageTokenRepository().setFirebaseMessageToken(event.account);
     }
+    if (event is OnCreateAccount) {
+      // New account --> re-start auth status
+      add(const InitAuthStatus());
+      // Set fcm token must be last instruction to allow login, even if there is an error here.
+      await FirebaseMessageTokenRepository().setFirebaseMessageToken(settingsStorage.accountName);
+    }
     if (event is EnablePasscode) {
       settingsStorage.savePasscode(event.newPasscode);
       settingsStorage.passcodeActive = true;

--- a/lib/v2/blocs/authentication/viewmodels/authentication_event.dart
+++ b/lib/v2/blocs/authentication/viewmodels/authentication_event.dart
@@ -35,6 +35,12 @@ class OnImportAccount extends AuthenticationEvent {
   String toString() => 'OnImportAccount { account: $account }';
 }
 
+class OnCreateAccount extends AuthenticationEvent {
+  const OnCreateAccount();
+  @override
+  String toString() => 'OnCreateAccount';
+}
+
 class UnlockWallet extends AuthenticationEvent {
   const UnlockWallet();
   @override

--- a/lib/v2/datasource/remote/api/signup_repository.dart
+++ b/lib/v2/datasource/remote/api/signup_repository.dart
@@ -80,11 +80,13 @@ class SignupRepository extends EosRepository with NetworkRepository {
     required String accountName,
     required String inviteSecret,
     required String displayName,
+    required EOSPrivateKey privateKey,
   }) async {
-    EOSPrivateKey privateKey = EOSPrivateKey.fromRandom();
     EOSPublicKey publicKey = privateKey.toEOSPublicKey();
 
     final applicationAccount = Config.onboardingAccountName;
+
+    //print("create account with secret: $inviteSecret  \npub: $publicKey \npriv: $privateKey");
 
     final actions = <Action>[
       Action()

--- a/lib/v2/datasource/remote/api/signup_repository.dart
+++ b/lib/v2/datasource/remote/api/signup_repository.dart
@@ -86,8 +86,6 @@ class SignupRepository extends EosRepository with NetworkRepository {
 
     final applicationAccount = Config.onboardingAccountName;
 
-    //print("create account with secret: $inviteSecret  \npub: $publicKey \npriv: $privateKey");
-
     final actions = <Action>[
       Action()
         ..account = applicationAccount

--- a/lib/v2/screens/sign_up/add_phone_number/add_phone_number.dart
+++ b/lib/v2/screens/sign_up/add_phone_number/add_phone_number.dart
@@ -45,7 +45,7 @@ class _AddPhoneNumberState extends State<AddPhoneNumber> {
             }
 
             if (state.addPhoneNumberState.pageState == PageState.success) {
-              NavigationService.of(context).navigateTo(Routes.wallet);
+              BlocProvider.of<AuthenticationBloc>(context).add(const OnCreateAccount());
             }
           },
           builder: (context, state) {

--- a/lib/v2/screens/sign_up/add_phone_number/add_phone_number.dart
+++ b/lib/v2/screens/sign_up/add_phone_number/add_phone_number.dart
@@ -7,7 +7,6 @@ import 'package:seeds/v2/components/flat_button_long.dart';
 import 'package:seeds/v2/components/full_page_loading_indicator.dart';
 import 'package:seeds/v2/components/snack_bar_info.dart';
 import 'package:seeds/v2/components/text_form_field_custom.dart';
-import 'package:seeds/v2/datasource/local/settings_storage.dart';
 import 'package:seeds/v2/design/app_theme.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
 import 'package:seeds/v2/domain-shared/ui_constants.dart';

--- a/lib/v2/screens/sign_up/add_phone_number/add_phone_number.dart
+++ b/lib/v2/screens/sign_up/add_phone_number/add_phone_number.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:seeds/i18n/phone_number.dart';
+import 'package:seeds/v2/blocs/authentication/viewmodels/authentication_bloc.dart';
+import 'package:seeds/v2/blocs/authentication/viewmodels/bloc.dart';
 import 'package:seeds/v2/components/flat_button_long.dart';
 import 'package:seeds/v2/components/full_page_loading_indicator.dart';
 import 'package:seeds/v2/components/snack_bar_info.dart';
 import 'package:seeds/v2/components/text_form_field_custom.dart';
+import 'package:seeds/v2/datasource/local/settings_storage.dart';
 import 'package:seeds/v2/design/app_theme.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
 import 'package:seeds/v2/domain-shared/ui_constants.dart';
-import 'package:seeds/v2/navigation/navigation_service.dart';
 import 'package:seeds/v2/screens/sign_up/viewmodels/bloc.dart';
 import 'package:seeds/v2/utils/formatters.dart';
 

--- a/lib/v2/screens/sign_up/add_phone_number/usecases/add_phone_number_usecase.dart
+++ b/lib/v2/screens/sign_up/add_phone_number/usecases/add_phone_number_usecase.dart
@@ -2,12 +2,14 @@ import 'package:async/async.dart';
 import 'package:seeds/utils/string_extension.dart';
 import 'package:seeds/v2/datasource/remote/api/signup_repository.dart';
 import 'package:seeds/v2/datasource/remote/firebase/firebase_user_repository.dart';
+// ignore: import_of_legacy_library_into_null_safe
+import 'package:eosdart_ecc/eosdart_ecc.dart';
 
 class AddPhoneNumberUseCase {
   AddPhoneNumberUseCase({
     required SignupRepository signupRepository,
     required FirebaseUserRepository firebaseUserRepository,
-  })   : _signupRepository = signupRepository,
+  })  : _signupRepository = signupRepository,
         _firebaseUserRepository = firebaseUserRepository;
 
   final SignupRepository _signupRepository;
@@ -17,12 +19,14 @@ class AddPhoneNumberUseCase {
     required String inviteSecret,
     required String displayName,
     required String username,
+    required EOSPrivateKey privateKey,
     String? phoneNumber,
   }) async {
     final Result result = await _signupRepository.createAccount(
       accountName: username,
       inviteSecret: inviteSecret,
       displayName: displayName,
+      privateKey: privateKey,
     );
 
     // Phone number is optional.

--- a/lib/v2/screens/sign_up/viewmodels/signup_bloc.dart
+++ b/lib/v2/screens/sign_up/viewmodels/signup_bloc.dart
@@ -28,7 +28,7 @@ class SignupBloc extends Bloc<SignupEvent, SignupState> {
     required CreateUsernameUseCase createUsernameUseCase,
     required AddPhoneNumberUseCase addPhoneNumberUseCase,
     required this.deeplinkBloc,
-  })   : _claimInviteUseCase = claimInviteUseCase,
+  })  : _claimInviteUseCase = claimInviteUseCase,
         _createUsernameUseCase = createUsernameUseCase,
         _addPhoneNumberUseCase = addPhoneNumberUseCase,
         super(SignupState.initial());
@@ -119,7 +119,7 @@ class SignupBloc extends Bloc<SignupEvent, SignupState> {
     final username = state.createUsernameState.username;
 
     final Result result = await _addPhoneNumberUseCase.run(
-        inviteSecret: inviteSecret!, displayName: displayName!, username: username!, phoneNumber: phoneNumber);
+        inviteSecret: inviteSecret, displayName: displayName!, username: username!, phoneNumber: phoneNumber);
 
     yield CreateAccountMapper().mapOnCreateAccountTappedToState(currentState, result);
   }

--- a/lib/v2/screens/sign_up/viewmodels/signup_bloc.dart
+++ b/lib/v2/screens/sign_up/viewmodels/signup_bloc.dart
@@ -4,7 +4,9 @@ import 'package:async/async.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
+import 'package:seeds/v2/blocs/authentication/viewmodels/bloc.dart';
 import 'package:seeds/v2/blocs/deeplink/viewmodels/deeplink_bloc.dart';
+import 'package:seeds/v2/datasource/local/settings_storage.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
 import 'package:seeds/v2/screens/sign_up/add_phone_number/mappers/create_account_mapper.dart';
 import 'package:seeds/v2/screens/sign_up/add_phone_number/usecases/add_phone_number_usecase.dart';
@@ -15,6 +17,8 @@ import 'package:seeds/v2/screens/sign_up/viewmodels/states/claim_invite_state.da
 import 'package:seeds/v2/screens/sign_up/viewmodels/states/create_username_state.dart';
 import 'package:seeds/v2/screens/sign_up/viewmodels/states/display_name_state.dart';
 import 'package:seeds/v2/utils/mnemonic_code/mnemonic_code.dart';
+// ignore: import_of_legacy_library_into_null_safe
+import 'package:eosdart_ecc/eosdart_ecc.dart';
 
 part 'signup_event.dart';
 
@@ -118,8 +122,19 @@ class SignupBloc extends Bloc<SignupEvent, SignupState> {
     final displayName = state.displayNameState.displayName;
     final username = state.createUsernameState.username;
 
+    EOSPrivateKey privateKey = EOSPrivateKey.fromRandom();
+
     final Result result = await _addPhoneNumberUseCase.run(
-        inviteSecret: inviteSecret, displayName: displayName!, username: username!, phoneNumber: phoneNumber);
+      inviteSecret: inviteSecret,
+      displayName: displayName!,
+      username: username!,
+      privateKey: privateKey,
+      phoneNumber: phoneNumber,
+    );
+
+    if (!result.isError) {
+      settingsStorage.saveAccount(username, privateKey.toString());
+    }
 
     yield CreateAccountMapper().mapOnCreateAccountTappedToState(currentState, result);
   }

--- a/lib/v2/screens/sign_up/viewmodels/signup_bloc.dart
+++ b/lib/v2/screens/sign_up/viewmodels/signup_bloc.dart
@@ -4,7 +4,6 @@ import 'package:async/async.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
-import 'package:seeds/v2/blocs/authentication/viewmodels/bloc.dart';
 import 'package:seeds/v2/blocs/deeplink/viewmodels/deeplink_bloc.dart';
 import 'package:seeds/v2/datasource/local/settings_storage.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';

--- a/lib/v2/screens/sign_up/viewmodels/signup_bloc.dart
+++ b/lib/v2/screens/sign_up/viewmodels/signup_bloc.dart
@@ -14,6 +14,7 @@ import 'package:seeds/v2/screens/sign_up/viewmodels/states/add_phone_number_stat
 import 'package:seeds/v2/screens/sign_up/viewmodels/states/claim_invite_state.dart';
 import 'package:seeds/v2/screens/sign_up/viewmodels/states/create_username_state.dart';
 import 'package:seeds/v2/screens/sign_up/viewmodels/states/display_name_state.dart';
+import 'package:seeds/v2/utils/mnemonic_code/mnemonic_code.dart';
 
 part 'signup_event.dart';
 
@@ -113,7 +114,7 @@ class SignupBloc extends Bloc<SignupEvent, SignupState> {
 
     yield currentState.copyWith(addPhoneNumberState: AddPhoneNumberState.loading(currentAddPhoneNumberState));
 
-    final inviteSecret = state.claimInviteState.inviteModel!.inviteSecret;
+    final String inviteSecret = secretFromMnemonic(state.claimInviteState.inviteMnemonic!);
     final displayName = state.displayNameState.displayName;
     final username = state.createUsernameState.username;
 


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Create account fails to return to wallet page

https://github.com/JoinSEEDS/seeds_light_wallet/issues/962

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Human Cause (HC):
Trying to navigate to wallet screen with navigator

However, the wallet screen didn't exist in the branch of the widget tree that the auth / signup screens are in. 

Fix: 
Adding event on auth bloc - informing auth bloc that a new user has successfully been created.

### 🙈 Screenshots

![Simulator Screen Shot - iPhone 11 Pro - 2021-08-01 at 19 57 17](https://user-images.githubusercontent.com/65412/127769998-7b4559b4-9e67-461d-a3ab-a27ec8319beb.png)

### 👯‍♀️ Paired with
nobody