### PR TITLE
Fix transactions on testnet

### DIFF
--- a/lib/datasource/remote/api/eos_repository.dart
+++ b/lib/datasource/remote/api/eos_repository.dart
@@ -45,6 +45,10 @@ abstract class EosRepository {
   ];
 
   Transaction buildFreeTransaction(List<Action> actions, String? accountName) {
+    if (testnetMode) {
+      return Transaction()..actions = actions;
+    }
+
     final freeAuth = <Authorization>[
       Authorization()
         ..actor = accountHarvest


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#### Problem
@buildc0de reported not being able to make transactions on testnet

This is because testnet apparently has a different key for the free CPU action, so transactions fail

#### Solution
Don't use free transactions on testnet. Not needed. 

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Only affects testnet mode - will never hit production

### 🙈 Screenshots
### 👯‍♀️ Paired with
