### PR TITLE
Polish: show enter pincode or 're-enter pincode' depending on the mode

### DIFF
--- a/lib/i18n/passcode.i18n.dart
+++ b/lib/i18n/passcode.i18n.dart
@@ -6,6 +6,7 @@ extension Localization on String {
         'es_es': {
           'Delete': 'Borrar',
           'Re-enter Pincode': 'Re-ingresar código de acceso',
+          'Enter Pincode': 'Ingresar código de acceso',
           'Create Pincode': 'Crear código de acceso',
           'Use biometric to unlock': 'Desbloquear con biometrico',
           'Succesful': 'Completado',

--- a/lib/v2/screens/authentication/verification/components/verify_passcode.dart
+++ b/lib/v2/screens/authentication/verification/components/verify_passcode.dart
@@ -62,19 +62,19 @@ class _VerifyPasscodeState extends State<VerifyPasscode> {
             },
           ),
         ],
-        child: PasscodeScreen(
-          cancelButton: const SizedBox.shrink(),
-          deleteButton: Text('Delete'.i18n, style: Theme.of(context).textTheme.subtitle2),
-          passwordDigits: 4,
-          title: Text('Re-enter Pincode'.i18n, style: Theme.of(context).textTheme.subtitle2),
-          backgroundColor: AppColors.primary,
-          shouldTriggerVerification: _verificationNotifier.stream,
-          passwordEnteredCallback: (passcode) =>
-              BlocProvider.of<VerificationBloc>(context).add(OnVerifyPasscode(passcode: passcode)),
-          isValidCallback: () => BlocProvider.of<VerificationBloc>(context).add(const OnValidVerifyPasscode()),
-          bottomWidget: BlocBuilder<VerificationBloc, VerificationState>(
-            builder: (context, state) {
-              return !state.authError! && settingsStorage.biometricActive!
+        child: BlocBuilder<VerificationBloc, VerificationState>(
+          builder: (context, state) {
+            return PasscodeScreen(
+              cancelButton: const SizedBox.shrink(),
+              deleteButton: Text('Delete'.i18n, style: Theme.of(context).textTheme.subtitle2),
+              passwordDigits: 4,
+              title: Text( (state.isCreateMode ?? false) ? 'Re-enter Pincode' : 'Enter Pincode'.i18n, style: Theme.of(context).textTheme.subtitle2),
+              backgroundColor: AppColors.primary,
+              shouldTriggerVerification: _verificationNotifier.stream,
+              passwordEnteredCallback: (passcode) =>
+                  BlocProvider.of<VerificationBloc>(context).add(OnVerifyPasscode(passcode: passcode)),
+              isValidCallback: () => BlocProvider.of<VerificationBloc>(context).add(const OnValidVerifyPasscode()),
+              bottomWidget: !state.authError! && settingsStorage.biometricActive!
                   ? Padding(
                       padding: const EdgeInsets.only(top: 20),
                       child: OutlinedButton(
@@ -89,10 +89,10 @@ class _VerifyPasscodeState extends State<VerifyPasscode> {
                               textAlign: TextAlign.center, style: Theme.of(context).textTheme.subtitle2),
                           onPressed: () => BlocProvider.of<VerificationBloc>(context).add(const TryAgainBiometric())),
                     )
-                  : const SizedBox.shrink();
-            },
-          ),
-          circleUIConfig: const CircleUIConfig(circleSize: 14),
+                  : const SizedBox.shrink(),
+              circleUIConfig: const CircleUIConfig(circleSize: 14),
+            );
+          },
         ),
       ),
     );


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

When returning to app, PIN code screen says "Re-enter pincode"

It should say "Enter Pincode"

It says re-enter on the pin confirm screen when setting up the pin code. 

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Moved the block builder one widget up, using the state variable isCreateMode to figure out if it's a "re-enter" or "enter" scren 

State variable already existed. 

### 🙈 Screenshots

Returning to app from backgrounded state

![Simulator Screen Shot - iPhone 8 - 2021-08-07 at 01 44 57](https://user-images.githubusercontent.com/65412/128552243-a6a9930b-1daa-4373-8c7e-9981d7f35a63.png)

Create flow
![Simulator Screen Shot - iPhone 8 - 2021-08-07 at 01 45 04](https://user-images.githubusercontent.com/65412/128552240-b5e878c1-d35c-41e6-81a5-7f25c70e3ed4.png)
![Simulator Screen Shot - iPhone 8 - 2021-08-07 at 01 45 26](https://user-images.githubusercontent.com/65412/128552230-22d3430b-e802-4045-9846-1bcac952e96f.png)
![Simulator Screen Shot - iPhone 8 - 2021-08-07 at 01 45 09](https://user-images.githubusercontent.com/65412/128552235-3a73ab17-abd5-46c5-b9ce-f91ef24150e9.png)

### 👯‍♀️ Paired with

_@github-handle or "nobody" if you did not pair._
