### PR TITLE
Autocorrect needs to be off on the user name search field

### DIFF
--- a/lib/components/search_user/search_user.dart
+++ b/lib/components/search_user/search_user.dart
@@ -34,6 +34,7 @@ class SearchUser extends StatelessWidget {
                 padding: const EdgeInsets.only(right: horizontalEdgePadding, left: horizontalEdgePadding, top: 10),
                 child: TextField(
                   autofocus: true,
+                  autocorrect: false,
                   controller: _controller,
                   onChanged: (String value) {
                     BlocProvider.of<SearchUserBloc>(context).add(OnSearchChange(searchQuery: value));


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Minor bugfix

The user search field should not have auto correct or capitalization. 

I noticed when doing the other ticket that I was getting word suggestions and corrections on the iPhone.

So turning autocorrect off here.

Capitalization is off by default so that's ok.

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Likely the smallest PR I've ever done!

### 🙈 Screenshots
### 👯‍♀️ Paired with
