### PR TITLE
Trigger on pull request

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,8 +1,5 @@
 name: Pull Request
-on:
-  pull_request:
-    branches:
-    - master
+on: [pull_request]
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Trigger build flows on every pull request created. This is to make sure release branches pull requests run workflows