### PR TITLE
Fix transactions time

### DIFF
--- a/lib/widgets/read_times_tamp.dart
+++ b/lib/widgets/read_times_tamp.dart
@@ -9,9 +9,8 @@ import 'package:timeago/timeago.dart' as timeago;
 //https://pub.dev/documentation/timeago/latest/timeago/timeago-library.html
 
 String timesTampToTimeAgo(String timestamp) {
-
-  var covertTimesTamp = DateTime.parse(timestamp);
-  covertTimesTamp = covertTimesTamp.toUtc();
+  // Note: Timestamps always come as UTC but don't have the time zone set on EOSIO
+  var covertTimesTamp = DateTime.parse(timestamp + "Z");
 
   var timeAgo = timeago.format(covertTimesTamp, locale: 'en',);
 


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Timestamps for transactions were wrong on the main screen.

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

The times that come from the blockchain use a standard format and are in UTC - but they don't have a time zone set.

Default behavior for Dart DateTime.parse is to then assume the time zone is the local time zone - which would mix up the time (and for example show "8 hours ago" for me here, for a transaction I just did). 

Fix is to add the timezone to the incoming string by appending a Z. 

Better fix will be to parse this in the transaction model and store it as an integer denoting milliseconds since epoch. Rather than storing it as String. 

I looked back at V1 and I think it had the same issue, but V1 would not show the timestamp on the list, only on the detail view, so we didn't find this bug.

### 🙈 Screenshots
![Simulator Screen Shot - iPhone 8 - 2021-08-08 at 20 00 19](https://user-images.githubusercontent.com/65412/128631241-5a396562-4818-4c2a-8606-ac9bf6431738.png)

### 👯‍♀️ Paired with