### PR TITLE
Add fiat currency display to send confirm and send success screens

### DIFF
--- a/lib/screens/transfer/send/send_confirmation/components/send_transaction_success_dialog.dart
+++ b/lib/screens/transfer/send/send_confirmation/components/send_transaction_success_dialog.dart
@@ -13,8 +13,8 @@ import 'package:seeds/utils/double_extension.dart';
 class SendTransactionSuccessDialog extends StatelessWidget {
   final String amount;
   final String tokenSymbol;
-  final String fiatCurrency;
   final String? fiatAmount;
+  final String fiatCurrency;
   final String? toImage;
   final String? toName;
   final String toAccount;

--- a/lib/screens/transfer/send/send_confirmation/components/send_transaction_success_dialog.dart
+++ b/lib/screens/transfer/send/send_confirmation/components/send_transaction_success_dialog.dart
@@ -12,7 +12,8 @@ import 'package:seeds/utils/double_extension.dart';
 
 class SendTransactionSuccessDialog extends StatelessWidget {
   final String amount;
-  final String currency;
+  final String tokenSymbol;
+  final String fiatCurrency;
   final String? fiatAmount;
   final String? toImage;
   final String? toName;
@@ -26,8 +27,9 @@ class SendTransactionSuccessDialog extends StatelessWidget {
   const SendTransactionSuccessDialog({
     Key? key,
     required this.amount,
-    required this.currency,
+    required this.tokenSymbol,
     this.fiatAmount,
+    required this.fiatCurrency,
     this.toImage,
     this.toName,
     required this.toAccount,
@@ -42,9 +44,10 @@ class SendTransactionSuccessDialog extends StatelessWidget {
       {required VoidCallback onCloseButtonPressed, required ShowTransferSuccess pageCommand}) {
     return SendTransactionSuccessDialog(
       onCloseButtonPressed: onCloseButtonPressed,
-      currency: pageCommand.transactionModel.symbol,
       amount: pageCommand.transactionModel.doubleQuantity.seedsFormatted,
+      tokenSymbol: pageCommand.transactionModel.symbol,
       fiatAmount: pageCommand.fiatQuantity.fiatFormatted,
+      fiatCurrency: pageCommand.fiatSymbol,
       fromAccount: pageCommand.transactionModel.from,
       fromImage: pageCommand.from?.image ?? "",
       fromName: pageCommand.from?.nickname ?? pageCommand.transactionModel.from,
@@ -71,11 +74,11 @@ class SendTransactionSuccessDialog extends StatelessWidget {
                 Text(amount, style: Theme.of(context).textTheme.headline4),
                 Padding(
                   padding: const EdgeInsets.only(top: 14, left: 4),
-                  child: Text(currency, style: Theme.of(context).textTheme.subtitle2),
+                  child: Text(tokenSymbol, style: Theme.of(context).textTheme.subtitle2),
                 ),
               ],
             ),
-            Text(fiatAmount != null ? fiatAmount! : "", style: Theme.of(context).textTheme.subtitle2),
+            Text(fiatAmount != null ? "$fiatAmount $fiatCurrency" : "", style: Theme.of(context).textTheme.subtitle2),
             const SizedBox(height: 30.0),
             DialogRow(imageUrl: toImage, account: toAccount, name: toName, toOrFromText: "To".i18n),
             const SizedBox(height: 30.0),

--- a/lib/screens/transfer/send/send_confirmation/interactor/mappers/send_transaction_state_mapper.dart
+++ b/lib/screens/transfer/send/send_confirmation/interactor/mappers/send_transaction_state_mapper.dart
@@ -32,7 +32,7 @@ class SendTransactionStateMapper extends StateMapper {
         transactionModel: transfer,
         from: resultResponse.parseFromUser,
         to: resultResponse.parseToUser,
-        quantity: transfer.doubleQuantity,
+        fiatSymbol: settingsStorage.selectedFiatCurrency,
         fiatQuantity: fiatQuantity,
       );
     } else {

--- a/lib/screens/transfer/send/send_confirmation/interactor/viewmodels/send_confirmation_commands.dart
+++ b/lib/screens/transfer/send/send_confirmation/interactor/viewmodels/send_confirmation_commands.dart
@@ -17,14 +17,14 @@ class ShowTransferSuccess extends TransactionPageCommand {
   final TransactionModel transactionModel;
   ProfileModel? from;
   ProfileModel? to;
-  double quantity;
+  String fiatSymbol;
   double fiatQuantity;
 
   ShowTransferSuccess({
     required this.transactionModel,
     this.from,
     this.to,
-    required this.quantity,
+    required this.fiatSymbol,
     required this.fiatQuantity,
   });
 }

--- a/lib/screens/transfer/send/send_confirmation/interactor/viewmodels/send_confirmation_commands.dart
+++ b/lib/screens/transfer/send/send_confirmation/interactor/viewmodels/send_confirmation_commands.dart
@@ -17,14 +17,14 @@ class ShowTransferSuccess extends TransactionPageCommand {
   final TransactionModel transactionModel;
   ProfileModel? from;
   ProfileModel? to;
-  String fiatSymbol;
   double fiatQuantity;
+  String fiatSymbol;
 
   ShowTransferSuccess({
     required this.transactionModel,
     this.from,
     this.to,
-    required this.fiatSymbol,
     required this.fiatQuantity,
+    required this.fiatSymbol,
   });
 }

--- a/lib/screens/transfer/send/send_enter_data/components/send_confirmation_dialog.dart
+++ b/lib/screens/transfer/send/send_enter_data/components/send_confirmation_dialog.dart
@@ -4,12 +4,12 @@ import 'package:seeds/design/app_theme.dart';
 import 'package:seeds/components/custom_dialog.dart';
 import 'package:seeds/components/profile_avatar.dart';
 import 'package:seeds/constants/app_colors.dart';
-import 'package:seeds/domain-shared/ui_constants.dart';
 import 'package:seeds/i18n/transfer/transfer.i18n.dart';
 
 class SendConfirmationDialog extends StatelessWidget {
   final String amount;
-  final String currency;
+  final String tokenSymbol;
+  final String fiatCurrency;
   final String? fiatAmount;
   final String? toImage;
   final String? toName;
@@ -19,8 +19,9 @@ class SendConfirmationDialog extends StatelessWidget {
 
   const SendConfirmationDialog({
     Key? key,
-    required this.currency,
     required this.amount,
+    required this.tokenSymbol,
+    required this.fiatCurrency,
     this.fiatAmount,
     this.toImage,
     this.toName,
@@ -58,11 +59,11 @@ class SendConfirmationDialog extends StatelessWidget {
             Text(amount, style: Theme.of(context).textTheme.headline4),
             Padding(
               padding: const EdgeInsets.only(top: 14, left: 4),
-              child: Text(currencySeedsCode, style: Theme.of(context).textTheme.subtitle2),
+              child: Text(tokenSymbol, style: Theme.of(context).textTheme.subtitle2),
             ),
           ],
         ),
-        Text(fiatAmount != null ? fiatAmount! : "", style: Theme.of(context).textTheme.subtitle2),
+        Text(fiatAmount != null ? "$fiatAmount $fiatCurrency" : "", style: Theme.of(context).textTheme.subtitle2),
         const SizedBox(height: 30.0),
         DialogRow(imageUrl: toImage, account: toAccount, name: toName, toOrFromText: "To".i18n),
         const SizedBox(height: 24.0),

--- a/lib/screens/transfer/send/send_enter_data/interactor/send_enter_data_bloc.dart
+++ b/lib/screens/transfer/send/send_enter_data/interactor/send_enter_data_bloc.dart
@@ -3,6 +3,7 @@ import 'package:bloc/bloc.dart';
 import 'package:seeds/blocs/rates/viewmodels/rates_state.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/datasource/remote/model/member_model.dart';
+import 'package:seeds/datasource/remote/model/token_model.dart';
 import 'package:seeds/domain-shared/app_constants.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/domain-shared/shared_use_cases/get_available_balance_use_case.dart';
@@ -38,11 +39,12 @@ class SendEnterDataPageBloc extends Bloc<SendEnterDataPageEvent, SendEnterDataPa
         shouldAutoFocusEnterField: false,
         pageCommand: ShowSendConfirmDialog(
           amount: state.quantity.toString(),
+          tokenSymbol: SeedsToken.symbol,
           toAccount: state.sendTo.account,
           memo: state.memo,
           toName: state.sendTo.nickname,
           toImage: state.sendTo.image,
-          currency: settingsStorage.selectedFiatCurrency,
+          fiatCurrency: settingsStorage.selectedFiatCurrency,
           fiatAmount: state.fiatAmount,
         ),
       );

--- a/lib/screens/transfer/send/send_enter_data/interactor/viewmodels/show_send_confirm_dialog_data.dart
+++ b/lib/screens/transfer/send/send_enter_data/interactor/viewmodels/show_send_confirm_dialog_data.dart
@@ -2,8 +2,9 @@ import 'package:seeds/domain-shared/page_command.dart';
 
 class ShowSendConfirmDialog extends PageCommand {
   final String amount;
-  final String currency;
   final String? fiatAmount;
+  final String fiatCurrency;
+  final String tokenSymbol;
   final String? toImage;
   final String? toName;
   final String toAccount;
@@ -11,7 +12,8 @@ class ShowSendConfirmDialog extends PageCommand {
 
   ShowSendConfirmDialog({
     required this.amount,
-    required this.currency,
+    required this.tokenSymbol,
+    required this.fiatCurrency,
     this.fiatAmount,
     this.toImage,
     this.toName,

--- a/lib/screens/transfer/send/send_enter_data/send_enter_data_screen.dart
+++ b/lib/screens/transfer/send/send_enter_data/send_enter_data_screen.dart
@@ -50,8 +50,9 @@ class SendEnterDataScreen extends StatelessWidget {
                   BlocProvider.of<SendEnterDataPageBloc>(context).add(OnSendButtonTapped());
                 },
                 amount: command.amount,
-                currency: command.currency,
+                tokenSymbol: command.tokenSymbol,
                 fiatAmount: command.fiatAmount,
+                fiatCurrency: command.fiatCurrency,
                 toAccount: command.toAccount,
                 toImage: command.toImage,
                 toName: command.toName,


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Send confirm and send success showed the fiat converted value, but not the fiat currency this was in (ie, USD)

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

The name "currency" was unclear, replaced with "fiatCurrency" and "tokenSymbol"

currency was used for fiat in one component, and for the token symbol in another component.

### 🙈 Screenshots

![Simulator Screen Shot - iPhone 8 - 2021-08-19 at 17 44 36](https://user-images.githubusercontent.com/65412/130047632-c421db22-10b7-473c-8adf-0710d3c1cd48.png)

![Simulator Screen Shot - iPhone 8 - 2021-08-19 at 17 44 42](https://user-images.githubusercontent.com/65412/130047629-840a4612-9a97-45d3-8853-a10d8fd75f75.png)

![Simulator Screen Shot - iPhone 8 - 2021-08-19 at 17 44 57](https://user-images.githubusercontent.com/65412/130047618-0c4ddcda-f303-42bb-9bd8-1f0eeeb87d41.png)

### 👯‍♀️ Paired with
