### PR TITLE
Cleanup: Remove unused event

### DIFF
--- a/lib/screens/transfer/send/send_confirmation/interactor/send_confirmation_bloc.dart
+++ b/lib/screens/transfer/send/send_confirmation/interactor/send_confirmation_bloc.dart
@@ -12,12 +12,7 @@ class SendConfirmationBloc extends Bloc<SendConfirmationEvent, SendConfirmationS
 
   @override
   Stream<SendConfirmationState> mapEventToState(SendConfirmationEvent event) async* {
-    if (event is InitSendConfirmationWithArguments) {
-      yield state.copyWith(
-        pageState: PageState.success,
-        transaction: state.transaction,
-      );
-    } else if (event is SendTransactionEvent) {
+    if (event is SendTransactionEvent) {
       yield state.copyWith(pageState: PageState.loading);
 
       final Result result = await SendTransactionUseCase().run(

--- a/lib/screens/transfer/send/send_confirmation/interactor/viewmodels/send_confirmation_events.dart
+++ b/lib/screens/transfer/send/send_confirmation/interactor/viewmodels/send_confirmation_events.dart
@@ -9,11 +9,6 @@ abstract class SendConfirmationEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class InitSendConfirmationWithArguments extends SendConfirmationEvent {
-  @override
-  String toString() => 'LoadSendConfirmation';
-}
-
 class SendTransactionEvent extends SendConfirmationEvent {
   final RatesState rates;
 

--- a/lib/screens/transfer/send/send_confirmation/send_confirmation_screen.dart
+++ b/lib/screens/transfer/send/send_confirmation/send_confirmation_screen.dart
@@ -30,7 +30,7 @@ class SendConfirmationScreen extends StatelessWidget {
         ModalRoute.of(context)!.settings.arguments! as SendConfirmationArguments;
 
     return BlocProvider(
-      create: (_) => SendConfirmationBloc(arguments)..add(InitSendConfirmationWithArguments()),
+      create: (_) => SendConfirmationBloc(arguments),
       child: Scaffold(
         appBar: AppBar(
             leading: IconButton(
@@ -70,12 +70,11 @@ class SendConfirmationScreen extends StatelessWidget {
           child: BlocBuilder<SendConfirmationBloc, SendConfirmationState>(
             builder: (context, SendConfirmationState state) {
               switch (state.pageState) {
-                case PageState.initial:
-                  return const SizedBox.shrink();
                 case PageState.loading:
                   return state.isTransfer ? const SendLoadingIndicator() : const FullPageLoadingIndicator();
                 case PageState.failure:
                   return const FullPageErrorIndicator();
+                case PageState.initial:
                 case PageState.success:
                   return Column(
                     children: [


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://github.com/JoinSEEDS/seeds_light_wallet/issues/1313

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Initial state is same as success since it is valid

The old code relied on the event that we jus removed to go from initial -> success state

The screen shows success state now immediately - success state data is present already when the page has been initialized. So success == init now. 

There's a few options of how to resolve this:
- Make init the same as success - what I did. A bit lazy, didn't want to search whether or not we even need success state anymore. I think we do. 
- Remove the init page state and make the initial state start out with success. I am not sure that meets "etiquette" but it would result in the same outcome, not having to check other places for success state. Main reason I didn't do it is the initial state is probably be expected to start out with PageState.initial? Not sure.
- Remove the success state? But there are some subsequent screens and popovers that all have success - don't weant to debug this. 


### 🙈 Screenshots
AFTER the changes screens, tested transfer ("send" on main screen") which worked, and one ESR transaction here (QR code)

![Simulator Screen Shot - iPhone 13 - 2021-11-08 at 10 10 52](https://user-images.githubusercontent.com/65412/140674063-ee036835-11de-4aba-b203-df6c1ca6e37b.png)
![Simulator Screen Shot - iPhone 13 - 2021-11-08 at 10 10 32](https://user-images.githubusercontent.com/65412/140674075-3874abe5-b13f-400e-8a53-5fac80a3cc06.png)

### 👯‍♀️ Paired with