### PR TITLE
amount entry needs decimal point

### DIFF
--- a/lib/v2/components/amount_entry/amount_entry_widget.dart
+++ b/lib/v2/components/amount_entry/amount_entry_widget.dart
@@ -43,7 +43,7 @@ class AmountEntryWidget extends StatelessWidget {
                       child: TextFormField(
                         textAlign: TextAlign.end,
                         style: Theme.of(context).textTheme.headline4,
-                        keyboardType: TextInputType.number,
+                        keyboardType: const TextInputType.numberWithOptions(decimal: true),
                         decoration: const InputDecoration(
                           hintText: "0.0",
                           border: InputBorder.none,


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

iOS enter amount did not have a decimal point, needs one, see before // after screenshots
### ✅ Checklist

- [.] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer
### 🙈 Screenshots

Before - no way to enter a decimal number

![IMG_7040](https://user-images.githubusercontent.com/65412/129499703-d96481dc-6e13-4ea8-85d4-1c9589d59a1c.PNG)

After - decimal 
![IMG_7041](https://user-images.githubusercontent.com/65412/129499696-a80f4820-0d22-4163-95f1-a412955ea847.PNG)


### 👯‍♀️ Paired with
