### PR TITLE
Refactor all scores for visitor and resident progress pages

### DIFF
--- a/lib/v2/blocs/deeplink/mappers/deep_link_state_mapper.dart
+++ b/lib/v2/blocs/deeplink/mappers/deep_link_state_mapper.dart
@@ -1,4 +1,4 @@
-import 'package:seeds/utils/string_extension.dart';
+import 'package:seeds/v2/utils/string_extension.dart';
 import 'package:seeds/v2/blocs/deeplink/model/deep_link_data.dart';
 import 'package:seeds/v2/blocs/deeplink/model/guardian_recovery_request_data.dart';
 import 'package:seeds/v2/blocs/deeplink/model/invite_link_data.dart';

--- a/lib/v2/datasource/remote/api/network_repository.dart
+++ b/lib/v2/datasource/remote/api/network_repository.dart
@@ -10,7 +10,7 @@ abstract class NetworkRepository {
   String fxApiKey = "thesecretapikey989";
   Map<String, String> headers = {'Content-type': 'application/json'};
 
-  String table_balances = 'balances';
+  String table_planted = 'planted';
   String table_guards = 'guards';
   String table_harvest = 'harvest';
   String table_invites = 'invites';

--- a/lib/v2/datasource/remote/api/planted_repository.dart
+++ b/lib/v2/datasource/remote/api/planted_repository.dart
@@ -13,7 +13,7 @@ class PlantedRepository extends NetworkRepository {
     var request = createRequest(
         code: account_harvest,
         scope: account_harvest,
-        table: table_balances,
+        table: table_planted,
         lowerBound: userAccount,
         upperBound: userAccount,
         limit: 1);

--- a/lib/v2/datasource/remote/api/profile_repository.dart
+++ b/lib/v2/datasource/remote/api/profile_repository.dart
@@ -79,7 +79,8 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     String contractName = account_harvest,
     String? scope,
     required String tableName,
-    String fieldName = "rank",
+    required String pointsName,
+    String rankName = "rank",
   }) async {
     print('[http] get score $account $tableName');
 
@@ -97,7 +98,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     return http
         .post(scoreURL, headers: headers, body: request)
         .then((http.Response response) => mapHttpResponse(response, (dynamic body) {
-              return ScoreModel.fromJson(json: body, fieldName: fieldName);
+              return ScoreModel.fromJson(json: body, pointsName: pointsName, rankName: rankName);
             }))
         .catchError((error) => mapHttpError(error));
   }

