### PR TITLE
QR scanner validates invite link

### DIFF
--- a/lib/v2/screens/sign_up/claim_invite/components/invite_link_fail_dialog.dart
+++ b/lib/v2/screens/sign_up/claim_invite/components/invite_link_fail_dialog.dart
@@ -14,7 +14,7 @@ class InviteLinkFailDialog extends StatelessWidget {
         Text('Invite Code Error'.i18n, style: Theme.of(context).textTheme.headline6),
         const SizedBox(height: 24.0),
         Text(
-          'Your invite code is no longer valid! Please check with the person who invited you to make sure their invitation is still valid. '
+          'This invite code has already been claimed! Please check with the person who invited you.'
               .i18n,
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.subtitle2,

--- a/lib/v2/screens/sign_up/claim_invite/mappers/claim_invite_mapper.dart
+++ b/lib/v2/screens/sign_up/claim_invite/mappers/claim_invite_mapper.dart
@@ -60,7 +60,7 @@ class ClaimInviteMapper extends StateMapper {
 
       return currentState.copyWith(
         claimInviteState: claimInviteCurrentState.copyWith(
-          claimInviteView: ClaimInviteView.success,
+          claimInviteView: ClaimInviteView.processing,
           inviteMnemonic: inviteMnemonic,
           pageCommand: !inviteMnemonic.isNullOrEmpty ? StopScan() : null,
         ),

--- a/lib/v2/screens/sign_up/viewmodels/signup_bloc.dart
+++ b/lib/v2/screens/sign_up/viewmodels/signup_bloc.dart
@@ -52,7 +52,7 @@ class SignupBloc extends Bloc<SignupEvent, SignupState> {
             fromDeepLink: true,
           ),
         );
-        await Future.delayed(const Duration(seconds: 2));
+        await Future.delayed(const Duration(seconds: 1));
         Result result = await _claimInviteUseCase.validateInviteCode(event.inviteCode!);
         yield ClaimInviteMapper().mapValidateInviteCodeToState(state, result);
         // if success shows successs screen for 1 second then move to add name
@@ -85,6 +85,17 @@ class SignupBloc extends Bloc<SignupEvent, SignupState> {
       );
       Result result = await _claimInviteUseCase.unpackLink(event.scannedLink);
       yield ClaimInviteMapper().mapInviteMnemonicToState(state, result);
+
+      if (state.claimInviteState.inviteMnemonic != null) {
+        yield state.copyWith(
+          claimInviteState: state.claimInviteState.copyWith(
+            pageCommand: StopScan(),
+          ),
+        );
+        Result result = await _claimInviteUseCase.validateInviteCode(state.claimInviteState.inviteMnemonic!);
+        yield ClaimInviteMapper().mapValidateInviteCodeToState(state, result);
+      }
+
       // if success shows successs screen for 1 second then move to add name
       if (state.claimInviteState.claimInviteView == ClaimInviteView.success) {
         await Future.delayed(const Duration(seconds: 1));


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Error description:
1 - user scans QR which has an invalid (already used) invite
2 - sees "success" dialog - this should be a fail dialog
3 - goes to enter their name and account name and phone number
4 - goes to create account -> now this fails because the invite was invalid

But it should not let the user enter their data, it should fail at step 2

Fix: 
Fails with error at step 2

"Done" button (see screenshot) goes back to QR scanner

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Add additional state change after unpacking link
-> verify link

### 🙈 Screenshots
![image](https://user-images.githubusercontent.com/65412/128540999-5b308717-d439-433e-91d0-b3ec774e8a76.jpeg)

### 👯‍♀️ Paired with
