### PR TITLE
Recover screen minor fix - selecting row should be the same as tapping next

### DIFF
--- a/lib/v2/screens/authentication/recover/recover_account_search/recover_account_screen.dart
+++ b/lib/v2/screens/authentication/recover/recover_account_search/recover_account_screen.dart
@@ -91,6 +91,8 @@ class _RecoverAccountScreenState extends State<RecoverAccountScreen> {
                             imageUrl: state.accountImage,
                             account: state.userName!,
                             name: state.accountName,
+                            resultCallBack: () =>
+                                BlocProvider.of<RecoverAccountBloc>(context).add(OnNextButtonTapped()),
                           ),
                         )
                       : const SizedBox.shrink(),


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

I ran into this testing, I expected that tapping the row would lead me to the next screen.

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer
### 🙈 Screenshots
### 👯‍♀️ Paired with