### PR TITLE
Bug fix: Refresh transaction list and balance in dashboard

### DIFF
--- a/lib/v2/domain-shared/event_bus/events.dart
+++ b/lib/v2/domain-shared/event_bus/events.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:seeds/v2/datasource/remote/model/transaction_model.dart';
 
 /// --- EVENT BUS EVENTS
 ///
@@ -10,5 +11,6 @@ abstract class BusEvent<T> {
 }
 
 class OnNewTransactionEventBus extends BusEvent<OnNewTransactionEventBus> {
-  const OnNewTransactionEventBus();
+  final TransactionModel? transactionModel;
+  const OnNewTransactionEventBus(this.transactionModel);
 }

--- a/lib/v2/domain-shared/event_bus/events.dart
+++ b/lib/v2/domain-shared/event_bus/events.dart
@@ -1,5 +1,4 @@
 import 'package:meta/meta.dart';
-import 'package:seeds/v2/datasource/remote/model/transaction_model.dart';
 
 /// --- EVENT BUS EVENTS
 ///
@@ -10,8 +9,6 @@ abstract class BusEvent<T> {
   String toString() => 'EventBus { $T }';
 }
 
-class TransactionSentEventBusEvent extends BusEvent<TransactionSentEventBusEvent> {
-  final TransactionModel? transaction;
-
-  const TransactionSentEventBusEvent(this.transaction);
+class OnNewTransactionEventBus extends BusEvent<OnNewTransactionEventBus> {
+  const OnNewTransactionEventBus();
 }

--- a/lib/v2/screens/explore_screens/plant_seeds/interactor/mappers/plant_seeds_result_mapper.dart
+++ b/lib/v2/screens/explore_screens/plant_seeds/interactor/mappers/plant_seeds_result_mapper.dart
@@ -9,7 +9,6 @@ import 'package:seeds/v2/i18n/explore_screens/plant_seeds/plant_seeds.i18n.dart'
 class PlantSeedsResultMapper extends StateMapper {
   PlantSeedsState mapResultToState(PlantSeedsState currentState, Result result) {
     if (result.isError) {
-      // Transaction fail show snackbar fail
       print('Error transaction hash not retrieved');
       return currentState.copyWith(
         pageState: PageState.success,
@@ -17,9 +16,7 @@ class PlantSeedsResultMapper extends StateMapper {
         isPlantSeedsButtonEnabled: false,
       );
     } else {
-      // Transaction success show plant seeds success dialog
-      eventBus.fire(const OnNewTransactionEventBus());
-
+      eventBus.fire(const OnNewTransactionEventBus(null));
       return currentState.copyWith(pageState: PageState.success, pageCommand: ShowPlantSeedsSuccess());
     }
   }

--- a/lib/v2/screens/explore_screens/plant_seeds/interactor/mappers/plant_seeds_result_mapper.dart
+++ b/lib/v2/screens/explore_screens/plant_seeds/interactor/mappers/plant_seeds_result_mapper.dart
@@ -1,5 +1,7 @@
 import 'package:seeds/v2/domain-shared/page_command.dart';
 import 'package:seeds/v2/domain-shared/page_state.dart';
+import 'package:seeds/v2/domain-shared/event_bus/event_bus.dart';
+import 'package:seeds/v2/domain-shared/event_bus/events.dart';
 import 'package:seeds/v2/domain-shared/result_to_state_mapper.dart';
 import 'package:seeds/v2/screens/explore_screens/plant_seeds/interactor/viewmodels/plant_seeds_state.dart';
 import 'package:seeds/v2/i18n/explore_screens/plant_seeds/plant_seeds.i18n.dart';
@@ -16,6 +18,8 @@ class PlantSeedsResultMapper extends StateMapper {
       );
     } else {
       // Transaction success show plant seeds success dialog
+      eventBus.fire(const OnNewTransactionEventBus());
+
       return currentState.copyWith(pageState: PageState.success, pageCommand: ShowPlantSeedsSuccess());
     }
   }

--- a/lib/v2/screens/transfer/receive/receive_enter_data/interactor/mappers/create_invoice_result_mapper.dart
+++ b/lib/v2/screens/transfer/receive/receive_enter_data/interactor/mappers/create_invoice_result_mapper.dart
@@ -1,6 +1,4 @@
 import 'package:seeds/v2/domain-shared/page_state.dart';
-import 'package:seeds/v2/domain-shared/event_bus/event_bus.dart';
-import 'package:seeds/v2/domain-shared/event_bus/events.dart';
 import 'package:seeds/v2/domain-shared/result_to_state_mapper.dart';
 import 'package:seeds/v2/screens/transfer/receive/receive_detail_qr_code/interactor/viewmodels/receive_detail_arguments.dart';
 import 'package:seeds/v2/screens/transfer/receive/receive_enter_data/interactor/viewmodels/page_commands.dart';
@@ -12,8 +10,6 @@ class CreateInvoiceResultMapper extends StateMapper {
       print('Error invoice hash not retrieved');
       return currentState.copyWith(pageState: PageState.success, pageCommand: ShowTransactionFail());
     } else {
-      eventBus.fire(const OnNewTransactionEventBus());
-
       return currentState.copyWith(
         pageState: PageState.success,
         pageCommand: NavigateToReceiveDetails(

--- a/lib/v2/screens/transfer/receive/receive_enter_data/interactor/mappers/create_invoice_result_mapper.dart
+++ b/lib/v2/screens/transfer/receive/receive_enter_data/interactor/mappers/create_invoice_result_mapper.dart
@@ -1,4 +1,6 @@
 import 'package:seeds/v2/domain-shared/page_state.dart';
+import 'package:seeds/v2/domain-shared/event_bus/event_bus.dart';
+import 'package:seeds/v2/domain-shared/event_bus/events.dart';
 import 'package:seeds/v2/domain-shared/result_to_state_mapper.dart';
 import 'package:seeds/v2/screens/transfer/receive/receive_detail_qr_code/interactor/viewmodels/receive_detail_arguments.dart';
 import 'package:seeds/v2/screens/transfer/receive/receive_enter_data/interactor/viewmodels/page_commands.dart';
@@ -8,11 +10,10 @@ class CreateInvoiceResultMapper extends StateMapper {
   ReceiveEnterDataState mapResultToState(ReceiveEnterDataState currentState, Result result) {
     if (result.isError) {
       print('Error invoice hash not retrieved');
-      return currentState.copyWith(
-        pageState: PageState.success,
-        pageCommand: ShowTransactionFail(),
-      );
+      return currentState.copyWith(pageState: PageState.success, pageCommand: ShowTransactionFail());
     } else {
+      eventBus.fire(const OnNewTransactionEventBus());
+
       return currentState.copyWith(
         pageState: PageState.success,
         pageCommand: NavigateToReceiveDetails(

--- a/lib/v2/screens/transfer/send/send_enter_data/interactor/mappers/send_transaction_mapper.dart
+++ b/lib/v2/screens/transfer/send/send_enter_data/interactor/mappers/send_transaction_mapper.dart
@@ -23,7 +23,7 @@ class SendTransactionMapper extends StateMapper {
       final selectedFiat = settingsStorage.selectedFiatCurrency;
       final String fiatAmount = currentState.ratesState.fromSeedsToFiat(parsedQuantity, selectedFiat).fiatFormatted;
 
-      eventBus.fire(const OnNewTransactionEventBus());
+      eventBus.fire(OnNewTransactionEventBus(resultResponse.transactionModel));
 
       if (areAllResultsSuccess(resultResponse.profiles)) {
         final toAccount = resultResponse.profiles[0].asValue!.value as ProfileModel;

--- a/lib/v2/screens/transfer/send/send_enter_data/interactor/mappers/send_transaction_mapper.dart
+++ b/lib/v2/screens/transfer/send/send_enter_data/interactor/mappers/send_transaction_mapper.dart
@@ -23,7 +23,7 @@ class SendTransactionMapper extends StateMapper {
       final selectedFiat = settingsStorage.selectedFiatCurrency;
       final String fiatAmount = currentState.ratesState.fromSeedsToFiat(parsedQuantity, selectedFiat).fiatFormatted;
 
-      eventBus.fire(TransactionSentEventBusEvent(resultResponse.transactionModel));
+      eventBus.fire(const OnNewTransactionEventBus());
 
       if (areAllResultsSuccess(resultResponse.profiles)) {
         final toAccount = resultResponse.profiles[0].asValue!.value as ProfileModel;

--- a/lib/v2/screens/wallet/components/tokens_cards/interactor/viewmodels/token_balances_bloc.dart
+++ b/lib/v2/screens/wallet/components/tokens_cards/interactor/viewmodels/token_balances_bloc.dart
@@ -15,7 +15,7 @@ class TokenBalancesBloc extends Bloc<TokenBalancesEvent, TokenBalancesState> {
   StreamSubscription? eventBusSubscription;
 
   TokenBalancesBloc() : super(TokenBalancesState.initial()) {
-    eventBusSubscription = eventBus.on<TransactionSentEventBusEvent>().listen((event) async {
+    eventBusSubscription = eventBus.on<OnNewTransactionEventBus>().listen((event) async {
       await Future.delayed(const Duration(milliseconds: 500)); // the blockchain needs 0.5 seconds to process
       add(const OnLoadTokenBalances());
     });

--- a/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_bloc.dart
+++ b/lib/v2/screens/wallet/components/transactions_list/interactor/viewmodels/transactions_list_bloc.dart
@@ -17,7 +17,7 @@ class TransactionsListBloc extends Bloc<TransactionsListEvent, TransactionsListS
     _tickerSubscription = Stream.periodic(const Duration(seconds: 20), (x) => x).listen((counter) {
       add(OnTransactionDisplayTick(counter));
     });
-    eventBusSubscription = eventBus.on<TransactionSentEventBusEvent>().listen((event) async {
+    eventBusSubscription = eventBus.on<OnNewTransactionEventBus>().listen((event) async {
       await Future.delayed(const Duration(milliseconds: 500)); // the blockchain needs 0.5 seconds to process
       add(OnLoadTransactionsList());
     });


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1033

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] all tested

### 🕵️‍♂️ Notes for Code Reviewer

The event bus is adjusted so that it is called in each transaction (send, recive, plant) to refresh the transactions and the seeds balanse in the dashboard.

NOTE: I found 2 bugs in the send flow (The are visibles in the gift below):
- When the loadig screen appears, the logo reach the top of the system.
- The keyboard reappears for some miliseconds when closing the done dialog.

### 🙈 Screenshots

| Send seeds | Plant seeds |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/42857405/129420182-99064ff4-9a9d-4d1c-b06b-5862270b9b96.gif" width="380"> | <img src="https://user-images.githubusercontent.com/42857405/129420238-fc6c726f-bb75-4806-9b67-a2bd50ba2545.gif" width="380"> |

### 👯‍♀️ Paired with
 "nobody"
