### PR TITLE
Update transactions time ago value

### DIFF
--- a/lib/v2/screens/transfer/send/send_enter_data/send_enter_data_screen.dart
+++ b/lib/v2/screens/transfer/send/send_enter_data/send_enter_data_screen.dart
@@ -79,7 +79,12 @@ class SendEnterDataScreen extends StatelessWidget {
             }
           },
           child: Scaffold(
-            appBar: AppBar(title: const Text("Back")),
+            appBar: AppBar(
+              title: Text("Send".i18n),
+              backgroundColor: Colors.transparent,
+              elevation: 0.0,
+            ),
+            extendBodyBehindAppBar: true,
             body: BlocBuilder<SendEnterDataPageBloc, SendEnterDataPageState>(buildWhen: (context, state) {
               return state.pageCommand == null;
             }, builder: (context, SendEnterDataPageState state) {
@@ -87,80 +92,85 @@ class SendEnterDataScreen extends StatelessWidget {
                 case PageState.initial:
                   return const SizedBox.shrink();
                 case PageState.loading:
+
                   /// We want to show special animation only when the user confirms send.
-                  return state.showSendingAnimation ? const SendLoadingIndicator(): const FullPageLoadingIndicator();
+                  return state.showSendingAnimation
+                      ? const SendLoadingIndicator()
+                      : const SafeArea(child: FullPageLoadingIndicator());
                 case PageState.failure:
-                  return const FullPageErrorIndicator();
+                  return const SafeArea(child: FullPageErrorIndicator());
                 case PageState.success:
-                  return Stack(
-                    children: [
-                      SingleChildScrollView(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.only(left: 16, top: 10),
-                              child: Text(
-                                "Send to",
-                                style: Theme.of(context).textTheme.subtitle1,
+                  return SafeArea(
+                    child: Stack(
+                      children: [
+                        SingleChildScrollView(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(left: 16, top: 10),
+                                child: Text(
+                                  "Send to",
+                                  style: Theme.of(context).textTheme.subtitle1,
+                                ),
                               ),
-                            ),
-                            const SizedBox(height: 8),
-                            SearchResultRow(
-                              account: memberModel.account,
-                              imageUrl: memberModel.image,
-                              name: memberModel.nickname,
-                            ),
-                            const SizedBox(height: 16),
-                            AmountEntryWidget(
-                              onValueChange: (value) {
-                                BlocProvider.of<SendEnterDataPageBloc>(context)
-                                    .add(OnAmountChange(amountChanged: value));
-                              },
-                              autoFocus: state.pageState == PageState.initial,
-                            ),
-                            const SizedBox(height: 24),
-                            AlertInputValue('Not enough balance'.i18n, isVisible: state.showAlert),
-                            const SizedBox(height: 30),
-                            Padding(
-                              padding: const EdgeInsets.only(left: 16, right: 16),
-                              child: Column(
-                                children: [
-                                  TextFormFieldLight(
-                                    labelText: "Memo",
-                                    hintText: "Add a note",
-                                    maxLength: 150,
-                                    onChanged: (String value) {
-                                      BlocProvider.of<SendEnterDataPageBloc>(context)
-                                          .add(OnMemoChange(memoChanged: value));
-                                    },
-                                  ),
-                                  const SizedBox(height: 16),
-                                  BalanceRow(
-                                    label: "Available Balance",
-                                    fiatAmount: state.availableBalanceFiat ?? "",
-                                    seedsAmount: state.availableBalance ?? "",
-                                  ),
-                                ],
+                              const SizedBox(height: 8),
+                              SearchResultRow(
+                                account: memberModel.account,
+                                imageUrl: memberModel.image,
+                                name: memberModel.nickname,
                               ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Align(
-                          alignment: Alignment.bottomCenter,
-                          child: FlatButtonLong(
-                            title: 'Next',
-                            enabled: state.isNextButtonEnabled,
-                            onPressed: () {
-                              BlocProvider.of<SendEnterDataPageBloc>(context).add(OnNextButtonTapped());
-                            },
+                              const SizedBox(height: 16),
+                              AmountEntryWidget(
+                                onValueChange: (value) {
+                                  BlocProvider.of<SendEnterDataPageBloc>(context)
+                                      .add(OnAmountChange(amountChanged: value));
+                                },
+                                autoFocus: state.pageState == PageState.initial,
+                              ),
+                              const SizedBox(height: 24),
+                              AlertInputValue('Not enough balance'.i18n, isVisible: state.showAlert),
+                              const SizedBox(height: 30),
+                              Padding(
+                                padding: const EdgeInsets.only(left: 16, right: 16),
+                                child: Column(
+                                  children: [
+                                    TextFormFieldLight(
+                                      labelText: "Memo",
+                                      hintText: "Add a note",
+                                      maxLength: 150,
+                                      onChanged: (String value) {
+                                        BlocProvider.of<SendEnterDataPageBloc>(context)
+                                            .add(OnMemoChange(memoChanged: value));
+                                      },
+                                    ),
+                                    const SizedBox(height: 16),
+                                    BalanceRow(
+                                      label: "Available Balance",
+                                      fiatAmount: state.availableBalanceFiat ?? "",
+                                      seedsAmount: state.availableBalance ?? "",
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
                           ),
                         ),
-                      )
-                    ],
+                        Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Align(
+                            alignment: Alignment.bottomCenter,
+                            child: FlatButtonLong(
+                              title: 'Next',
+                              enabled: state.isNextButtonEnabled,
+                              onPressed: () {
+                                BlocProvider.of<SendEnterDataPageBloc>(context).add(OnNextButtonTapped());
+                              },
+                            ),
+                          ),
+                        )
+                      ],
+                    ),
                   );
                 default:
                   return const SizedBox.shrink();

--- a/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_bloc.dart
+++ b/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_bloc.dart
@@ -13,7 +13,6 @@ class TransactionsListBloc extends Bloc<TransactionsListEvent, TransactionsListS
   
   TransactionsListBloc() : super(TransactionsListState.initial()) {
       _tickerSubscription = Stream.periodic(const Duration(seconds: 3), (x) => x).listen((counter) { // TODO make this 30 seconds
-        print("ticker counter: $counter");
         add(OnTransactionDisplayTick(counter));
       });
   }

--- a/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_bloc.dart
+++ b/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_bloc.dart
@@ -12,7 +12,7 @@ class TransactionsListBloc extends Bloc<TransactionsListEvent, TransactionsListS
   StreamSubscription<int>? _tickerSubscription;
   
   TransactionsListBloc() : super(TransactionsListState.initial()) {
-      _tickerSubscription = Stream.periodic(const Duration(seconds: 3), (x) => x).listen((counter) { // TODO make this 30 seconds
+      _tickerSubscription = Stream.periodic(const Duration(seconds: 20), (x) => x).listen((counter) {
         add(OnTransactionDisplayTick(counter));
       });
   }

--- a/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_bloc.dart
+++ b/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
 import 'package:seeds/v2/screens/wallet/components/transactions_list/interactor/mappers/transactions_state_mapper.dart';
@@ -6,7 +8,21 @@ import 'package:seeds/v2/screens/wallet/components/transactions_list/interactor/
 import 'package:seeds/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_state.dart';
 
 class TransactionsListBloc extends Bloc<TransactionsListEvent, TransactionsListState> {
-  TransactionsListBloc() : super(TransactionsListState.initial());
+    
+  StreamSubscription<int>? _tickerSubscription;
+  
+  TransactionsListBloc() : super(TransactionsListState.initial()) {
+      _tickerSubscription = Stream.periodic(const Duration(seconds: 3), (x) => x).listen((counter) { // TODO make this 30 seconds
+        print("ticker counter: $counter");
+        add(OnTransactionDisplayTick(counter));
+      });
+  }
+
+  @override
+  Future<void> close() {
+    _tickerSubscription?.cancel();
+    return super.close();
+  }
 
   @override
   Stream<TransactionsListState> mapEventToState(TransactionsListEvent event) async* {
@@ -16,6 +32,8 @@ class TransactionsListBloc extends Bloc<TransactionsListEvent, TransactionsListS
       final result = await LoadTransactionsUseCase().run();
 
       yield TransactionsListStateMapper().mapResultToState(state, result);
+    } else if (event is OnTransactionDisplayTick) {
+      yield state.copyWith(counter: event.count);
     }
   }
 }

--- a/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_events.dart
+++ b/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_events.dart
@@ -11,3 +11,15 @@ class OnLoadTransactionsList extends TransactionsListEvent {
   @override
   List<Object> get props => [];
 }
+
+class OnTransactionDisplayTick extends TransactionsListEvent {
+  final int count;
+  
+  OnTransactionDisplayTick(this.count);
+
+  @override
+  String toString() => 'OnTick';
+
+  @override
+  List<Object> get props => [count];
+}

--- a/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_state.dart
+++ b/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_state.dart
@@ -5,20 +5,23 @@ import 'package:seeds/v2/domain-shared/page_state.dart';
 class TransactionsListState extends Equatable {
   final PageState pageState;
   final List<TransactionModel> transactions;
+  final int counter;
   bool get isLoadingNoData => pageState == PageState.loading && transactions.isEmpty;
 
   const TransactionsListState({
     required this.pageState,
     required this.transactions,
+    required this.counter,
   });
 
   @override
-  List<Object> get props => [pageState, transactions];
+  List<Object> get props => [pageState, transactions, counter];
 
-  TransactionsListState copyWith({pageState, transactions}) {
+  TransactionsListState copyWith({pageState, transactions, counter}) {
     return TransactionsListState(
       pageState: pageState ?? this.pageState,
       transactions: transactions ?? this.transactions,
+      counter: counter ?? this.counter,
     );
   }
 
@@ -26,6 +29,7 @@ class TransactionsListState extends Equatable {
     return const TransactionsListState(
       pageState: PageState.initial,
       transactions: [],
+      counter: 0,
     );
   }
 }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Bug: 

Time would show as "1 second ago" but never update

Fix: 

Add counter / timer to periodically update the display 

This does not need to reload anything. Just updating display. 

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

The transactions list shows time as relative, ie 1 minute ago

Therefore we need to update it periodically to update those values

Screenshots show it working

### 🙈 Screenshots

![Simulator Screen Shot - iPhone 11 Pro - 2021-08-09 at 09 57 43](https://user-images.githubusercontent.com/65412/128653802-0e8546ef-7408-45c7-ad79-e7755ef52efd.png)
![Uploading Simulator Screen Shot - iPhone 11 Pro - 2021-08-09 at 09.59.09.png…]()

### 👯‍♀️ Paired with