--- a/lib/v2/datasource/remote/model/planted_model.dart
+++ b/lib/v2/datasource/remote/model/planted_model.dart
@@ -5,8 +5,9 @@ import 'package:seeds/v2/domain-shared/ui_constants.dart';
 class PlantedModel {
   // Seeds planted
   final double quantity;
+  final int rank;
 
-  const PlantedModel(this.quantity);
+  const PlantedModel(this.quantity, this.rank);
 
   /// Returns the rounded amount in seeds with its symbol
   String get formattedQuantity => '${quantity.seedsFormatted} $currencySeedsCode';
@@ -14,13 +15,17 @@ class PlantedModel {
   /// Returns the rounded amount in seeds
   String get roundedQuantity => '${quantity.seedsFormatted}';
 
+  int get intQuantity => quantity as int;
+
   factory PlantedModel.fromJson(Map<String, dynamic>? json) {
     if (json != null && json['rows'].isNotEmpty) {
       var value = json['rows'][0]['planted'] ?? 0.toString();
+      var rankString = json['rows'][0]['rank'] ?? 0.toString();
       var amount = double.parse(value.split(' ').first);
-      return PlantedModel(amount);
+      var rank = int.parse(rankString);
+      return PlantedModel(amount, rank);
     } else {
-      return const PlantedModel(0);
+      return const PlantedModel(0, 0);
     }
   }
 }

--- a/lib/v2/datasource/remote/model/score_model.dart
+++ b/lib/v2/datasource/remote/model/score_model.dart
@@ -1,27 +1,53 @@
+import 'package:seeds/v2/utils/string_extension.dart';
+
 class ScoreModel {
-  final int value;
+  final int points;
+  final int score;
 
   ScoreModel({
-    required this.value,
+    required this.points,
+    required this.score,
   });
 
-  double toDouble() => value.toDouble();
+  double pointsDouble() => points.toDouble();
+  double scoreDouble() => score.toDouble();
 
-  factory ScoreModel.fromJson({required Map<String, dynamic> json, String fieldName = "rank"}) {
+  factory ScoreModel.fromJson(
+      {required Map<String, dynamic> json, required String pointsName, String rankName = "rank"}) {
     if (json['rows'].isNotEmpty) {
       Map<String, dynamic> item = json['rows'][0];
       return ScoreModel(
-        value: item[fieldName],
+        points: item[pointsName],
+        score: item[rankName],
       );
     } else {
       return ScoreModel(
-        value: 0,
+        points: 0,
+        score: 0,
+      );
+    }
+  }
+
+  factory ScoreModel.fromJsonPlanted(
+      {required Map<String, dynamic> json, required String pointsName, String rankName = "rank"}) {
+    if (json['rows'].isNotEmpty) {
+      Map<String, dynamic> item = json['rows'][0];
+      String assetString = item[pointsName];
+      int assetAsInt = assetString.assetAmount as int;
+      return ScoreModel(
+        points: assetAsInt,
+        score: item[rankName],
+      );
+    } else {
+      return ScoreModel(
+        points: 0,
+        score: 0,
       );
     }
   }
 
   @override
   String toString() {
-    return "ScoreModel: $value";
+    return "ScoreModel: points: $points score: $score";
   }
 }

--- a/lib/v2/screens/authentication/recover/recover_account_found/components/guardian_row_widget.dart
+++ b/lib/v2/screens/authentication/recover/recover_account_found/components/guardian_row_widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:seeds/utils/string_extension.dart';
+import 'package:seeds/v2/utils/string_extension.dart';
 import 'package:seeds/v2/components/profile_avatar.dart';
 import 'package:seeds/v2/constants/app_colors.dart';
 import 'package:seeds/v2/datasource/remote/model/member_model.dart';

--- a/lib/v2/screens/profile_screens/citizenship/components/resident_view.dart
+++ b/lib/v2/screens/profile_screens/citizenship/components/resident_view.dart
@@ -54,7 +54,7 @@ class _ResidentViewState extends State<ResidentView> with TickerProviderStateMix
             setState(() => _timeLine = _timeLineAnimation.value.toInt());
           });
         _reputationAnimation =
-            Tween<double>(begin: 0, end: state.score!.reputationScore?.toDouble()).animate(_controller)
+            Tween<double>(begin: 0, end: state.score!.reputationScore?.scoreDouble()).animate(_controller)
               ..addListener(() {
                 setState(() => _reputation = _reputationAnimation.value.toInt());
               });
@@ -66,12 +66,12 @@ class _ResidentViewState extends State<ResidentView> with TickerProviderStateMix
           ..addListener(() {
             setState(() => _age = _ageAnimation.value.toInt());
           });
-        _seedsAnimation = Tween<double>(begin: 0, end: state.score!.plantedScore?.toDouble()).animate(_controller)
+        _seedsAnimation = Tween<double>(begin: 0, end: state.score!.plantedScore?.quantity).animate(_controller)
           ..addListener(() {
             setState(() => _seeds = _seedsAnimation.value.toInt());
           });
         _transactionsAnimation =
-            Tween<double>(begin: 0, end: state.score!.transactionScore?.toDouble()).animate(_controller)
+            Tween<double>(begin: 0, end: state.score!.transactionScore?.scoreDouble()).animate(_controller)
               ..addListener(() {
                 setState(() => _transactions = _transactionsAnimation.value.toInt());
               });

