### PR TITLE
Hotfix: Fix custom username

### DIFF
--- a/lib/screens/authentication/sign_up/create_username/mappers/create_username_mapper.dart
+++ b/lib/screens/authentication/sign_up/create_username/mappers/create_username_mapper.dart
@@ -5,12 +5,15 @@ import 'package:seeds/screens/authentication/sign_up/viewmodels/bloc.dart';
 import 'package:seeds/screens/authentication/sign_up/viewmodels/states/create_username_state.dart';
 
 class CreateUsernameMapper extends StateMapper {
-  SignupState mapValidateUsernameToState(SignupState currentState, Result result) {
+  SignupState mapValidateUsernameToState(SignupState currentState, String username, Result result) {
     final createUsernameCurrentState = currentState.createUsernameState;
 
     if (result.isError) {
       // Error means username is not taken and is available for the user to take it
-      final newState = createUsernameCurrentState.copyWith(pageState: PageState.success);
+      final newState = createUsernameCurrentState.copyWith(
+        username: username,
+        pageState: PageState.success,
+      );
 
       return currentState.copyWith(createUsernameState: newState);
     }

--- a/lib/screens/authentication/sign_up/create_username/usecases/create_username_usecase.dart
+++ b/lib/screens/authentication/sign_up/create_username/usecases/create_username_usecase.dart
@@ -18,7 +18,7 @@ class CreateUsernameUseCase {
 
       final Result result = await _signupRepository.isUsernameTaken(username);
 
-      yield CreateUsernameMapper().mapValidateUsernameToState(currentState, result);
+      yield CreateUsernameMapper().mapValidateUsernameToState(currentState, username, result);
     } else {
       yield currentState.copyWith(
           createUsernameState: CreateUsernameState.error(currentState.createUsernameState, validationError));


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

This allows users to enter a custom username

Ticket:
'Accept invite > custom username' is ignored #1273

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Cause of error: Our user name state was not updated when the user entered a new user name

This means that the first state - the default username - was always used, if the user customized their username, that new information would go through validation, to check if available; but it would not actually be stored in the create user name state object. The state object would remain on the initially set name.

On create we use the state's username.

Fix: Update the user name state any time the user has entered and found a valid username to use

### 🙈 Screenshots

Initial state - default was masterplan11 before I changed it to masterplaxxx

![Simulator Screen Shot - iPhone 8 - 2021-10-27 at 09 03 08](https://user-images.githubusercontent.com/65412/138983114-e31ccbe7-c76b-4da5-ac17-2bc0d4f724fb.png)

Debug print output proving how we create username
<img width="461" alt="image" src="https://user-images.githubusercontent.com/65412/138983052-6bf2348b-7067-4488-b234-5db2e110f3f1.png">

### 👯‍♀️ Paired with
