### PR TITLE
Added TLOS rates, made rates more generic

### DIFF
--- a/lib/blocs/rates/mappers/rates_state_mapper.dart
+++ b/lib/blocs/rates/mappers/rates_state_mapper.dart
@@ -1,6 +1,7 @@
 import 'package:seeds/blocs/rates/viewmodels/rates_bloc.dart';
 import 'package:seeds/datasource/remote/model/fiat_rate_model.dart';
 import 'package:seeds/datasource/remote/model/rate_model.dart';
+import 'package:seeds/datasource/remote/model/token_model.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/domain-shared/result_to_state_mapper.dart';
 
@@ -9,11 +10,20 @@ class RatesStateMapper extends StateMapper {
     if (areAllResultsError(results)) {
       return currentState.copyWith(pageState: PageState.failure, errorMessage: 'Cannot fetch balance...');
     } else {
-      results.retainWhere((Result i) => i.isValue);
-      final values = results.map((Result i) => i.asValue!.value).toList();
-      final RateModel? rate = values.firstWhere((i) => i is RateModel, orElse: () => null);
-      final FiatRateModel? fiatRate = values.firstWhere((i) => i is FiatRateModel, orElse: () => null);
-      return currentState.copyWith(rate: rate, fiatRate: fiatRate);
+      /// note: we re-use existing conversion rates if we can't load new ones
+      final RateModel? seedsRateModel = results[0].asValue?.value ?? currentState.rates?[seedsToken.symbol];
+      final RateModel? telosRateModel = results[1].asValue?.value ?? currentState.rates?[telosToken.symbol];
+      final rates = {
+        husdToken.symbol: RateModel(husdToken.symbol, 1),
+      };
+      if (seedsRateModel != null) {
+        rates[seedsToken.symbol] = seedsRateModel;
+      }
+      if (telosRateModel != null) {
+        rates[telosToken.symbol] = telosRateModel;
+      }
+      final FiatRateModel? fiatRate = results[2].asValue?.value;
+      return currentState.copyWith(rates: rates, fiatRate: fiatRate);
     }
   }
 }

