### PR TITLE
removing all preferences on logout

### DIFF
--- a/lib/v2/datasource/local/settings_storage.dart
+++ b/lib/v2/datasource/local/settings_storage.dart
@@ -260,6 +260,9 @@ class _SettingsStorage {
     _backupLatestReminder = 0;
     _secureStorage.delete(key: BACKUP_REMINDER_COUNT);
     _preferences.remove(IS_CITIZEN);
+    _preferences.remove(TOKENS_WHITELIST);
+    _preferences.remove(GUARDIAN_TUTORIAL_SHOWN);
+    _preferences.remove(IN_RECOVERY_MODE);
     _backupReminderCount = 0;
   }
 


### PR DESCRIPTION

### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Removes more preferences on logout - now all user preferences are removed on logout. 

May fix token whitelist bug #980 

However, whether or not it fixes that, it is definitely necessary anyway. Because we want to remove user prefs on logout, and were missing a few. 

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer
### 🙈 Screenshots
### 👯‍♀️ Paired with
nobody