### PR TITLE
reset recovery flag on import key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ pubspec\.lock
 ios/Podfile.lock
 dartesr/
 ios/Flutter/Flutter.podspec
+ios/build

--- a/lib/screens/authentication/import_key/interactor/import_key_bloc.dart
+++ b/lib/screens/authentication/import_key/interactor/import_key_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:bloc/bloc.dart';
 import 'package:seeds/blocs/authentication/viewmodels/bloc.dart';
+import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 
 import 'package:seeds/i18n/authentication/import_key/import_key.i18n.dart';
@@ -31,6 +32,7 @@ class ImportKeyBloc extends Bloc<ImportKeyEvent, ImportKeyState> {
     } else if (event is AccountSelected) {
       _authenticationBloc.add(OnImportAccount(account: event.account, privateKey: state.privateKey.toString()));
     } else if (event is OnPrivateKeyChange) {
+      settingsStorage.inRecoveryMode = false;
       yield state.copyWith(enableButton: event.privateKeyChanged.isNotEmpty);
     }
   }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

This keeps happening to me

Import key while in recovery mode ends in a dead app - can't go anywhere, stuck on import screen

I don't want to see this in production, also, logically, when someone imports a key recovery needs to be off.

Tested and it fixes the issue.

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

I've had this before, this is the second time. 

We can't risk this happening in production.

No downside, so let's do it.

### 🙈 Screenshots
### 👯‍♀️ Paired with