### PR TITLE
Bugfix/receive token after restart

### DIFF
--- a/lib/datasource/remote/firebase/firebase_remote_config.dart
+++ b/lib/datasource/remote/firebase/firebase_remote_config.dart
@@ -71,7 +71,7 @@ class _FirebaseRemoteConfigService {
 
   bool get featureFlagImportAccountEnabled => _remoteConfig.getBool(_featureFlagImportAccount);
 
-  String get hyphaEndPoint => testnetMode ? _testnet_hyphaEndPointUrl : _remoteConfig.getString(_hyphaEndPointUrl);
+  String get hyphaEndPoint => testnetMode ? _testnet_hyphaEndPointUrl : _hyphaEndPointUrl;
 
   String get defaultEndPointUrl =>
       testnetMode ? _testnet_defaultEndPointUrl : _remoteConfig.getString(_defaultEndPointUrlKey);

--- a/lib/screens/wallet/components/tokens_cards/interactor/viewmodels/token_balances_bloc.dart
+++ b/lib/screens/wallet/components/tokens_cards/interactor/viewmodels/token_balances_bloc.dart
@@ -42,6 +42,7 @@ class TokenBalancesBloc extends Bloc<TokenBalancesEvent, TokenBalancesState> {
       final result = await LoadTokenBalancesUseCase().run(potentialTokens);
 
       yield await TokenBalancesStateMapper().mapResultToState(state, potentialTokens, result);
+      settingsStorage.selectedToken = state.selectedToken.token;
     } else if (event is OnSelectedTokenChanged) {
       yield state.copyWith(selectedIndex: event.index);
       settingsStorage.selectedToken = state.availableTokens[event.index].token;


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1152 

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

It's a bad idea to store the selected token, as @gguij004 has pointed out .. but changing that will be for another PR as that's a major change. 

So for now, update whenever it could change which is whenever we reload the tokens. 

Cause of error:
Storing the selected token in settings, but on app restart, not reading this back in and updating the display

Another valid fix would be to update the display on restart, trying to make it show the selected token. But that's also tricky if the token can't be loaded, or went away, or whatever. 
In addition we always want to start showing Seeds , at least for now. 

In the future, if we want our wallet to have a more general appeal, we may want to actually store the last selected and show it on the display. 

### 🙈 Screenshots
### 👯‍♀️ Paired with