--- a/lib/blocs/rates/usecases/get_rates_use_case.dart
+++ b/lib/blocs/rates/usecases/get_rates_use_case.dart
@@ -8,7 +8,8 @@ class GetRatesUseCase {
 
   Future<List<Result>> run() {
     final futures = [
-      _ratesRepository.getUSDRate(),
+      _ratesRepository.getSeedsRate(),
+      _ratesRepository.getTelosRate(),
       _ratesRepository.getFiatRates(),
     ];
     return Future.wait(futures);

--- a/lib/blocs/rates/viewmodels/rates_state.dart
+++ b/lib/blocs/rates/viewmodels/rates_state.dart
@@ -3,13 +3,13 @@ part of 'rates_bloc.dart';
 class RatesState extends Equatable {
   final PageState pageState;
   final String? errorMessage;
-  final RateModel? rate;
+  final Map<String, RateModel>? rates;
   final FiatRateModel? fiatRate;
 
   const RatesState({
     required this.pageState,
     this.errorMessage,
-    this.rate,
+    this.rates,
     this.fiatRate,
   });
 
@@ -17,20 +17,20 @@ class RatesState extends Equatable {
   List<Object?> get props => [
         pageState,
         errorMessage,
-        rate,
+        rates,
         fiatRate,
       ];
 
   RatesState copyWith({
     PageState? pageState,
     String? errorMessage,
-    RateModel? rate,
+    Map<String, RateModel>? rates,
     FiatRateModel? fiatRate,
   }) {
     return RatesState(
       pageState: pageState ?? this.pageState,
       errorMessage: errorMessage,
-      rate: rate ?? this.rate,
+      rates: rates ?? this.rates,
       fiatRate: fiatRate ?? this.fiatRate,
     );
   }

--- a/lib/datasource/remote/api/rates_repository.dart
+++ b/lib/datasource/remote/api/rates_repository.dart
@@ -32,23 +32,13 @@ class RatesRepository extends NetworkRepository {
   Future<Result<RateModel>> getTelosRate() async {
     print('[http] get telos rate USD');
 
-    final params = '''
-    {
-      "json": true,
-      "code": "delphioracle",
-      "scope": "tlosusd",
-      "table": "datapoints",
-      "table_key": "",
-      "lower_bound": "",
-      "upper_bound": "",
-      "limit": 1,
-      "key_type": "",
-      "index_position": "",
-      "encode_type": "dec",
-      "reverse": false,
-      "show_payer": false
-    }
-    ''';
+    final params = createRequest(
+      code: "delphioracle",
+      scope: "tlosusd",
+      table: "datapoints",
+      // ignore: avoid_redundant_argument_values
+      limit: 1,
+    );
 
     return http
         .post(Uri.parse('$baseURL/v1/chain/get_table_rows'), headers: headers, body: params)

--- a/lib/datasource/remote/api/rates_repository.dart
+++ b/lib/datasource/remote/api/rates_repository.dart
@@ -16,7 +16,7 @@ class RatesRepository extends NetworkRepository {
         .catchError((error) => mapHttpError(error));
   }
 
-  Future<Result<RateModel>> getUSDRate() async {
+  Future<Result<RateModel>> getSeedsRate() async {
     print('[http] get seeds rate USD');
 
     final request = '{"json":true,"code":"tlosto.seeds","scope":"tlosto.seeds","table":"price"}';
@@ -24,7 +24,36 @@ class RatesRepository extends NetworkRepository {
     return http
         .post(Uri.parse('$baseURL/v1/chain/get_table_rows'), headers: headers, body: request)
         .then((http.Response response) => mapHttpResponse<RateModel>(response, (dynamic body) {
-              return RateModel.fromJson(body);
+              return RateModel.fromSeedsJson(body);
+            }))
+        .catchError((error) => mapHttpError(error));
+  }
+
+  Future<Result<RateModel>> getTelosRate() async {
+    print('[http] get telos rate USD');
+
+    final params = '''
+    {
+      "json": true,
+      "code": "delphioracle",
+      "scope": "tlosusd",
+      "table": "datapoints",
+      "table_key": "",
+      "lower_bound": "",
+      "upper_bound": "",
+      "limit": 1,
+      "key_type": "",
+      "index_position": "",
+      "encode_type": "dec",
+      "reverse": false,
+      "show_payer": false
+    }
+    ''';
+
+    return http
+        .post(Uri.parse('$baseURL/v1/chain/get_table_rows'), headers: headers, body: params)
+        .then((http.Response response) => mapHttpResponse<RateModel>(response, (dynamic body) {
+              return RateModel.fromOracleJson("TLOS", 4, body);
             }))
         .catchError((error) => mapHttpError(error));
   }

--- a/lib/datasource/remote/model/rate_model.dart
+++ b/lib/datasource/remote/model/rate_model.dart
@@ -28,9 +28,10 @@ class RateModel {
 
   factory RateModel.fromOracleJson(String tokenSymbol, int precision, Map<String, dynamic>? json) {
     if (json != null && json['rows'].isNotEmpty) {
+      print("JSON $json");
       final int value = json['rows'][0]['median'] ?? 0;
       final double amount = value / pow(10, precision).toDouble();
-      return RateModel(tokenSymbol, amount);
+      return RateModel(tokenSymbol, 1 / amount);
     } else {
       return RateModel(tokenSymbol, 0);
     }

--- a/lib/datasource/remote/model/rate_model.dart
+++ b/lib/datasource/remote/model/rate_model.dart
@@ -1,24 +1,38 @@
-/// The current SEEDS per USD
+import 'dart:math';
+import 'package:seeds/datasource/remote/model/token_model.dart';
+
+/// Token per USD
 class RateModel {
-  final double seedsPerUSD;
+  final String tokenSymbol;
+  final double tokensPerUSD;
 
-  const RateModel(this.seedsPerUSD);
+  const RateModel(this.tokenSymbol, this.tokensPerUSD);
 
-  double? seedsToUSD(double seedsAmount) {
-    return seedsPerUSD > 0 ? seedsAmount / seedsPerUSD : null;
+  double? tokenToUSD(double seedsAmount) {
+    return tokensPerUSD > 0 ? seedsAmount / tokensPerUSD : null;
   }
 
-  double? usdToSeeds(double usdAmount) {
-    return seedsPerUSD > 0 ? usdAmount * seedsPerUSD : null;
+  double? usdToToken(double usdAmount) {
+    return tokensPerUSD > 0 ? usdAmount * tokensPerUSD : null;
   }
 
-  factory RateModel.fromJson(Map<String, dynamic>? json) {
+  factory RateModel.fromSeedsJson(Map<String, dynamic>? json) {
     if (json != null && json['rows'].isNotEmpty) {
       final value = json['rows'][0]['current_seeds_per_usd'] ?? 0.toString();
       final amount = double.parse(value.split(' ').first);
-      return RateModel(amount);
+      return RateModel(seedsToken.symbol, amount);
     } else {
-      return const RateModel(0);
+      return RateModel(seedsToken.symbol, 0);
+    }
+  }
+
+  factory RateModel.fromOracleJson(String tokenSymbol, int precision, Map<String, dynamic>? json) {
+    if (json != null && json['rows'].isNotEmpty) {
+      final int value = json['rows'][0]['median'] ?? 0;
+      final double amount = value / pow(10, precision).toDouble();
+      return RateModel(tokenSymbol, amount);
+    } else {
+      return RateModel(tokenSymbol, 0);
     }
   }
 }

--- a/lib/utils/rate_states_extensions.dart
+++ b/lib/utils/rate_states_extensions.dart
@@ -1,22 +1,20 @@
 import 'package:seeds/blocs/rates/viewmodels/rates_bloc.dart';
 import 'package:seeds/datasource/local/models/fiat_data_model.dart';
 import 'package:seeds/datasource/local/models/token_data_model.dart';
+import 'package:seeds/datasource/remote/model/rate_model.dart';
 import 'package:seeds/datasource/remote/model/token_model.dart';
 
 extension RatesStateExtensions on RatesState {
   FiatDataModel? tokenToFiat(TokenDataModel tokenAmount, String currencySymbol) {
-    // Convert seeds to USD
-    if (tokenAmount.symbol == seedsToken.symbol) {
-      final double? usdValue = rate?.seedsToUSD(tokenAmount.amount);
+    // Convert token to USD
+    final RateModel? rateModel = rates?[tokenAmount.symbol];
+    if (rateModel != null) {
+      final double? usdValue = rateModel.tokenToUSD(tokenAmount.amount);
       if (usdValue != null) {
         // Convert the seeds (USD amount) in the new currency
         final double? res = fiatRate?.usdToCurrency(usdValue, currencySymbol);
         return res != null ? FiatDataModel(res, fiatSymbol: currencySymbol) : null;
       }
-    } else if (tokenAmount.symbol == husdToken.symbol) {
-      final double usdValue = tokenAmount.amount;
-      final double? res = fiatRate?.usdToCurrency(usdValue, currencySymbol);
-      return res != null ? FiatDataModel(res, fiatSymbol: currencySymbol) : null;
     }
     return null;
   }
@@ -25,31 +23,14 @@ extension RatesStateExtensions on RatesState {
     // Convert seeds to USD
     final double? usdValue = fiatRate?.currencyToUSD(fiatAmount.amount, fiatAmount.symbol);
     if (usdValue != null) {
-      if (tokenSymbol == seedsToken.symbol) {
-        final double? seedsValue = rate?.usdToSeeds(usdValue);
-        if (seedsValue != null) {
-          return TokenDataModel(seedsValue);
+      final RateModel? rateModel = rates?[tokenSymbol];
+      if (rateModel != null) {
+        final double? tokenValue = rateModel.usdToToken(usdValue);
+        if (tokenValue != null) {
+          return TokenDataModel(tokenValue, token: TokenModel.fromSymbol(tokenSymbol));
         }
-      } else if (tokenSymbol == husdToken.symbol) {
-        return TokenDataModel(usdValue, token: husdToken);
       }
     }
     return null;
-  }
-
-  /// Returns a double representing the amount of given fiat currency in seeds
-  double fromFiatToSeeds(double currencyAmount, String currencySymbol) {
-    if (currencySymbol == "USD") {
-      return rate?.usdToSeeds(currencyAmount) ?? double.nan;
-    } else {
-      // Convert that currency value to USD value
-      final double? usdValue = fiatRate?.currencyToUSD(currencyAmount, currencySymbol);
-      if (usdValue != null) {
-        // Convert the currency (USD amount) in seeds
-        return rate?.usdToSeeds(usdValue) ?? double.nan;
-      } else {
-        return double.nan;
-      }
-    }
   }
 }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

No ticket but we want to support more token conversions in the future

This PR adds
- A step towards a more generic handling of token rates, with SEEDS and TELOS
- Added Telos rates from oracle contract

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Instead of a singe RateModel object we now have a map symbol => RateModel

Thanks to this I could remove the special case for HUSD

It can be extended to additional tokens - we can switch to loading them from coinmarketcap for tokens other than Telos. 

I like getting the Telos rate from the oracle since that's decentralized.

### 🙈 Screenshots

Telos rate is currently very close to 1 USD

![Simulator Screen Shot - iPhone 13 - 2021-12-03 at 08 42 31](https://user-images.githubusercontent.com/65412/144526034-59ef96c9-b81c-48fe-9e64-9670ef506ff6.png)



### 👯‍♀️ Paired with

_@github-handle or "nobody" if you did not pair._