--- a/lib/v2/screens/profile_screens/citizenship/components/visitor_view.dart
+++ b/lib/v2/screens/profile_screens/citizenship/components/visitor_view.dart
@@ -53,7 +53,7 @@ class _VisitorViewState extends State<VisitorView> with TickerProviderStateMixin
             setState(() => _timeLine = _timeLineAnimation.value.toInt());
           });
         _reputationAnimation =
-            Tween<double>(begin: 0, end: state.score!.reputationScore?.toDouble()).animate(_controller)
+            Tween<double>(begin: 0, end: state.score!.reputationScore?.pointsDouble()).animate(_controller)
               ..addListener(() {
                 setState(() => _reputation = _reputationAnimation.value.toInt());
               });
@@ -61,12 +61,12 @@ class _VisitorViewState extends State<VisitorView> with TickerProviderStateMixin
           ..addListener(() {
             setState(() => _visitors = _visitorsAnimation.value.toInt() * 100);
           });
-        _seedsAnimation = Tween<double>(begin: 0, end: state.score!.plantedScore?.toDouble()).animate(_controller)
+        _seedsAnimation = Tween<double>(begin: 0, end: state.score!.plantedScore?.quantity).animate(_controller)
           ..addListener(() {
             setState(() => _seeds = _seedsAnimation.value.toInt());
           });
         _transactionsAnimation =
-            Tween<double>(begin: 0, end: state.score!.transactionScore?.toDouble()).animate(_controller)
+            Tween<double>(begin: 0, end: state.score!.transactionScore?.pointsDouble()).animate(_controller)
               ..addListener(() {
                 setState(() => _transactions = _transactionsAnimation.value.toInt());
               });

