### PR TITLE
Support lists in storage for accounts an private keys

### DIFF
--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -49,7 +49,7 @@ class _SettingsStorage {
 
   String? get privateKey => _privateKey;
 
-  List<String>? get privateKeysList => _privateKeysList;
+  List<String> get privateKeysList => _privateKeysList ?? [];
 
   String? get passcode => _passcode;
 
@@ -147,7 +147,7 @@ class _SettingsStorage {
     await _preferences.setBool(_kIsFirstRun, false);
 
     await _secureStorage.readAll().then((values) {
-      _privateKeysList = values[_kPrivateKeysList]?.split(',') ?? [];
+      _privateKeysList = values[_kPrivateKeysList]?.split(',');
 
       _privateKey = values[_kPrivateKey];
       _privateKey ??= _migrateFromPrefs(_kPrivateKey); // <-- privateKey in not in pref
@@ -205,8 +205,7 @@ class _SettingsStorage {
   Future<void> saveAccount(String accountName, String privateKey) async {
     _accountName = accountName;
     _privateKey = privateKey;
-    // Retrieve private keys list
-    final List<String> pkeys = (await _secureStorage.read(key: _kPrivateKeysList))?.split(',') ?? [];
+    final List<String> pkeys = _privateKeysList ?? [];
     // If new private key --> add to list
     if (!pkeys.contains(privateKey)) {
       pkeys.add(privateKey);

--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -75,7 +75,7 @@ class _SettingsStorage {
     _preferences.setString(_kAccountName, value ?? '');
     // Retrieve accounts list
     final List<String> accts = accountsList;
-    // If new account add to list
+    // If new account --> add to list
     if (!accountsList.contains(value)) {
       accts.add(accountName);
     }
@@ -207,7 +207,7 @@ class _SettingsStorage {
     _privateKey = privateKey;
     // Retrieve private keys list
     final List<String> pkeys = (await _secureStorage.read(key: _kPrivateKeysList))?.split(',') ?? [];
-    // If new private key add to list
+    // If new private key --> add to list
     if (!pkeys.contains(privateKey)) {
       pkeys.add(privateKey);
     }

--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -189,7 +189,7 @@ class _SettingsStorage {
   void enableRecoveryMode({required String accountName, String? privateKey}) {
     inRecoveryMode = true;
     _accountName = accountName;
-    _privateKey = privateKey;
+    this.privateKey = privateKey;
   }
 
   void finishRecoveryProcess() => inRecoveryMode = false;
@@ -197,7 +197,7 @@ class _SettingsStorage {
   void cancelRecoveryProcess() {
     inRecoveryMode = false;
     _accountName = null;
-    _privateKey = null;
+    privateKey = null;
   }
 
   void savePasscode(String? passcode) => this.passcode = passcode;

--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -72,11 +72,11 @@ class _SettingsStorage {
 
   set _accountName(String? value) {
     _preferences.setString(_kAccountName, value ?? '');
-    // retrieve accounts list
+    // Retrieve accounts list
     final List<String> accts = accountsList;
-    // add new account
+    // Add new account
     accts.add(accountName);
-    // save updated accounts list
+    // Save updated accounts list
     _preferences.setStringList(_kAccountsList, accts);
   }
 
@@ -193,13 +193,13 @@ class _SettingsStorage {
   Future<void> saveAccount(String accountName, String privateKey) async {
     _accountName = accountName;
     _privateKey = privateKey;
-    // Retrieve provate keys list
+    // Retrieve private keys list
     final List<String> pkeys = (await _secureStorage.read(key: _kPrivateKeysList))?.split(',') ?? [];
-    // add new private key
+    // Add new private key
     pkeys.add(privateKey);
-    // save updated private keys list
+    // Save updated private keys list
     await _secureStorage.write(key: _kPrivateKeysList, value: pkeys.join(","));
-    // update local field
+    // Update local field
     _privateKeysList = pkeys;
   }
 

--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -78,9 +78,9 @@ class _SettingsStorage {
     // If new account --> add to list
     if (!accountsList.contains(value)) {
       accts.add(accountName);
+      // Save updated accounts list
+      _preferences.setStringList(_kAccountsList, accts);
     }
-    // Save updated accounts list
-    _preferences.setStringList(_kAccountsList, accts);
   }
 
   set passcode(String? value) {
@@ -210,11 +210,11 @@ class _SettingsStorage {
     // If new private key --> add to list
     if (!pkeys.contains(privateKey)) {
       pkeys.add(privateKey);
+      // Save updated private keys list
+      await _secureStorage.write(key: _kPrivateKeysList, value: pkeys.join(","));
+      // Update local field
+      _privateKeysList = pkeys;
     }
-    // Save updated private keys list
-    await _secureStorage.write(key: _kPrivateKeysList, value: pkeys.join(","));
-    // Update local field
-    _privateKeysList = pkeys;
   }
 
   void savePrivateKeyBackedUp(bool value) => privateKeyBackedUp = value;

--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -150,7 +150,7 @@ class _SettingsStorage {
       _privateKeysList = values[_kPrivateKeysList]?.split(',');
 
       _privateKey = values[_kPrivateKey];
-      _privateKey ??= _migrateFromPrefs(_kPrivateKey); // <-- privateKey in not in pref
+      _privateKey ??= _migrateFromPrefs(_kPrivateKey); // <-- privateKey is not in pref
 
       _passcode = values[_kPasscode];
       _passcode ??= _migrateFromPrefs(_kPasscode); // <-- passcode is not in pref

--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -199,6 +199,8 @@ class _SettingsStorage {
     pkeys.add(privateKey);
     // save updated private keys list
     await _secureStorage.write(key: _kPrivateKeysList, value: pkeys.join(","));
+    // update local field
+    _privateKeysList = pkeys;
   }
 
   void savePrivateKeyBackedUp(bool value) => privateKeyBackedUp = value;


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1096 
### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [ ] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

I add two lists one for accounts shared-preferences and one for private keys in the secure-storage. 
Only perform the operations for reading and writing them. 

- When a new account is saved both account and private key are saved in their lists, also privateKey and accountName fields are updated.
- Getters for both lists added.

But I still have doubts about how these lists will work with the rest of the app, so I did not remove the original fields.

- When user switch account we save the new account in the account list and update the accountName field, and how about the privateKey field do we need updated this too?
- I'm just saving the list of private keys in the secure storage, should I save the privateKey field as the current one as well? And retrieve it as well?
- I found fields that are not being used and I would also like we define what data should or should not be saved in the secure storage. Besides the private keys, I don't think the other settings are relevant.

Guys If I am making wrong assumptions about this feature I will be happy to change them.

### 👯‍♀️ Paired with

 "nobody"
