### PR TITLE
Looking up keys on chain, removing MongoDB lookup

### DIFF
--- a/lib/datasource/remote/api/key_accounts_repository.dart
+++ b/lib/datasource/remote/api/key_accounts_repository.dart
@@ -3,27 +3,18 @@ import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 
 class KeyAccountsRepository extends NetworkRepository {
-  Future<Result<dynamic>> getKeyAccountsMongo(String publicKey) {
-    print('[http] get seeds getKeyAccountsMongo ');
+  Future<Result<dynamic>> getKeyAccounts(String publicKey) {
+    print('[http] getKeyAccounts');
 
-    final body = '''
-        {
-          "collection": "pub_keys",
-          "query": {
-            "public_key": "$publicKey"\n    
-          },
-          "limit": 100
-        }
-        ''';
+    final url = Uri.parse('$baseURL/v1/history/get_key_accounts');
+    final body = '{ "public_key": "$publicKey" }';
 
     return http
-        .post(Uri.parse('https://mongo-api.hypha.earth/find'), headers: headers, body: body)
+        .post(url, headers: headers, body: body)
         .then((http.Response response) => mapHttpResponse(response, (dynamic body) {
               print('result: $body');
 
-              final items = List<Map<String, dynamic>>.from(body['items'])
-                  .where((item) => item['permission'] == 'active' || item['permission'] == 'owner');
-              final result = items.map<String>((item) => item['account']).toSet().toList();
+              final result = List<String>.from(body['account_names']);
 
               result.sort();
 

--- a/lib/screens/authentication/import_key/interactor/usecases/import_key_use_case.dart
+++ b/lib/screens/authentication/import_key/interactor/usecases/import_key_use_case.dart
@@ -7,7 +7,7 @@ class ImportKeyUseCase {
   final ProfileRepository _profileRepository = ProfileRepository();
 
   Future<List<Result>> run(String publicKey) async {
-    final accountsResponse = await _keyAccountsRepository.getKeyAccountsMongo(publicKey);
+    final accountsResponse = await _keyAccountsRepository.getKeyAccounts(publicKey);
     if (accountsResponse.isError) {
       final List<Result> items = [accountsResponse];
       return items;

--- a/lib/screens/profile_screens/profile/components/switch_account_bottom_sheet/interactor/usecases/import_accounts_use_case.dart
+++ b/lib/screens/profile_screens/profile/components/switch_account_bottom_sheet/interactor/usecases/import_accounts_use_case.dart
@@ -8,7 +8,7 @@ class ImportAccountsUseCase {
   final ProfileRepository _profileRepository = ProfileRepository();
 
   Future<List<Result>> run(String publicKey) async {
-    final accountsResponse = await _keyAccountsRepository.getKeyAccountsMongo(publicKey);
+    final accountsResponse = await _keyAccountsRepository.getKeyAccounts(publicKey);
     if (accountsResponse.isError) {
       final List<Result> items = [accountsResponse];
       return items;


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Ticket: https://github.com/JoinSEEDS/seeds_light_wallet/issues/1256

This is in response to bug reports where people can't import account.

I believe it's much more solid to use the direct chain API for this, than our MongoDB backend.

Mongo DB introduces unknown source of errors - also, these days, getting the key accounts from chain works really well.

### ✅ Checklist

- [x] Ticket is up to date
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

I have a testing branch where I support importing public keys in the import key field - this way we can test this function without needing anyone's private keys. 
Branch here bc8c32b6

### 🙈 Screenshots
### 👯‍♀️ Paired with