--- a/lib/v2/screens/profile_screens/citizenship/interactor/mappers/set_values_mapper.dart
+++ b/lib/v2/screens/profile_screens/citizenship/interactor/mappers/set_values_mapper.dart
@@ -21,10 +21,10 @@ class SetValuesStateMapper extends StateMapper {
       if (profile.status == ProfileStatus.visitor) {
         // Timeline to resident
         // If the scores are greater than those required, use the required ones instead to avoid errors in the formula.
-        int reputation = min(score.reputationScore?.value ?? 0, resident_required_reputation);
+        int reputation = min(score.reputationScore?.points ?? 0, resident_required_reputation);
         int visitors = profiles.isNotEmpty ? resident_required_visitors_invited : 0;
-        int planted = min(score.plantedScore?.value ?? 0, resident_required_planted_seeds);
-        int transactions = min(score.transactionScore?.value ?? 0, resident_required_seeds_transactions);
+        int planted = min(score.plantedScore?.intQuantity ?? 0, resident_required_planted_seeds);
+        int transactions = min(score.transactionScore?.points ?? 0, resident_required_seeds_transactions);
         // Timeline to resident formula
         timeline = ((reputation / resident_required_reputation) +
                 (visitors / resident_required_visitors_invited) +
@@ -35,9 +35,9 @@ class SetValuesStateMapper extends StateMapper {
       } else {
         // Timeline to citizen
         // If the scores are greater than those required, use the required ones instead to avoid errors in the formula.
-        int reputation = min(score.reputationScore?.value ?? 0, citizen_required_reputation);
-        int planted = min(score.plantedScore?.value ?? 0, citizen_required_planted_seeds);
-        int transactions = min(score.transactionScore?.value ?? 0, citizen_required_seeds_transactions);
+        int reputation = min(score.reputationScore?.score ?? 0, citizen_required_reputation);
+        int planted = min(score.plantedScore?.intQuantity ?? 0, citizen_required_planted_seeds);
+        int transactions = min(score.transactionScore?.points ?? 0, citizen_required_seeds_transactions);
         int residents =
             profiles.where((i) => i.status == ProfileStatus.resident).length > citizen_required_residents_invited
                 ? citizen_required_residents_invited

--- a/lib/v2/screens/profile_screens/contribution/contribution_screen.dart
+++ b/lib/v2/screens/profile_screens/contribution/contribution_screen.dart
@@ -52,28 +52,28 @@ class _ContributionScreenState extends State<ContributionScreen> with TickerProv
               previous.pageState != PageState.success && current.pageState == PageState.success,
           listener: (context, state) {
             _contributionAnimation =
-                Tween<double>(begin: 0, end: (state.score!.contributionScore?.value ?? 0).toDouble())
+                Tween<double>(begin: 0, end: (state.score!.contributionScore?.score ?? 0).toDouble())
                     .animate(_controller)
                       ..addListener(() {
                         setState(() => _contribution = _contributionAnimation.value.toInt());
                       });
             _communityAnimation =
-                Tween<double>(begin: 0, end: (state.score!.communityScore?.value ?? 0).toDouble()).animate(_controller)
+                Tween<double>(begin: 0, end: (state.score!.communityScore?.score ?? 0).toDouble()).animate(_controller)
                   ..addListener(() {
                     setState(() => _community = _communityAnimation.value.toInt());
                   });
-            _reputationAnimation =
-                Tween<double>(begin: 0, end: (state.score!.reputationScore?.value ?? 0).toDouble()).animate(_controller)
+            _reputationAnimation = Tween<double>(begin: 0, end: (state.score!.reputationScore?.points ?? 0).toDouble())
+                .animate(_controller)
                   ..addListener(() {
                     setState(() => _reputation = _reputationAnimation.value.toInt());
                   });
             _seedsAnimation =
-                Tween<double>(begin: 0, end: (state.score!.plantedScore?.value ?? 0).toDouble()).animate(_controller)
+                Tween<double>(begin: 0, end: (state.score!.plantedScore?.intQuantity ?? 0).toDouble()).animate(_controller)
                   ..addListener(() {
                     setState(() => _seeds = _seedsAnimation.value.toInt());
                   });
             _transactionsAnimation =
-                Tween<double>(begin: 0, end: (state.score!.transactionScore?.value ?? 0).toDouble())
+                Tween<double>(begin: 0, end: (state.score!.transactionScore?.points ?? 0).toDouble())
                     .animate(_controller)
                       ..addListener(() {
                         setState(() => _transactions = _transactionsAnimation.value.toInt());

--- a/lib/v2/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart
+++ b/lib/v2/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart
@@ -1,11 +1,12 @@
 import 'package:equatable/equatable.dart';
+import 'package:seeds/v2/datasource/remote/model/planted_model.dart';
 import 'package:seeds/v2/datasource/remote/model/score_model.dart';
 
 class ScoresViewModel extends Equatable {
   final ScoreModel? contributionScore;
   final ScoreModel? communityScore;
   final ScoreModel? reputationScore;
-  final ScoreModel? plantedScore;
+  final PlantedModel? plantedScore;
   final ScoreModel? transactionScore;
 
   const ScoresViewModel(
@@ -16,5 +17,5 @@ class ScoresViewModel extends Equatable {
 
   @override
   String toString() =>
-      "ScoreViewModel: cs: ${contributionScore?.value} community: ${communityScore?.value} rep: ${reputationScore?.value} planted: ${plantedScore?.value} transactions: ${transactionScore?.value}";
+      "ScoreViewModel: cs: ${contributionScore?.score} community: ${communityScore?.score} rep: ${reputationScore?.score} planted: ${plantedScore?.quantity} transactions: ${transactionScore?.points}";
 }

--- a/lib/v2/screens/profile_screens/guardians/guardians_tabs/components/guardian_row_widget.dart
+++ b/lib/v2/screens/profile_screens/guardians/guardians_tabs/components/guardian_row_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:seeds/utils/string_extension.dart';
+import 'package:seeds/v2/utils/string_extension.dart';
 import 'package:seeds/v2/components/profile_avatar.dart';
 import 'package:seeds/v2/datasource/remote/model/firebase_models/guardian_model.dart';
 import 'package:seeds/v2/design/app_theme.dart';

--- a/lib/v2/screens/profile_screens/profile/components/profile_middle.dart
+++ b/lib/v2/screens/profile_screens/profile/components/profile_middle.dart
@@ -30,7 +30,7 @@ class ProfileMiddle extends StatelessWidget {
                 trailing: state.pageState == PageState.loading || state.pageState == PageState.initial
                     ? const ShimmerRectangle(size: Size(52, 21))
                     : Text(
-                        '${state.score?.contributionScore?.value ?? '00'}/99',
+                        '${state.score?.contributionScore?.score ?? '00'}/99',
                         textAlign: TextAlign.center,
                         style: Theme.of(context).textTheme.headline7LowEmphasis,
                       ),

--- a/lib/v2/screens/profile_screens/profile/interactor/usecases/get_profile_values_use_case.dart
+++ b/lib/v2/screens/profile_screens/profile/interactor/usecases/get_profile_values_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:seeds/v2/datasource/local/settings_storage.dart';
+import 'package:seeds/v2/datasource/remote/api/planted_repository.dart';
 import 'package:seeds/v2/datasource/remote/api/profile_repository.dart';
 
 class GetProfileValuesUseCase {
@@ -9,11 +10,12 @@ class GetProfileValuesUseCase {
     var account = settingsStorage.accountName;
     var futures = [
       _profileRepository.getProfile(account),
-      _profileRepository.getScore(account: account, tableName: "cspoints"),
-      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: "cbs"),
-      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: "rep"),
-      _profileRepository.getScore(account: account, tableName: "planted"),
-      _profileRepository.getScore(account: account, tableName: "txpoints"),
+      _profileRepository.getScore(account: account, tableName: "cspoints", pointsName: "contribution_points"),
+      _profileRepository.getScore(
+          account: account, contractName: "accts.seeds", tableName: "cbs", pointsName: "community_building_score"),
+      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: "rep", pointsName: "rep"),
+      PlantedRepository().getPlanted(account),
+      _profileRepository.getScore(account: account, tableName: "txpoints", pointsName: "points"),
       _profileRepository.canResident(account),
       _profileRepository.canCitizen(account),
     ];

--- a/lib/v2/screens/sign_up/add_phone_number/usecases/add_phone_number_usecase.dart
+++ b/lib/v2/screens/sign_up/add_phone_number/usecases/add_phone_number_usecase.dart
@@ -1,5 +1,5 @@
 import 'package:async/async.dart';
-import 'package:seeds/utils/string_extension.dart';
+import 'package:seeds/v2/utils/string_extension.dart';
 import 'package:seeds/v2/datasource/remote/api/signup_repository.dart';
 import 'package:seeds/v2/datasource/remote/firebase/firebase_user_repository.dart';
 // ignore: import_of_legacy_library_into_null_safe

--- a/lib/v2/screens/sign_up/claim_invite/mappers/claim_invite_mapper.dart
+++ b/lib/v2/screens/sign_up/claim_invite/mappers/claim_invite_mapper.dart
@@ -1,5 +1,5 @@
 import 'package:seeds/i18n/claim_code.i18n.dart';
-import 'package:seeds/utils/string_extension.dart';
+import 'package:seeds/v2/utils/string_extension.dart';
 import 'package:seeds/v2/datasource/remote/model/invite_model.dart';
 import 'package:seeds/v2/domain-shared/page_command.dart';
 import 'package:seeds/v2/domain-shared/result_to_state_mapper.dart';

--- a/lib/v2/screens/sign_up/create_username/usecases/create_username_usecase.dart
+++ b/lib/v2/screens/sign_up/create_username/usecases/create_username_usecase.dart
@@ -1,5 +1,5 @@
 import 'package:async/async.dart';
-import 'package:seeds/utils/string_extension.dart';
+import 'package:seeds/v2/utils/string_extension.dart';
 import 'package:seeds/v2/datasource/remote/api/signup_repository.dart';
 import 'package:seeds/v2/screens/sign_up/create_username/mappers/create_username_mapper.dart';
 import 'package:seeds/v2/screens/sign_up/viewmodels/bloc.dart';

--- a/lib/v2/screens/sign_up/display_name/display_name.dart
+++ b/lib/v2/screens/sign_up/display_name/display_name.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:seeds/i18n/edit_name.i18n.dart';
-import 'package:seeds/utils/string_extension.dart';
+import 'package:seeds/v2/utils/string_extension.dart';
 import 'package:seeds/v2/components/flat_button_long.dart';
 import 'package:seeds/v2/components/text_form_field_custom.dart';
 import 'package:seeds/v2/design/app_theme.dart';

--- a/lib/v2/screens/sign_up/viewmodels/states/create_username_state.dart
+++ b/lib/v2/screens/sign_up/viewmodels/states/create_username_state.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:seeds/utils/string_extension.dart';
+import 'package:seeds/v2/utils/string_extension.dart';
 import 'package:seeds/v2/domain-shared/page_command.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
 

--- a/lib/v2/screens/wallet/components/transactions_list/components/transaction_info_row.dart
+++ b/lib/v2/screens/wallet/components/transactions_list/components/transaction_info_row.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:seeds/v2/constants/app_colors.dart';
-import 'package:seeds/utils/string_extension.dart';
+import 'package:seeds/v2/utils/string_extension.dart';
 import 'package:seeds/v2/screens/wallet/components/transactions_list/interactor/viewmodels/member_bloc.dart';
 import 'package:seeds/v2/screens/wallet/components/transactions_list/interactor/viewmodels/member_events.dart';
 import 'package:seeds/v2/screens/wallet/components/transactions_list/interactor/viewmodels/member_state.dart';

--- a/lib/v2/utils/string_extension.dart
+++ b/lib/v2/utils/string_extension.dart
@@ -10,6 +10,10 @@ extension StringExtension on String {
   String get symbolFromAmount {
     return split(" ")[1];
   }
+
+  double get assetAmount {
+    return double.parse(split(" ")[0]);
+  }
 }
 
 extension NullableStringExtension on String? {

--- a/lib/widgets/available_balance.dart
+++ b/lib/widgets/available_balance.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:seeds/v2/constants/app_colors.dart';
 import 'package:seeds/providers/notifiers/balance_notifier.dart';
 import 'package:seeds/i18n/widgets.i18n.dart';
-import 'package:seeds/utils/string_extension.dart';
+import 'package:seeds/v2/utils/string_extension.dart';
 
 class AvailableBalance extends StatelessWidget {
   @override

--- a/lib/widgets/v2_widgets/dashboard_widgets/transaction_info_card.dart
+++ b/lib/widgets/v2_widgets/dashboard_widgets/transaction_info_card.dart
@@ -1,7 +1,7 @@
 // import 'package:flutter/material.dart';
 // import 'package:flutter_svg/svg.dart';
 // import 'package:seeds/v2/constants/app_colors.dart';
-// import 'package:seeds/utils/string_extension.dart';
+// import 'package:seeds/v2/utils/string_extension.dart';
 // import 'package:seeds/widgets/read_times_tamp.dart';
 // import 'package:seeds/widgets/transaction_avatar.dart';
 // import 'package:seeds/v2/design/app_theme.dart';


### PR DESCRIPTION
We may not need this if Gabriel's changes work

### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Fixing scores

Sometimes we need to show points, sometimes rank, we always load both now (same amount of calls)

visitor screen need to show reputation points
Resident -> Citizen screen need to show reputation rank (score)

Using planted model for planted

Fix planted table to be correct

TBD: Ensure all scores are correct. I think tx points and planted not yet. 


### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

### 🙈 Screenshots

### 👯‍♀️ Paired with

