### PR TITLE
Bux fix: Unable to save key on logout

### DIFF
--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -224,7 +224,8 @@ class _SettingsStorage {
     recoveryLink = null;
   }
 
-  // Notice this funtion its also called on import
+  // Notice this function it's also called on import
+  // to cancel any recover process previously started
   void cancelRecoveryProcess() {
     inRecoveryMode = false;
     _accountName = null;

--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -224,6 +224,7 @@ class _SettingsStorage {
     recoveryLink = null;
   }
 
+  // Notice this funtion its also called on import
   void cancelRecoveryProcess() {
     inRecoveryMode = false;
     _accountName = null;

--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -123,7 +123,7 @@ class _SettingsStorage {
   }
 
   set recoveryWords(List<String>? words) {
-    if (words != null) {
+    if (words != null && words.isNotEmpty) {
       _secureStorage.write(key: _kRecoveryWords, value: words.join('-'));
       _recoveryWords = words;
     } else {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1250 

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

The `.join()` funtion has a String return type even if it is used on a empty list. 
That is why the logic for recover words was returning is not empty.
![image](https://user-images.githubusercontent.com/42857405/137567636-0ff3cda8-2391-4d48-8e13-4b3c77ca53c1.png)


### 👯‍♀️ Paired with

 "nobody"
