### PR TITLE
Better results

### DIFF
--- a/lib/datasource/remote/api/invite_repository.dart
+++ b/lib/datasource/remote/api/invite_repository.dart
@@ -121,7 +121,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     return http
         .post(inviteURL, headers: headers, body: request)
-        .then((http.Response res) => mapHttpResponse<List<InviteModel>>(res, toDomainInviteModel))
+        .then((http.Response response) => mapHttpResponse<List<InviteModel>>(response, toDomainInviteModel))
         .catchError((e) => mapHttpError(e));
   }
 

--- a/lib/datasource/remote/api/invite_repository.dart
+++ b/lib/datasource/remote/api/invite_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:async/async.dart';
 
 // ignore: import_of_legacy_library_into_null_safe
@@ -5,6 +7,7 @@ import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/remote/api/eos_repository.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
+import 'package:seeds/datasource/remote/datamappers/toDomainInviteModel.dart';
 import 'package:seeds/datasource/remote/model/invite_model.dart';
 import 'package:seeds/datasource/remote/model/member_model.dart';
 import 'package:seeds/datasource/remote/model/transaction_response.dart';
@@ -101,7 +104,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
         .catchError((error) => mapHttpError(error));
   }
 
-  Future<Result> getInvites(String userAccount) async {
+  Future<Result<List<InviteModel>>> getInvites(String userAccount) async {
     print('[http] find all invites');
 
     final inviteURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
@@ -118,11 +121,9 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     return http
         .post(inviteURL, headers: headers, body: request)
-        .then((http.Response response) => mapHttpResponse(response, (dynamic body) {
-              final List<dynamic> invites = body['rows'].toList();
-              return invites.map((item) => InviteModel.fromJson(item)).toList();
-            }))
-        .catchError((error) => mapHttpError(error));
+        .then((http.Response res) => mapHttpResponse<List<InviteModel>>(res, toDomainInviteModel),
+            onError: mapHttpError)
+        .catchError((e) => mapHttpError(e));
   }
 
   Future<Result> cancelInvite({

--- a/lib/datasource/remote/api/invite_repository.dart
+++ b/lib/datasource/remote/api/invite_repository.dart
@@ -121,8 +121,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     return http
         .post(inviteURL, headers: headers, body: request)
-        .then((http.Response res) => mapHttpResponse<List<InviteModel>>(res, toDomainInviteModel),
-            onError: mapHttpError)
+        .then((http.Response res) => mapHttpResponse<List<InviteModel>>(res, toDomainInviteModel))
         .catchError((e) => mapHttpError(e));
   }
 

--- a/lib/datasource/remote/api/network_repository.dart
+++ b/lib/datasource/remote/api/network_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
@@ -30,7 +32,7 @@ abstract class NetworkRepository {
   String tableRecover = 'recovers';
   String tableTotals = 'totals';
 
-  Result mapHttpResponse(http.Response response, Function modelMapper) {
+  FutureOr<Result<T>> mapHttpResponse<T>(http.Response response, Function modelMapper) {
     switch (response.statusCode) {
       case 200:
         {
@@ -44,7 +46,7 @@ abstract class NetworkRepository {
     }
   }
 
-  Result mapHttpError(dynamic error) {
+  ErrorResult mapHttpError(dynamic error) {
     print('mapHttpError: $error');
     return ErrorResult(error);
   }

--- a/lib/datasource/remote/api/profile_repository.dart
+++ b/lib/datasource/remote/api/profile_repository.dart
@@ -14,7 +14,7 @@ import 'package:seeds/domain-shared/app_constants.dart';
 import 'package:seeds/domain-shared/ui_constants.dart';
 
 class ProfileRepository extends NetworkRepository with EosRepository {
-  Future<Result> getProfile(String accountName) {
+  Future<Result<ProfileModel>> getProfile(String accountName) {
     print('[http] get seeds getProfile $accountName');
 
     final request = createRequest(
@@ -28,7 +28,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     return http
         .post(Uri.parse('${remoteConfigurations.activeEOSServerUrl.url}/v1/chain/get_table_rows'),
             headers: headers, body: request)
-        .then((http.Response response) => mapHttpResponse(response, (dynamic body) {
+        .then((http.Response response) => mapHttpResponse<ProfileModel>(response, (dynamic body) {
               return ProfileModel.fromJson(body['rows'][0]);
             }))
         .catchError((error) => mapHttpError(error));

--- a/lib/datasource/remote/datamappers/toDomainInviteModel.dart
+++ b/lib/datasource/remote/datamappers/toDomainInviteModel.dart
@@ -1,0 +1,6 @@
+import 'package:seeds/datasource/remote/model/invite_model.dart';
+
+List<InviteModel> toDomainInviteModel(dynamic body) {
+  final List invites = body['rows'].toList();
+  return invites.map((item) => InviteModel.fromJson(item)).toList();
+}

--- a/lib/screens/explore_screens/manage_invites/interactor/usecases/load_invites_use_case.dart
+++ b/lib/screens/explore_screens/manage_invites/interactor/usecases/load_invites_use_case.dart
@@ -12,7 +12,7 @@ class GetInvitesUseCase {
   Future<InvitesDto?> run() async {
     final account = settingsStorage.accountName;
 
-    final result = await _inviteRepository.getInvites(account);
+    final Result<List<InviteModel>> result = await _inviteRepository.getInvites(account);
 
     if (result.isError) {
       return null;


### PR DESCRIPTION
Improved Typed Results

we can now pass a type to the result mapper 

`mapHttpResponse<T>` 


This will allow to add type to the return in the repo. Which will eliminate castings in the future



