### PR TITLE
QR / ESR scan use normal endpoint

### DIFF
--- a/lib/datasource/local/util/seeds_esr.dart
+++ b/lib/datasource/local/util/seeds_esr.dart
@@ -3,7 +3,6 @@ import 'package:dart_esr/dart_esr.dart';
 import 'package:seeds/datasource/local/models/scan_qr_code_result_data.dart';
 import 'package:async/async.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
-import 'package:seeds/screens/app/interactor/viewmodels/connection_notifier.dart';
 
 class SeedsESR {
   late SigningRequestManager manager;

--- a/lib/datasource/local/util/seeds_esr.dart
+++ b/lib/datasource/local/util/seeds_esr.dart
@@ -2,6 +2,8 @@
 import 'package:dart_esr/dart_esr.dart';
 import 'package:seeds/datasource/local/models/scan_qr_code_result_data.dart';
 import 'package:async/async.dart';
+import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
+import 'package:seeds/screens/app/interactor/viewmodels/connection_notifier.dart';
 
 class SeedsESR {
   late SigningRequestManager manager;
@@ -44,7 +46,7 @@ class SeedsESR {
 extension TelosSigningManager on SigningRequestManager {
   static SigningRequestManager from(String? uri) {
     return SigningRequestManager.from(uri,
-        options: defaultSigningRequestEncodingOptions(nodeUrl: 'https://api.eos.miami'));
+        options: defaultSigningRequestEncodingOptions(nodeUrl: remoteConfigurations.defaultEndPointUrl));
   }
 
   Future<List<Action>> fetchActions({String? account, String permission = "active"}) async {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

The previous endpoint was not working, which is why QR scanning was not working.

Tested on my iPhone

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Not sure why this snuck in there, this should always have used the normal endpoint.

Only noticed now as endpoint was down, and QR wasn't scanning

### 🙈 Screenshots
### 👯‍♀️ Paired with
