### PR TITLE
Move scores calls out of profile

### DIFF
--- a/lib/screens/profile_screens/citizenship/citizenship_screen.dart
+++ b/lib/screens/profile_screens/citizenship/citizenship_screen.dart
@@ -14,7 +14,7 @@ class CitizenshipScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final ProfileValuesArguments args = ModalRoute.of(context)!.settings.arguments! as ProfileValuesArguments;
     return BlocProvider(
-      create: (_) => CitizenshipBloc()..add(SetValues(profile: args.profile, score: args.scores)),
+      create: (_) => CitizenshipBloc()..add(SetValues(profile: args.profile)),
       child: Scaffold(
         appBar: AppBar(),
         body: SafeArea(

--- a/lib/screens/profile_screens/citizenship/components/resident_view.dart
+++ b/lib/screens/profile_screens/citizenship/components/resident_view.dart
@@ -60,7 +60,7 @@ class _ResidentViewState extends State<ResidentView> with TickerProviderStateMix
             setState(() => _timeLine = _timeLineAnimation.value.toInt());
           });
         _reputationAnimation =
-            Tween<double>(begin: 0, end: state.score!.reputationScore?.toDouble()).animate(_controller)
+            Tween<double>(begin: 0, end: state.reputationScore?.toDouble()).animate(_controller)
               ..addListener(() {
                 setState(() => _reputation = _reputationAnimation.value.toInt());
               });

--- a/lib/screens/profile_screens/citizenship/interactor/mappers/set_values_mapper.dart
+++ b/lib/screens/profile_screens/citizenship/interactor/mappers/set_values_mapper.dart
@@ -8,7 +8,6 @@ import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/domain-shared/result_to_state_mapper.dart';
 import 'package:seeds/i18n/profile_screens/citizenship/citizenship.i18n.dart';
 import 'package:seeds/screens/profile_screens/citizenship/interactor/viewmodels/citizenship_state.dart';
-import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
 
 class SetValuesStateMapper extends StateMapper {
   CitizenshipState mapResultToState(

--- a/lib/screens/profile_screens/citizenship/interactor/mappers/set_values_mapper.dart
+++ b/lib/screens/profile_screens/citizenship/interactor/mappers/set_values_mapper.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:seeds/datasource/remote/model/planted_model.dart';
 import 'package:seeds/datasource/remote/model/profile_model.dart';
+import 'package:seeds/datasource/remote/model/score_model.dart';
 import 'package:seeds/datasource/remote/model/seeds_history_model.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/domain-shared/result_to_state_mapper.dart';
@@ -23,16 +24,16 @@ class SetValuesStateMapper extends StateMapper {
 
       final PlantedModel? plantedSeeds = values.firstWhere((i) => i is PlantedModel, orElse: () => null);
       final SeedsHistoryModel? seedsHistory = values.firstWhere((i) => i is SeedsHistoryModel, orElse: () => null);
+      final ScoreModel? reputationScore = values.firstWhere((i) => i is ScoreModel, orElse: () => null);
 
       final int planted = plantedSeeds?.quantity.toInt() ?? 0;
       final int transactions = seedsHistory?.totalNumberOfTransactions ?? 0;
 
       double timeline = 0;
       final ProfileModel profile = currentState.profile!;
-      final ScoresViewModel score = currentState.score!;
       final List<ProfileModel> profiles = referredAccountResults.map((i) => i.asValue!.value as ProfileModel).toList();
 
-      final int reputation = score.reputationScore?.value ?? 0;
+      final int reputation = reputationScore?.value ?? 0;
 
       // Define timeline
       if (profile.status == ProfileStatus.visitor) {

--- a/lib/screens/profile_screens/citizenship/interactor/viewmodels/citizenship_bloc.dart
+++ b/lib/screens/profile_screens/citizenship/interactor/viewmodels/citizenship_bloc.dart
@@ -12,10 +12,10 @@ class CitizenshipBloc extends Bloc<CitizenshipEvent, CitizenshipState> {
   @override
   Stream<CitizenshipState> mapEventToState(CitizenshipEvent event) async* {
     if (event is SetValues) {
-      if (event.profile == null || event.score == null) {
+      if (event.profile == null) {
         yield state.copyWith(pageState: PageState.failure, errorMessage: 'Error Loading Page');
       } else {
-        yield state.copyWith(pageState: PageState.loading, profile: event.profile, score: event.score);
+        yield state.copyWith(pageState: PageState.loading, profile: event.profile);
         final referredAccountResults = await GetReferredAccountsUseCase().run();
         final citizenshipDataResults = await GetCitizenshipDataUseCase().run();
         yield SetValuesStateMapper().mapResultToState(state, referredAccountResults, citizenshipDataResults);

--- a/lib/screens/profile_screens/citizenship/interactor/viewmodels/citizenship_event.dart
+++ b/lib/screens/profile_screens/citizenship/interactor/viewmodels/citizenship_event.dart
@@ -1,20 +1,21 @@
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 import 'package:seeds/datasource/remote/model/profile_model.dart';
-import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
 
 /// --- EVENTS
 @immutable
 abstract class CitizenshipEvent extends Equatable {
   const CitizenshipEvent();
+
   @override
   List<Object> get props => [];
 }
 
 class SetValues extends CitizenshipEvent {
   final ProfileModel? profile;
-  final ScoresViewModel? score;
-  const SetValues({required this.profile, required this.score});
+
+  const SetValues({required this.profile});
+
   @override
-  String toString() => 'SetValues { profile: $profile score: $score }';
+  String toString() => 'SetValues { profile: $profile }';
 }

--- a/lib/screens/profile_screens/citizenship/interactor/viewmodels/citizenship_state.dart
+++ b/lib/screens/profile_screens/citizenship/interactor/viewmodels/citizenship_state.dart
@@ -2,7 +2,6 @@ import 'package:equatable/equatable.dart';
 import 'package:seeds/datasource/remote/model/profile_model.dart';
 import 'package:seeds/datasource/remote/model/score_model.dart';
 import 'package:seeds/domain-shared/page_state.dart';
-import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
 
 /// Resident requirements
 const int resident_required_reputation = 50;

--- a/lib/screens/profile_screens/citizenship/interactor/viewmodels/citizenship_state.dart
+++ b/lib/screens/profile_screens/citizenship/interactor/viewmodels/citizenship_state.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:seeds/datasource/remote/model/profile_model.dart';
+import 'package:seeds/datasource/remote/model/score_model.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
 
@@ -22,7 +23,7 @@ class CitizenshipState extends Equatable {
   final PageState pageState;
   final String? errorMessage;
   final ProfileModel? profile;
-  final ScoresViewModel? score;
+  final ScoreModel? reputationScore;
   final double? progressTimeline;
   final int? invitedVisitors;
   final int? invitedResidents;
@@ -33,7 +34,7 @@ class CitizenshipState extends Equatable {
     required this.pageState,
     this.errorMessage,
     this.profile,
-    this.score,
+    this.reputationScore,
     this.progressTimeline,
     this.invitedResidents,
     this.invitedVisitors,
@@ -46,7 +47,7 @@ class CitizenshipState extends Equatable {
         pageState,
         errorMessage,
         profile,
-        score,
+        reputationScore,
         progressTimeline,
         invitedResidents,
         invitedVisitors,
@@ -58,7 +59,7 @@ class CitizenshipState extends Equatable {
     PageState? pageState,
     String? errorMessage,
     ProfileModel? profile,
-    ScoresViewModel? score,
+    ScoreModel? reputationScore,
     double? progressTimeline,
     int? invitedResidents,
     int? invitedVisitors,
@@ -69,7 +70,7 @@ class CitizenshipState extends Equatable {
       pageState: pageState ?? this.pageState,
       errorMessage: errorMessage,
       profile: profile ?? this.profile,
-      score: score ?? this.score,
+      reputationScore: reputationScore ?? this.reputationScore,
       progressTimeline: progressTimeline ?? this.progressTimeline,
       invitedResidents: invitedResidents ?? this.invitedResidents,
       invitedVisitors: invitedVisitors ?? this.invitedVisitors,

--- a/lib/screens/profile_screens/contribution/contribution_screen.dart
+++ b/lib/screens/profile_screens/contribution/contribution_screen.dart
@@ -3,12 +3,12 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:seeds/components/circular_progress_item.dart';
 import 'package:seeds/components/full_page_error_indicator.dart';
+import 'package:seeds/components/full_page_loading_indicator.dart';
 import 'package:seeds/constants/app_colors.dart';
 import 'package:seeds/design/app_theme.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/i18n/profile_screens/contribution/contribution.i18n.dart';
 import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/bloc.dart';
-import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
 import 'package:step_progress_indicator/step_progress_indicator.dart';
 
 /// CONTRIBUTION SCREEN
@@ -46,9 +46,8 @@ class _ContributionScreenState extends State<ContributionScreen> with TickerProv
 
   @override
   Widget build(BuildContext context) {
-    final scores = ModalRoute.of(context)!.settings.arguments;
     return BlocProvider(
-      create: (_) => ContributionBloc()..add(SetScores(score: scores as ScoresViewModel?)),
+      create: (_) => ContributionBloc()..add(const FetchScores()),
       child: Scaffold(
         appBar: AppBar(title: Text('Contribution Score'.i18n)),
         body: BlocConsumer<ContributionBloc, ContributionState>(
@@ -86,6 +85,8 @@ class _ContributionScreenState extends State<ContributionScreen> with TickerProv
           },
           builder: (context, state) {
             switch (state.pageState) {
+              case PageState.loading:
+                return const FullPageLoadingIndicator();
               case PageState.initial:
                 return const SizedBox.shrink();
               case PageState.failure:

--- a/lib/screens/profile_screens/contribution/interactor/mappers/profile_scores_state_mapper.dart
+++ b/lib/screens/profile_screens/contribution/interactor/mappers/profile_scores_state_mapper.dart
@@ -1,0 +1,29 @@
+import 'package:seeds/domain-shared/page_state.dart';
+import 'package:seeds/domain-shared/result_to_state_mapper.dart';
+import 'package:seeds/i18n/profile_screens/profile/profile.i18n.dart';
+import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/bloc.dart';
+import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
+
+const int _contributionScoreResultIndex = 0;
+const int _communityScoreResultIndex = 1;
+const int _reputationScoreResultIndex = 2;
+const int _plantedScoreResultIndex = 3;
+const int _transactionScoreResultIndex = 4;
+
+class ProfileScoresStateMapper extends StateMapper {
+  ContributionState mapResultToState(ContributionState currentState, List<Result> results) {
+    if (areAllResultsError(results)) {
+      return currentState.copyWith(pageState: PageState.failure, errorMessage: 'Error Loading Page'.i18n);
+    } else {
+      final score = ScoresViewModel(
+        contributionScore: results[_contributionScoreResultIndex].valueOrNull,
+        communityScore: results[_communityScoreResultIndex].valueOrNull,
+        reputationScore: results[_reputationScoreResultIndex].valueOrNull,
+        plantedScore: results[_plantedScoreResultIndex].valueOrNull,
+        transactionScore: results[_transactionScoreResultIndex].valueOrNull,
+      );
+
+      return currentState.copyWith(pageState: PageState.success, score: score);
+    }
+  }
+}

--- a/lib/screens/profile_screens/contribution/interactor/usecases/get_profile_scores_use_case.dart
+++ b/lib/screens/profile_screens/contribution/interactor/usecases/get_profile_scores_use_case.dart
@@ -1,20 +1,18 @@
 import 'package:async/async.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
-import 'package:seeds/datasource/remote/api/planted_repository.dart';
 import 'package:seeds/datasource/remote/api/profile_repository.dart';
-import 'package:seeds/datasource/remote/api/seeds_history_repository.dart';
 
-class GetCitizenshipDataUseCase {
-  final PlantedRepository _plantedRepository = PlantedRepository();
-  final SeedsHistoryRepository _seedsHistoryRepository = SeedsHistoryRepository();
+class GetProfileScoresUseCase {
   final ProfileRepository _profileRepository = ProfileRepository();
 
   Future<List<Result>> run() {
     final account = settingsStorage.accountName;
     final futures = [
-      _plantedRepository.getPlanted(account),
-      _seedsHistoryRepository.getNumberOfTransactions(account),
+      _profileRepository.getScore(account: account, tableName: "cspoints"),
       _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: "cbs"),
+      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: "rep"),
+      _profileRepository.getScore(account: account, tableName: "planted"),
+      _profileRepository.getScore(account: account, tableName: "txpoints"),
     ];
     return Future.wait(futures);
   }

--- a/lib/screens/profile_screens/contribution/interactor/viewmodels/contribution_bloc.dart
+++ b/lib/screens/profile_screens/contribution/interactor/viewmodels/contribution_bloc.dart
@@ -1,5 +1,8 @@
 import 'package:bloc/bloc.dart';
 import 'package:seeds/domain-shared/page_state.dart';
+import 'package:seeds/domain-shared/result_to_state_mapper.dart';
+import 'package:seeds/screens/profile_screens/contribution/interactor/mappers/profile_scores_state_mapper.dart';
+import 'package:seeds/screens/profile_screens/contribution/interactor/usecases/get_profile_scores_use_case.dart';
 import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/bloc.dart';
 
 /// --- BLOC
@@ -14,6 +17,10 @@ class ContributionBloc extends Bloc<ContributionEvent, ContributionState> {
       } else {
         yield state.copyWith(pageState: PageState.success, score: event.score);
       }
+    } else if (event is FetchScores) {
+      yield state.copyWith(pageState: PageState.loading);
+      final List<Result> result = await GetProfileScoresUseCase().run();
+      yield ProfileScoresStateMapper().mapResultToState(state, result);
     }
   }
 }

--- a/lib/screens/profile_screens/contribution/interactor/viewmodels/contribution_event.dart
+++ b/lib/screens/profile_screens/contribution/interactor/viewmodels/contribution_event.dart
@@ -6,13 +6,23 @@ import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels
 @immutable
 abstract class ContributionEvent extends Equatable {
   const ContributionEvent();
+
   @override
   List<Object> get props => [];
 }
 
 class SetScores extends ContributionEvent {
   final ScoresViewModel? score;
+
   const SetScores({required this.score});
+
   @override
   String toString() => 'SetScores { score: $score }';
+}
+
+class FetchScores extends ContributionEvent {
+  const FetchScores();
+
+  @override
+  String toString() => 'FetchScores';
 }

--- a/lib/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart
+++ b/lib/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart
@@ -8,11 +8,22 @@ class ScoresViewModel extends Equatable {
   final ScoreModel? plantedScore;
   final ScoreModel? transactionScore;
 
-  const ScoresViewModel(
-      {this.contributionScore, this.communityScore, this.reputationScore, this.plantedScore, this.transactionScore});
+  const ScoresViewModel({
+    this.contributionScore,
+    this.communityScore,
+    this.reputationScore,
+    this.plantedScore,
+    this.transactionScore,
+  });
 
   @override
-  List<Object?> get props => [contributionScore, communityScore, reputationScore, plantedScore, transactionScore];
+  List<Object?> get props => [
+        contributionScore,
+        communityScore,
+        reputationScore,
+        plantedScore,
+        transactionScore,
+      ];
 
   @override
   String toString() =>

--- a/lib/screens/profile_screens/profile/components/citizenship_card.dart
+++ b/lib/screens/profile_screens/profile/components/citizenship_card.dart
@@ -118,7 +118,6 @@ class CitizenshipCard extends StatelessWidget {
                                         Routes.citizenship,
                                         ProfileValuesArguments(
                                           profile: BlocProvider.of<ProfileBloc>(context).state.profile!,
-                                          scores: BlocProvider.of<ProfileBloc>(context).state.score!,
                                         ),
                                       ),
                                       child: Text(

--- a/lib/screens/profile_screens/profile/components/profile_middle.dart
+++ b/lib/screens/profile_screens/profile/components/profile_middle.dart
@@ -23,9 +23,9 @@ class ProfileMiddle extends StatelessWidget {
               showShimmer: state.showShimmer,
               leading: SvgPicture.asset('assets/images/profile/contribution_icon.svg'),
               title: 'Contribution Score'.i18n,
-              trailing: '${state.score?.contributionScore?.value ?? '00'}/99',
+              trailing: '${state.contributionScore?.value ?? '00'}/99',
               onTap: () {
-                NavigationService.of(context).navigateTo(Routes.contribution, state.score);
+                NavigationService.of(context).navigateTo(Routes.contribution);
               },
             ),
             const Padding(padding: EdgeInsets.symmetric(horizontal: 16), child: DividerJungle(thickness: 2)),

--- a/lib/screens/profile_screens/profile/interactor/mappers/profile_values_state_mapper.dart
+++ b/lib/screens/profile_screens/profile/interactor/mappers/profile_values_state_mapper.dart
@@ -4,7 +4,6 @@ import 'package:seeds/datasource/remote/model/profile_model.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/domain-shared/result_to_state_mapper.dart';
 import 'package:seeds/i18n/profile_screens/profile/profile.i18n.dart';
-import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
 import 'package:seeds/screens/profile_screens/profile/interactor/viewmodels/profile_state.dart';
 
 const int _profileResultIndex = 0;

--- a/lib/screens/profile_screens/profile/interactor/mappers/profile_values_state_mapper.dart
+++ b/lib/screens/profile_screens/profile/interactor/mappers/profile_values_state_mapper.dart
@@ -9,13 +9,9 @@ import 'package:seeds/screens/profile_screens/profile/interactor/viewmodels/prof
 
 const int _profileResultIndex = 0;
 const int _contributionScoreResultIndex = 1;
-const int _communityScoreResultIndex = 2;
-const int _reputationScoreResultIndex = 3;
-const int _plantedScoreResultIndex = 4;
-const int _transactionScoreResultIndex = 5;
-const int _organizationResultIndex = 6;
-const int _canResidentResultIndex = 7;
-const int _canCitizenResultIndex = 8;
+const int _organizationResultIndex = 2;
+const int _canResidentResultIndex = 3;
+const int _canCitizenResultIndex = 4;
 
 class ProfileValuesStateMapper extends StateMapper {
   ProfileState mapResultToState(ProfileState currentState, List<Result> results) {
@@ -28,39 +24,27 @@ class ProfileValuesStateMapper extends StateMapper {
       final CitizenshipUpgradeStatus citizenshipUpgradeStatus;
 
       if (isCitizen) {
-        final score = ScoresViewModel(
+        return currentState.copyWith(
+            pageState: PageState.success,
+            profile: profile,
+            contributionScore: results[_contributionScoreResultIndex].valueOrNull);
+      } else {
+        final organization = results[_organizationResultIndex].asValue?.value as List<OrganizationModel>;
+
+        results[_canResidentResultIndex].isValue
+            ? citizenshipUpgradeStatus = CitizenshipUpgradeStatus.canResident
+            : results[_canCitizenResultIndex].isValue
+                ? citizenshipUpgradeStatus = CitizenshipUpgradeStatus.canCitizen
+                : citizenshipUpgradeStatus = CitizenshipUpgradeStatus.notReady;
+
+        return currentState.copyWith(
+          pageState: PageState.success,
+          profile: profile,
           contributionScore: results[_contributionScoreResultIndex].valueOrNull,
-          communityScore: results[_communityScoreResultIndex].valueOrNull,
-          reputationScore: results[_reputationScoreResultIndex].valueOrNull,
-          plantedScore: results[_plantedScoreResultIndex].valueOrNull,
-          transactionScore: results[_transactionScoreResultIndex].valueOrNull,
+          isOrganization: organization.isNotEmpty,
+          citizenshipUpgradeStatus: citizenshipUpgradeStatus,
         );
-        return currentState.copyWith(pageState: PageState.success, profile: profile, score: score);
       }
-
-      final score = ScoresViewModel(
-        contributionScore: results[_contributionScoreResultIndex].valueOrNull,
-        communityScore: results[_communityScoreResultIndex].valueOrNull,
-        reputationScore: results[_reputationScoreResultIndex].valueOrNull,
-        plantedScore: results[_plantedScoreResultIndex].valueOrNull,
-        transactionScore: results[_transactionScoreResultIndex].valueOrNull,
-      );
-
-      final organization = results[_organizationResultIndex].asValue?.value as List<OrganizationModel>;
-
-      results[_canResidentResultIndex].isValue
-          ? citizenshipUpgradeStatus = CitizenshipUpgradeStatus.canResident
-          : results[_canCitizenResultIndex].isValue
-              ? citizenshipUpgradeStatus = CitizenshipUpgradeStatus.canCitizen
-              : citizenshipUpgradeStatus = CitizenshipUpgradeStatus.notReady;
-
-      return currentState.copyWith(
-        pageState: PageState.success,
-        profile: profile,
-        score: score,
-        isOrganization: organization.isNotEmpty,
-        citizenshipUpgradeStatus: citizenshipUpgradeStatus,
-      );
     }
   }
 }

--- a/lib/screens/profile_screens/profile/interactor/usecases/get_profile_values_use_case.dart
+++ b/lib/screens/profile_screens/profile/interactor/usecases/get_profile_values_use_case.dart
@@ -10,10 +10,6 @@ class GetProfileValuesUseCase {
     final futures = [
       _profileRepository.getProfile(account),
       _profileRepository.getScore(account: account, tableName: "cspoints"),
-      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: "cbs"),
-      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: "rep"),
-      _profileRepository.getScore(account: account, tableName: "planted"),
-      _profileRepository.getScore(account: account, tableName: "txpoints"),
       _profileRepository.getOrganizationAccount(account),
       _profileRepository.canResident(account),
       _profileRepository.canCitizen(account),

--- a/lib/screens/profile_screens/profile/interactor/viewmodels/profileValuesArguments.dart
+++ b/lib/screens/profile_screens/profile/interactor/viewmodels/profileValuesArguments.dart
@@ -1,6 +1,4 @@
 import 'package:seeds/datasource/remote/model/profile_model.dart';
-import 'package:seeds/datasource/remote/model/score_model.dart';
-import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
 
 class ProfileValuesArguments {
   final ProfileModel profile;

--- a/lib/screens/profile_screens/profile/interactor/viewmodels/profileValuesArguments.dart
+++ b/lib/screens/profile_screens/profile/interactor/viewmodels/profileValuesArguments.dart
@@ -1,9 +1,9 @@
 import 'package:seeds/datasource/remote/model/profile_model.dart';
+import 'package:seeds/datasource/remote/model/score_model.dart';
 import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
 
 class ProfileValuesArguments {
   final ProfileModel profile;
-  final ScoresViewModel scores;
 
-  ProfileValuesArguments({required this.profile, required this.scores});
+  ProfileValuesArguments({required this.profile});
 }

--- a/lib/screens/profile_screens/profile/interactor/viewmodels/profile_state.dart
+++ b/lib/screens/profile_screens/profile/interactor/viewmodels/profile_state.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:seeds/datasource/remote/model/profile_model.dart';
+import 'package:seeds/datasource/remote/model/score_model.dart';
 import 'package:seeds/domain-shared/page_command.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
@@ -12,7 +13,7 @@ class ProfileState extends Equatable {
   final PageCommand? pageCommand;
   final String? errorMessage;
   final ProfileModel? profile;
-  final ScoresViewModel? score;
+  final ScoreModel? contributionScore;
   final bool isOrganization;
   final bool showLogoutButton;
   final bool hasSecurityNotification;
@@ -24,7 +25,7 @@ class ProfileState extends Equatable {
     this.pageCommand,
     this.errorMessage,
     this.profile,
-    this.score,
+    this.contributionScore,
     required this.isOrganization,
     required this.showLogoutButton,
     required this.hasSecurityNotification,
@@ -38,7 +39,7 @@ class ProfileState extends Equatable {
         pageCommand,
         errorMessage,
         profile,
-        score,
+        contributionScore,
         isOrganization,
         showLogoutButton,
         hasSecurityNotification,
@@ -55,7 +56,7 @@ class ProfileState extends Equatable {
     PageCommand? pageCommand,
     String? errorMessage,
     ProfileModel? profile,
-    ScoresViewModel? score,
+    ScoreModel? contributionScore,
     bool? isOrganization,
     bool? showLogoutButton,
     bool? hasSecurityNotification,
@@ -67,7 +68,7 @@ class ProfileState extends Equatable {
       pageCommand: pageCommand,
       errorMessage: errorMessage,
       profile: profile ?? this.profile,
-      score: score ?? this.score,
+      contributionScore: contributionScore ?? this.contributionScore,
       isOrganization: isOrganization ?? this.isOrganization,
       showLogoutButton: showLogoutButton ?? this.showLogoutButton,
       hasSecurityNotification: hasSecurityNotification ?? this.hasSecurityNotification,

--- a/lib/screens/profile_screens/profile/interactor/viewmodels/profile_state.dart
+++ b/lib/screens/profile_screens/profile/interactor/viewmodels/profile_state.dart
@@ -3,7 +3,6 @@ import 'package:seeds/datasource/remote/model/profile_model.dart';
 import 'package:seeds/datasource/remote/model/score_model.dart';
 import 'package:seeds/domain-shared/page_command.dart';
 import 'package:seeds/domain-shared/page_state.dart';
-import 'package:seeds/screens/profile_screens/contribution/interactor/viewmodels/scores_view_model.dart';
 
 enum CitizenshipUpgradeStatus { notReady, canResident, canCitizen }
 


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1351

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Moved Score Calls out of profile page. They are not needed there. 
Moved to where they are used.

NOTE: Profile displaying data needs to be tested. No changes around updating data, only displaying in profile and subsequent profile screens like Contribution Score Screen and Citizen Upgrade Screen

### 👯‍♀️ Paired with

Solo
