### PR TITLE
Lock types for createRequest call in http service

### DIFF
--- a/lib/datasource/remote/api/eos_repository.dart
+++ b/lib/datasource/remote/api/eos_repository.dart
@@ -62,7 +62,7 @@ abstract class EosRepository {
 
     final freeAuth = <Authorization>[
       Authorization()
-        ..actor = SeedsScope.accountHarvest.value
+        ..actor = SeedsCode.accountHarvest.value
         ..permission = 'payforcpu',
       Authorization()
         ..actor = accountName
@@ -70,7 +70,7 @@ abstract class EosRepository {
     ];
 
     final freeAction = Action()
-      ..account = SeedsScope.accountHarvest.value
+      ..account = SeedsCode.accountHarvest.value
       ..name = 'payforcpu'
       ..authorization = freeAuth
       ..data = {'account': accountName};

--- a/lib/datasource/remote/api/eos_repository.dart
+++ b/lib/datasource/remote/api/eos_repository.dart
@@ -4,6 +4,7 @@ import 'package:async/async.dart';
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:eosdart/eosdart.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
 import 'package:seeds/domain-shared/app_constants.dart';
 
@@ -61,7 +62,7 @@ abstract class EosRepository {
 
     final freeAuth = <Authorization>[
       Authorization()
-        ..actor = accountHarvest
+        ..actor = SeedsScope.accountHarvest.value
         ..permission = 'payforcpu',
       Authorization()
         ..actor = accountName
@@ -69,7 +70,7 @@ abstract class EosRepository {
     ];
 
     final freeAction = Action()
-      ..account = accountHarvest
+      ..account = SeedsScope.accountHarvest.value
       ..name = 'payforcpu'
       ..authorization = freeAuth
       ..data = {'account': accountName};

--- a/lib/datasource/remote/api/eos_repository.dart
+++ b/lib/datasource/remote/api/eos_repository.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
+
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:eosdart/eosdart.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
-import 'package:seeds/domain-shared/app_constants.dart';
 
 abstract class EosRepository {
   String cpuPrivateKey = '5Hy2cvMbrusscGnusLWqYuXyM8fZ65G7DTzs4nDXyiV5wo77n9a';

--- a/lib/datasource/remote/api/guardians_repository.dart
+++ b/lib/datasource/remote/api/guardians_repository.dart
@@ -8,6 +8,7 @@ import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/datasource/remote/api/eos_repository.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
@@ -38,7 +39,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     // Check if permissions are already set?
     // ignore: unnecessary_cast
     for (final Map<String, dynamic> acct in ownerPermission.requiredAuth.accounts as List<dynamic>) {
-      if (acct['permission']['actor'] == accountGuards) {
+      if (acct['permission']['actor'] == SeedsScope.accountGuards) {
         print('permission already set, doing nothing');
         return currentPermissions;
       }
@@ -46,7 +47,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     ownerPermission.requiredAuth.accounts.add({
       'weight': ownerPermission.requiredAuth.threshold,
-      'permission': {'actor': accountGuards, 'permission': 'eosio.code'}
+      'permission': {'actor': SeedsScope.accountGuards.value, 'permission': 'eosio.code'}
     });
 
     return await _updatePermission(ownerPermission);
@@ -65,7 +66,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     final actions = [
       Action()
-        ..account = accountGuards
+        ..account = SeedsScope.accountGuards.value
         ..name = actionNameInit
         ..data = {
           'user_account': accountName,
@@ -104,7 +105,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     final actions = [
       Action()
-        ..account = accountGuards
+        ..account = SeedsScope.accountGuards.value
         ..name = actionNameClaim
         ..data = {'user_account': userAccount}
     ];
@@ -112,7 +113,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     for (final action in actions) {
       action.authorization = [
         Authorization()
-          ..actor = accountGuards
+          ..actor = SeedsScope.accountGuards.value
           ..permission = permissionApplication
       ];
     }
@@ -140,7 +141,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     final actions = [
       Action()
-        ..account = accountGuards
+        ..account = SeedsScope.accountGuards.value
         ..name = actionNameCancel
         ..authorization = [
           Authorization()
@@ -174,7 +175,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     final actions = [
       Action()
-        ..account = accountGuards
+        ..account = SeedsScope.accountGuards.value
         ..name = actionNameRecover
         ..authorization = [
           Authorization()
@@ -224,7 +225,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     final actions = [
       Action()
-        ..account = accountEosio
+        ..account = SeedsScope.accountEosio.value
         ..name = actionNameUpdateauth
         ..data = {
           'account': accountName,
@@ -258,8 +259,8 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     final String requestURL = "$baseURL/v1/chain/get_table_rows";
 
     final String request = createRequest(
-        code: accountGuards,
-        scope: accountGuards,
+        code: SeedsScope.accountGuards,
+        scope: SeedsScope.accountGuards.value,
         table: SeedsTable.tableRecover,
         lowerBound: accountName,
         upperBound: accountName);
@@ -279,8 +280,8 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     final String requestURL = "$baseURL/v1/chain/get_table_rows";
 
     final String request = createRequest(
-      code: accountGuards,
-      scope: accountGuards,
+      code: SeedsScope.accountGuards,
+      scope: SeedsScope.accountGuards.value,
       table: SeedsTable.tableGuards,
       lowerBound: accountName,
       upperBound: accountName,
@@ -307,7 +308,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     };
 
     final esr.Action action = esr.Action()
-      ..account = accountGuards
+      ..account = SeedsScope.accountGuards.value
       ..name = 'recover'
       ..authorization = auth
       ..data = data;

--- a/lib/datasource/remote/api/guardians_repository.dart
+++ b/lib/datasource/remote/api/guardians_repository.dart
@@ -39,7 +39,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     // Check if permissions are already set?
     // ignore: unnecessary_cast
     for (final Map<String, dynamic> acct in ownerPermission.requiredAuth.accounts as List<dynamic>) {
-      if (acct['permission']['actor'] == SeedsScope.accountGuards) {
+      if (acct['permission']['actor'] == SeedsCode.accountGuards.value) {
         print('permission already set, doing nothing');
         return currentPermissions;
       }
@@ -47,7 +47,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     ownerPermission.requiredAuth.accounts.add({
       'weight': ownerPermission.requiredAuth.threshold,
-      'permission': {'actor': SeedsScope.accountGuards.value, 'permission': 'eosio.code'}
+      'permission': {'actor': SeedsCode.accountGuards.value, 'permission': 'eosio.code'}
     });
 
     return await _updatePermission(ownerPermission);
@@ -66,7 +66,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     final actions = [
       Action()
-        ..account = SeedsScope.accountGuards.value
+        ..account = SeedsCode.accountGuards.value
         ..name = actionNameInit
         ..data = {
           'user_account': accountName,
@@ -105,7 +105,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     final actions = [
       Action()
-        ..account = SeedsScope.accountGuards.value
+        ..account = SeedsCode.accountGuards.value
         ..name = actionNameClaim
         ..data = {'user_account': userAccount}
     ];
@@ -113,7 +113,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     for (final action in actions) {
       action.authorization = [
         Authorization()
-          ..actor = SeedsScope.accountGuards.value
+          ..actor = SeedsCode.accountGuards.value
           ..permission = permissionApplication
       ];
     }
@@ -141,7 +141,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     final actions = [
       Action()
-        ..account = SeedsScope.accountGuards.value
+        ..account = SeedsCode.accountGuards.value
         ..name = actionNameCancel
         ..authorization = [
           Authorization()
@@ -175,7 +175,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     final actions = [
       Action()
-        ..account = SeedsScope.accountGuards.value
+        ..account = SeedsCode.accountGuards.value
         ..name = actionNameRecover
         ..authorization = [
           Authorization()
@@ -225,7 +225,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
 
     final actions = [
       Action()
-        ..account = SeedsScope.accountEosio.value
+        ..account = SeedsCode.accountEosio.value
         ..name = actionNameUpdateauth
         ..data = {
           'account': accountName,
@@ -259,8 +259,8 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     final String requestURL = "$baseURL/v1/chain/get_table_rows";
 
     final String request = createRequest(
-        code: SeedsScope.accountGuards,
-        scope: SeedsScope.accountGuards.value,
+        code: SeedsCode.accountGuards,
+        scope: SeedsCode.accountGuards.value,
         table: SeedsTable.tableRecover,
         lowerBound: accountName,
         upperBound: accountName);
@@ -280,8 +280,8 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     final String requestURL = "$baseURL/v1/chain/get_table_rows";
 
     final String request = createRequest(
-      code: SeedsScope.accountGuards,
-      scope: SeedsScope.accountGuards.value,
+      code: SeedsCode.accountGuards,
+      scope: SeedsCode.accountGuards.value,
       table: SeedsTable.tableGuards,
       lowerBound: accountName,
       upperBound: accountName,
@@ -308,7 +308,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     };
 
     final esr.Action action = esr.Action()
-      ..account = SeedsScope.accountGuards.value
+      ..account = SeedsCode.accountGuards.value
       ..name = 'recover'
       ..authorization = auth
       ..data = data;

--- a/lib/datasource/remote/api/guardians_repository.dart
+++ b/lib/datasource/remote/api/guardians_repository.dart
@@ -8,6 +8,7 @@ import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/datasource/remote/api/eos_repository.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
 import 'package:seeds/datasource/remote/model/account_guardians_model.dart';
@@ -259,7 +260,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     final String request = createRequest(
         code: accountGuards,
         scope: accountGuards,
-        table: tableRecover,
+        table: SeedsTable.tableRecover,
         lowerBound: accountName,
         upperBound: accountName);
 
@@ -280,7 +281,7 @@ class GuardiansRepository extends EosRepository with NetworkRepository {
     final String request = createRequest(
       code: accountGuards,
       scope: accountGuards,
-      table: tableGuards,
+      table: SeedsTable.tableGuards,
       lowerBound: accountName,
       upperBound: accountName,
     );

--- a/lib/datasource/remote/api/http_repo/seeds_scopes.dart
+++ b/lib/datasource/remote/api/http_repo/seeds_scopes.dart
@@ -1,0 +1,64 @@
+const String _accountAccounts = 'accts.seeds';
+const String _accountCycle = 'cycle.seeds';
+const String _accountEosio = 'eosio';
+const String _accountFunds = 'funds.seeds';
+const String _accountGuards = 'guard.seeds';
+const String _accountHarvest = 'harvst.seeds';
+const String _accountJoin = 'join.seeds';
+const String _accountToken = 'token.seeds';
+const String _accountRules = 'rules.seeds';
+const String _accountSettgs = 'settgs.seeds';
+const String _historySeeds = 'histry.seeds';
+const String _accountOrgs = 'orgs.seeds';
+const String _accountdelphioracle = 'delphioracle';
+
+enum SeedsScope {
+  accountAccounts,
+  accountCycle,
+  accountEosio,
+  accountFunds,
+  accountGuards,
+  accountHarvest,
+  accountJoin,
+  accountToken,
+  accountRules,
+  accountSettgs,
+  historySeeds,
+  accountOrgs,
+  accountdelphioracle,
+}
+
+extension SeedsTableExtension on SeedsScope {
+  String get value {
+    switch (this) {
+      case SeedsScope.accountAccounts:
+        return _accountAccounts;
+      case SeedsScope.accountCycle:
+        return _accountCycle;
+      case SeedsScope.accountEosio:
+        return _accountEosio;
+      case SeedsScope.accountFunds:
+        return _accountFunds;
+      case SeedsScope.accountGuards:
+        return _accountGuards;
+      case SeedsScope.accountHarvest:
+        return _accountHarvest;
+      case SeedsScope.accountJoin:
+        return _accountJoin;
+      case SeedsScope.accountToken:
+        return _accountToken;
+      case SeedsScope.accountRules:
+        return _accountRules;
+      case SeedsScope.accountSettgs:
+        return _accountSettgs;
+      case SeedsScope.historySeeds:
+        return _historySeeds;
+      case SeedsScope.accountOrgs:
+        return _accountOrgs;
+      case SeedsScope.accountdelphioracle:
+        return _accountdelphioracle;
+      default:
+        return '';
+    }
+  }
+}

--- a/lib/datasource/remote/api/http_repo/seeds_scopes.dart
+++ b/lib/datasource/remote/api/http_repo/seeds_scopes.dart
@@ -12,7 +12,7 @@ const String _historySeeds = 'histry.seeds';
 const String _accountOrgs = 'orgs.seeds';
 const String _accountdelphioracle = 'delphioracle';
 
-enum SeedsScope {
+enum SeedsCode {
   accountAccounts,
   accountCycle,
   accountEosio,
@@ -28,34 +28,34 @@ enum SeedsScope {
   accountdelphioracle,
 }
 
-extension SeedsTableExtension on SeedsScope {
+extension SeedsCodeExtension on SeedsCode {
   String get value {
     switch (this) {
-      case SeedsScope.accountAccounts:
+      case SeedsCode.accountAccounts:
         return _accountAccounts;
-      case SeedsScope.accountCycle:
+      case SeedsCode.accountCycle:
         return _accountCycle;
-      case SeedsScope.accountEosio:
+      case SeedsCode.accountEosio:
         return _accountEosio;
-      case SeedsScope.accountFunds:
+      case SeedsCode.accountFunds:
         return _accountFunds;
-      case SeedsScope.accountGuards:
+      case SeedsCode.accountGuards:
         return _accountGuards;
-      case SeedsScope.accountHarvest:
+      case SeedsCode.accountHarvest:
         return _accountHarvest;
-      case SeedsScope.accountJoin:
+      case SeedsCode.accountJoin:
         return _accountJoin;
-      case SeedsScope.accountToken:
+      case SeedsCode.accountToken:
         return _accountToken;
-      case SeedsScope.accountRules:
+      case SeedsCode.accountRules:
         return _accountRules;
-      case SeedsScope.accountSettgs:
+      case SeedsCode.accountSettgs:
         return _accountSettgs;
-      case SeedsScope.historySeeds:
+      case SeedsCode.historySeeds:
         return _historySeeds;
-      case SeedsScope.accountOrgs:
+      case SeedsCode.accountOrgs:
         return _accountOrgs;
-      case SeedsScope.accountdelphioracle:
+      case SeedsCode.accountdelphioracle:
         return _accountdelphioracle;
       default:
         return '';

--- a/lib/datasource/remote/api/http_repo/seeds_tables.dart
+++ b/lib/datasource/remote/api/http_repo/seeds_tables.dart
@@ -1,0 +1,116 @@
+const String _tableBalances = 'balances';
+const String _tableConfig = 'config';
+const String _tableGuards = 'guards';
+const String _tableHarvest = 'harvest';
+const String _tableRefunds = 'refunds';
+const String _tableInvites = 'invites';
+const String _tableMoonphases = 'moonphases';
+const String _tableProps = 'props';
+const String _tableReferendums = 'referendums';
+const String _tableRefs = 'refs';
+const String _tableSupport = 'support';
+const String _tableUsers = 'users';
+const String _tableVoice = 'voice';
+const String _tableOrganization = 'organization';
+const String _tableProposalVotes = 'votes';
+const String _tableReferendumVoters = 'voters';
+const String _tableDelegates = 'deltrusts';
+const String _tableRecover = 'recovers';
+const String _tableTotals = 'totals';
+const String _tableCycleStats = 'cyclestats';
+const String _tabledatapoints = 'datapoints';
+const String _tablecbs = 'cbs';
+const String _tableCspoints = 'cspoints';
+const String _tableRep = 'rep';
+const String _tablePlanted = 'planted';
+const String _tabletxpoints = 'txpoints';
+
+enum SeedsTable {
+  tableBalances,
+  tableConfig,
+  tableGuards,
+  tableHarvest,
+  tableRefunds,
+  tableInvites,
+  tableMoonphases,
+  tableProps,
+  tableReferendums,
+  tableRefs,
+  tableSupport,
+  tableUsers,
+  tableVoice,
+  tableOrganization,
+  tableProposalVotes,
+  tableReferendumVoters,
+  tableDelegates,
+  tableRecover,
+  tableTotals,
+  tableCycleStats,
+  tableDatapoints,
+  tableCbs,
+  tableCspoints,
+  tableRep,
+  tablePlanted,
+  tableTxpoints,
+}
+
+extension SeedsTableExtension on SeedsTable {
+  String get value {
+    switch (this) {
+      case SeedsTable.tableBalances:
+        return _tableBalances;
+      case SeedsTable.tableConfig:
+        return _tableConfig;
+      case SeedsTable.tableGuards:
+        return _tableGuards;
+      case SeedsTable.tableHarvest:
+        return _tableHarvest;
+      case SeedsTable.tableRefunds:
+        return _tableRefunds;
+      case SeedsTable.tableInvites:
+        return _tableInvites;
+      case SeedsTable.tableMoonphases:
+        return _tableMoonphases;
+      case SeedsTable.tableProps:
+        return _tableProps;
+      case SeedsTable.tableReferendums:
+        return _tableReferendums;
+      case SeedsTable.tableRefs:
+        return _tableRefs;
+      case SeedsTable.tableSupport:
+        return _tableSupport;
+      case SeedsTable.tableUsers:
+        return _tableUsers;
+      case SeedsTable.tableVoice:
+        return _tableVoice;
+      case SeedsTable.tableOrganization:
+        return _tableOrganization;
+      case SeedsTable.tableProposalVotes:
+        return _tableProposalVotes;
+      case SeedsTable.tableReferendumVoters:
+        return _tableReferendumVoters;
+      case SeedsTable.tableDelegates:
+        return _tableDelegates;
+      case SeedsTable.tableRecover:
+        return _tableRecover;
+      case SeedsTable.tableTotals:
+        return _tableTotals;
+      case SeedsTable.tableCycleStats:
+        return _tableCycleStats;
+      case SeedsTable.tableDatapoints:
+        return _tabledatapoints;
+      case SeedsTable.tableCbs:
+        return _tablecbs;
+      case SeedsTable.tableCspoints:
+        return _tableCspoints;
+      case SeedsTable.tableRep:
+        return _tableRep;
+      case SeedsTable.tablePlanted:
+        return _tablePlanted;
+      case SeedsTable.tableTxpoints:
+        return _tabletxpoints;
+      default:
+        return '';
+    }
+  }
+}

--- a/lib/datasource/remote/api/invite_repository.dart
+++ b/lib/datasource/remote/api/invite_repository.dart
@@ -29,7 +29,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = SeedsScope.accountToken.value
+        ..account = SeedsCode.accountToken.value
         ..name = actionNameTransfer
         ..authorization = [
           Authorization()
@@ -38,12 +38,12 @@ class InviteRepository extends NetworkRepository with EosRepository {
         ]
         ..data = {
           'from': accountName,
-          'to': SeedsScope.accountJoin.value,
+          'to': SeedsCode.accountJoin.value,
           'quantity': '${quantity.toStringAsFixed(4)} $currencySeedsCode',
           'memo': '',
         },
       Action()
-        ..account = SeedsScope.accountJoin.value
+        ..account = SeedsCode.accountJoin.value
         ..name = actionNameInvite
         ..authorization = [
           Authorization()
@@ -71,7 +71,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
-    final request = createRequest(code: SeedsScope.accountAccounts, scope: SeedsScope.accountAccounts.value, table: SeedsTable.tableUsers, limit: 1000);
+    final request = createRequest(code: SeedsCode.accountAccounts, scope: SeedsCode.accountAccounts.value, table: SeedsTable.tableUsers, limit: 1000);
 
     return http
         .post(membersURL, headers: headers, body: request)
@@ -89,8 +89,8 @@ class InviteRepository extends NetworkRepository with EosRepository {
     // 'https://node.hypha.earth/v1/chain/get_table_rows'; // todo: Why is this still Hypha when config has changed?
 
     final request = createRequest(
-        code: SeedsScope.accountJoin,
-        scope: SeedsScope.accountJoin.value,
+        code: SeedsCode.accountJoin,
+        scope: SeedsCode.accountJoin.value,
         table: SeedsTable.tableInvites,
         lowerBound: inviteHash,
         upperBound: inviteHash,
@@ -112,8 +112,8 @@ class InviteRepository extends NetworkRepository with EosRepository {
     final inviteURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-      code: SeedsScope.accountJoin,
-      scope: SeedsScope.accountJoin.value,
+      code: SeedsCode.accountJoin,
+      scope: SeedsCode.accountJoin.value,
       table: SeedsTable.tableInvites,
       limit: 200,
       indexPosition: 3,
@@ -135,7 +135,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = SeedsScope.accountJoin.value
+        ..account = SeedsCode.accountJoin.value
         ..name = actionNameCancelInvite
         ..authorization = [
           Authorization()

--- a/lib/datasource/remote/api/invite_repository.dart
+++ b/lib/datasource/remote/api/invite_repository.dart
@@ -13,7 +13,6 @@ import 'package:seeds/datasource/remote/datamappers/toDomainInviteModel.dart';
 import 'package:seeds/datasource/remote/model/invite_model.dart';
 import 'package:seeds/datasource/remote/model/member_model.dart';
 import 'package:seeds/datasource/remote/model/transaction_response.dart';
-import 'package:seeds/domain-shared/app_constants.dart';
 import 'package:seeds/domain-shared/ui_constants.dart';
 
 class InviteRepository extends NetworkRepository with EosRepository {
@@ -71,7 +70,11 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
-    final request = createRequest(code: SeedsCode.accountAccounts, scope: SeedsCode.accountAccounts.value, table: SeedsTable.tableUsers, limit: 1000);
+    final request = createRequest(
+        code: SeedsCode.accountAccounts,
+        scope: SeedsCode.accountAccounts.value,
+        table: SeedsTable.tableUsers,
+        limit: 1000);
 
     return http
         .post(membersURL, headers: headers, body: request)

--- a/lib/datasource/remote/api/invite_repository.dart
+++ b/lib/datasource/remote/api/invite_repository.dart
@@ -6,6 +6,7 @@ import 'package:async/async.dart';
 import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/remote/api/eos_repository.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/datamappers/toDomainInviteModel.dart';
 import 'package:seeds/datasource/remote/model/invite_model.dart';
@@ -69,7 +70,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
-    final request = createRequest(code: accountAccounts, scope: accountAccounts, table: tableUsers, limit: 1000);
+    final request = createRequest(code: accountAccounts, scope: accountAccounts, table: SeedsTable.tableUsers, limit: 1000);
 
     return http
         .post(membersURL, headers: headers, body: request)
@@ -89,7 +90,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
         code: accountJoin,
         scope: accountJoin,
-        table: tableInvites,
+        table: SeedsTable.tableInvites,
         lowerBound: inviteHash,
         upperBound: inviteHash,
         indexPosition: 2,
@@ -112,7 +113,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
       code: accountJoin,
       scope: accountJoin,
-      table: tableInvites,
+      table: SeedsTable.tableInvites,
       limit: 200,
       indexPosition: 3,
       lowerBound: userAccount,

--- a/lib/datasource/remote/api/invite_repository.dart
+++ b/lib/datasource/remote/api/invite_repository.dart
@@ -6,6 +6,7 @@ import 'package:async/async.dart';
 import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/remote/api/eos_repository.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/datamappers/toDomainInviteModel.dart';
@@ -28,7 +29,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = accountToken
+        ..account = SeedsScope.accountToken.value
         ..name = actionNameTransfer
         ..authorization = [
           Authorization()
@@ -37,12 +38,12 @@ class InviteRepository extends NetworkRepository with EosRepository {
         ]
         ..data = {
           'from': accountName,
-          'to': accountJoin,
+          'to': SeedsScope.accountJoin.value,
           'quantity': '${quantity.toStringAsFixed(4)} $currencySeedsCode',
           'memo': '',
         },
       Action()
-        ..account = accountJoin
+        ..account = SeedsScope.accountJoin.value
         ..name = actionNameInvite
         ..authorization = [
           Authorization()
@@ -70,7 +71,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
-    final request = createRequest(code: accountAccounts, scope: accountAccounts, table: SeedsTable.tableUsers, limit: 1000);
+    final request = createRequest(code: SeedsScope.accountAccounts, scope: SeedsScope.accountAccounts.value, table: SeedsTable.tableUsers, limit: 1000);
 
     return http
         .post(membersURL, headers: headers, body: request)
@@ -88,8 +89,8 @@ class InviteRepository extends NetworkRepository with EosRepository {
     // 'https://node.hypha.earth/v1/chain/get_table_rows'; // todo: Why is this still Hypha when config has changed?
 
     final request = createRequest(
-        code: accountJoin,
-        scope: accountJoin,
+        code: SeedsScope.accountJoin,
+        scope: SeedsScope.accountJoin.value,
         table: SeedsTable.tableInvites,
         lowerBound: inviteHash,
         upperBound: inviteHash,
@@ -111,8 +112,8 @@ class InviteRepository extends NetworkRepository with EosRepository {
     final inviteURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-      code: accountJoin,
-      scope: accountJoin,
+      code: SeedsScope.accountJoin,
+      scope: SeedsScope.accountJoin.value,
       table: SeedsTable.tableInvites,
       limit: 200,
       indexPosition: 3,
@@ -134,7 +135,7 @@ class InviteRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = accountJoin
+        ..account = SeedsScope.accountJoin.value
         ..name = actionNameCancelInvite
         ..authorization = [
           Authorization()

--- a/lib/datasource/remote/api/members_repository.dart
+++ b/lib/datasource/remote/api/members_repository.dart
@@ -12,8 +12,8 @@ class MembersRepository extends NetworkRepository {
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-        code: SeedsScope.accountAccounts,
-        scope: SeedsScope.accountAccounts.value,
+        code: SeedsCode.accountAccounts,
+        scope: SeedsCode.accountAccounts.value,
         table: SeedsTable.tableUsers,
         limit: 1000);
 
@@ -37,8 +37,8 @@ class MembersRepository extends NetworkRepository {
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-        code: SeedsScope.accountAccounts,
-        scope: SeedsScope.accountAccounts.value,
+        code: SeedsCode.accountAccounts,
+        scope: SeedsCode.accountAccounts.value,
         table: SeedsTable.tableUsers,
         lowerBound: lowerBound,
         upperBound: upperBound,
@@ -109,8 +109,8 @@ class MembersRepository extends NetworkRepository {
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-        code: SeedsScope.accountAccounts,
-        scope: SeedsScope.accountAccounts.value,
+        code: SeedsCode.accountAccounts,
+        scope: SeedsCode.accountAccounts.value,
         table: SeedsTable.tableUsers,
         lowerBound: accountName,
         upperBound: accountName);

--- a/lib/datasource/remote/api/members_repository.dart
+++ b/lib/datasource/remote/api/members_repository.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/member_model.dart';
 import 'package:seeds/domain-shared/app_constants.dart';
@@ -10,7 +11,7 @@ class MembersRepository extends NetworkRepository {
 
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
-    final request = createRequest(code: accountAccounts, scope: accountAccounts, table: tableUsers, limit: 1000);
+    final request = createRequest(code: accountAccounts, scope: accountAccounts, table: SeedsTable.tableUsers, limit: 1000);
 
     return http
         .post(membersURL, headers: headers, body: request)
@@ -34,7 +35,7 @@ class MembersRepository extends NetworkRepository {
     final request = createRequest(
         code: accountAccounts,
         scope: accountAccounts,
-        table: tableUsers,
+        table: SeedsTable.tableUsers,
         lowerBound: lowerBound,
         upperBound: upperBound,
         limit: 100);
@@ -106,7 +107,7 @@ class MembersRepository extends NetworkRepository {
     final request = createRequest(
         code: accountAccounts,
         scope: accountAccounts,
-        table: tableUsers,
+        table: SeedsTable.tableUsers,
         lowerBound: accountName,
         upperBound: accountName);
 

--- a/lib/datasource/remote/api/members_repository.dart
+++ b/lib/datasource/remote/api/members_repository.dart
@@ -1,9 +1,9 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/member_model.dart';
-import 'package:seeds/domain-shared/app_constants.dart';
 
 class MembersRepository extends NetworkRepository {
   Future<Result<List<MemberModel>>> getMembers() {
@@ -11,7 +11,11 @@ class MembersRepository extends NetworkRepository {
 
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
-    final request = createRequest(code: accountAccounts, scope: accountAccounts, table: SeedsTable.tableUsers, limit: 1000);
+    final request = createRequest(
+        code: SeedsScope.accountAccounts,
+        scope: SeedsScope.accountAccounts.value,
+        table: SeedsTable.tableUsers,
+        limit: 1000);
 
     return http
         .post(membersURL, headers: headers, body: request)
@@ -33,8 +37,8 @@ class MembersRepository extends NetworkRepository {
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-        code: accountAccounts,
-        scope: accountAccounts,
+        code: SeedsScope.accountAccounts,
+        scope: SeedsScope.accountAccounts.value,
         table: SeedsTable.tableUsers,
         lowerBound: lowerBound,
         upperBound: upperBound,
@@ -105,8 +109,8 @@ class MembersRepository extends NetworkRepository {
     final membersURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-        code: accountAccounts,
-        scope: accountAccounts,
+        code: SeedsScope.accountAccounts,
+        scope: SeedsScope.accountAccounts.value,
         table: SeedsTable.tableUsers,
         lowerBound: accountName,
         upperBound: accountName);

--- a/lib/datasource/remote/api/network_repository.dart
+++ b/lib/datasource/remote/api/network_repository.dart
@@ -34,7 +34,7 @@ abstract class NetworkRepository {
   }
 
   String createRequest({
-    required SeedsScope code,
+    required SeedsCode code,
     required String scope,
     required SeedsTable table,
     String lowerBound = "",
@@ -47,9 +47,10 @@ abstract class NetworkRepository {
     bool showPayer = false,
   }) {
     final tableName = table.value;
+    final seedsCode = code.value;
 
     final String request =
-        '{"json": true, "code": "$code", "scope": "$scope", "table": "$tableName", "table_key":"$tableKey", "lower_bound": "$lowerBound", "upper_bound": "$upperBound", "index_position": "$indexPosition", "key_type": "$keyType", "limit": $limit, "reverse": $reverse, "show_payer":"$showPayer"}';
+        '{"json": true, "code": "$seedsCode", "scope": "$scope", "table": "$tableName", "table_key":"$tableKey", "lower_bound": "$lowerBound", "upper_bound": "$upperBound", "index_position": "$indexPosition", "key_type": "$keyType", "limit": $limit, "reverse": $reverse, "show_payer":"$showPayer"}';
 
     return request;
   }

--- a/lib/datasource/remote/api/network_repository.dart
+++ b/lib/datasource/remote/api/network_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
 import 'package:seeds/datasource/remote/util/response_extension.dart';
@@ -33,7 +34,7 @@ abstract class NetworkRepository {
   }
 
   String createRequest({
-    required String code,
+    required SeedsScope code,
     required String scope,
     required SeedsTable table,
     String lowerBound = "",

--- a/lib/datasource/remote/api/network_repository.dart
+++ b/lib/datasource/remote/api/network_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
 import 'package:seeds/datasource/remote/util/response_extension.dart';
 
@@ -11,27 +12,6 @@ abstract class NetworkRepository {
   String hyphaURL = remoteConfigurations.hyphaEndPoint;
   String fxApiKey = "thesecretapikey989";
   Map<String, String> headers = {'Content-type': 'application/json'};
-
-  String tableBalances = 'balances';
-  String tableConfig = 'config';
-  String tableGuards = 'guards';
-  String tableHarvest = 'harvest';
-  String tableRefunds = 'refunds';
-  String tableInvites = 'invites';
-  String tableMoonphases = 'moonphases';
-  String tableProps = 'props';
-  String tableReferendums = 'referendums';
-  String tableRefs = 'refs';
-  String tableSupport = 'support';
-  String tableUsers = 'users';
-  String tableVoice = 'voice';
-  String tableOrganization = 'organization';
-  String tableProposalVotes = 'votes';
-  String tableReferendumVoters = 'voters';
-  String tableDelegates = 'deltrusts';
-  String tableRecover = 'recovers';
-  String tableTotals = 'totals';
-  String tableCycleStats = 'cyclestats';
 
   FutureOr<Result<T>> mapHttpResponse<T>(http.Response response, Function modelMapper) {
     switch (response.statusCode) {
@@ -55,7 +35,7 @@ abstract class NetworkRepository {
   String createRequest({
     required String code,
     required String scope,
-    required String table,
+    required SeedsTable table,
     String lowerBound = "",
     String upperBound = "",
     String tableKey = "",
@@ -65,8 +45,10 @@ abstract class NetworkRepository {
     bool reverse = false,
     bool showPayer = false,
   }) {
+    final tableName = table.value;
+
     final String request =
-        '{"json": true, "code": "$code", "scope": "$scope", "table": "$table", "table_key":"$tableKey", "lower_bound": "$lowerBound", "upper_bound": "$upperBound", "index_position": "$indexPosition", "key_type": "$keyType", "limit": $limit, "reverse": $reverse, "show_payer":"$showPayer"}';
+        '{"json": true, "code": "$code", "scope": "$scope", "table": "$tableName", "table_key":"$tableKey", "lower_bound": "$lowerBound", "upper_bound": "$upperBound", "index_position": "$indexPosition", "key_type": "$keyType", "limit": $limit, "reverse": $reverse, "show_payer":"$showPayer"}';
 
     return request;
   }

--- a/lib/datasource/remote/api/planted_repository.dart
+++ b/lib/datasource/remote/api/planted_repository.dart
@@ -14,8 +14,8 @@ class PlantedRepository extends NetworkRepository {
     final plantedURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-        code: SeedsScope.accountHarvest,
-        scope: SeedsScope.accountHarvest.value,
+        code: SeedsCode.accountHarvest,
+        scope: SeedsCode.accountHarvest.value,
         table: SeedsTable.tableBalances,
         lowerBound: userAccount,
         upperBound: userAccount);
@@ -34,7 +34,7 @@ class PlantedRepository extends NetworkRepository {
     final plantedURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-      code: SeedsScope.accountHarvest,
+      code: SeedsCode.accountHarvest,
       scope: userAccount,
       table: SeedsTable.tableRefunds,
       limit: 1000,

--- a/lib/datasource/remote/api/planted_repository.dart
+++ b/lib/datasource/remote/api/planted_repository.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/planted_model.dart';
@@ -13,8 +14,8 @@ class PlantedRepository extends NetworkRepository {
     final plantedURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-        code: accountHarvest,
-        scope: accountHarvest,
+        code: SeedsScope.accountHarvest,
+        scope: SeedsScope.accountHarvest.value,
         table: SeedsTable.tableBalances,
         lowerBound: userAccount,
         upperBound: userAccount);
@@ -33,7 +34,7 @@ class PlantedRepository extends NetworkRepository {
     final plantedURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-      code: accountHarvest,
+      code: SeedsScope.accountHarvest,
       scope: userAccount,
       table: SeedsTable.tableRefunds,
       limit: 1000,

--- a/lib/datasource/remote/api/planted_repository.dart
+++ b/lib/datasource/remote/api/planted_repository.dart
@@ -5,7 +5,6 @@ import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/planted_model.dart';
 import 'package:seeds/datasource/remote/model/refund_model.dart';
-import 'package:seeds/domain-shared/app_constants.dart';
 
 class PlantedRepository extends NetworkRepository {
   Future<Result<PlantedModel>> getPlanted(String userAccount) {

--- a/lib/datasource/remote/api/planted_repository.dart
+++ b/lib/datasource/remote/api/planted_repository.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/planted_model.dart';
 import 'package:seeds/datasource/remote/model/refund_model.dart';
@@ -14,7 +15,7 @@ class PlantedRepository extends NetworkRepository {
     final request = createRequest(
         code: accountHarvest,
         scope: accountHarvest,
-        table: tableBalances,
+        table: SeedsTable.tableBalances,
         lowerBound: userAccount,
         upperBound: userAccount);
 
@@ -34,7 +35,7 @@ class PlantedRepository extends NetworkRepository {
     final request = createRequest(
       code: accountHarvest,
       scope: userAccount,
-      table: tableRefunds,
+      table: SeedsTable.tableRefunds,
       limit: 1000,
     );
 

--- a/lib/datasource/remote/api/profile_repository.dart
+++ b/lib/datasource/remote/api/profile_repository.dart
@@ -1,4 +1,5 @@
 import 'package:async/async.dart';
+
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
@@ -12,7 +13,6 @@ import 'package:seeds/datasource/remote/model/profile_model.dart';
 import 'package:seeds/datasource/remote/model/referred_accounts_model.dart';
 import 'package:seeds/datasource/remote/model/score_model.dart';
 import 'package:seeds/datasource/remote/model/transaction_response.dart';
-import 'package:seeds/domain-shared/app_constants.dart';
 import 'package:seeds/domain-shared/ui_constants.dart';
 
 class ProfileRepository extends NetworkRepository with EosRepository {
@@ -209,7 +209,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     final transaction = buildFreeTransaction(
         List.from(requestIds.map(
           (id) => Action()
-            ..account =SeedsCode.accountHarvest.value
+            ..account = SeedsCode.accountHarvest.value
             ..name = actionNameClaimRefund
             ..authorization = [
               Authorization()
@@ -247,7 +247,8 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     return citizenshipAction(accountName: accountName, isMake: false, isCitizen: false);
   }
 
-  Future<Result<TransactionResponse>> citizenshipAction({required String accountName, required bool isMake, required bool isCitizen}) async {
+  Future<Result<TransactionResponse>> citizenshipAction(
+      {required String accountName, required bool isMake, required bool isCitizen}) async {
     final String isMakeText = isMake ? "make" : "can";
     final String isCitizenText = isMake ? "citizen" : "resident";
 

--- a/lib/datasource/remote/api/profile_repository.dart
+++ b/lib/datasource/remote/api/profile_repository.dart
@@ -3,6 +3,7 @@ import 'package:async/async.dart';
 import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/remote/api/eos_repository.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
@@ -19,8 +20,8 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     print('[http] get seeds getProfile $accountName');
 
     final request = createRequest(
-      code: accountAccounts,
-      scope: accountAccounts,
+      code: SeedsScope.accountAccounts,
+      scope: SeedsScope.accountAccounts.value,
       table: SeedsTable.tableUsers,
       lowerBound: accountName,
       upperBound: accountName,
@@ -68,7 +69,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = accountAccounts
+        ..account = SeedsScope.accountAccounts.value
         ..name = actionNameUpdate
         ..authorization = [
           Authorization()
@@ -97,7 +98,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
   Future<Result<ScoreModel>> getScore({
     required String account,
-    String contractName = accountHarvest,
+    SeedsScope contractName = SeedsScope.accountHarvest,
     String? scope,
     required SeedsTable tableName,
     String fieldName = "rank",
@@ -108,7 +109,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
     final request = createRequest(
       code: contractName,
-      scope: scope ?? contractName,
+      scope: scope ?? contractName.value,
       table: tableName,
       lowerBound: account,
       upperBound: account,
@@ -126,8 +127,8 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     print('[http] get Referred Accounts $accountName');
 
     final request = createRequest(
-      code: accountAccounts,
-      scope: accountAccounts,
+      code: SeedsScope.accountAccounts,
+      scope: SeedsScope.accountAccounts.value,
       table: SeedsTable.tableRefs,
       lowerBound: accountName,
       upperBound: accountName,
@@ -149,7 +150,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = accountToken
+        ..account = SeedsScope.accountToken.value
         ..name = actionNameTransfer
         ..authorization = [
           Authorization()
@@ -158,7 +159,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
         ]
         ..data = {
           'from': accountName,
-          'to': accountHarvest,
+          'to': SeedsScope.accountHarvest.value,
           'quantity': '${amount.toStringAsFixed(4)} $currencySeedsCode',
           'memo': '',
         }
@@ -177,7 +178,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = accountHarvest
+        ..account = SeedsScope.accountHarvest.value
         ..name = actionNameUnplant
         ..authorization = [
           Authorization()
@@ -208,7 +209,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     final transaction = buildFreeTransaction(
         List.from(requestIds.map(
           (id) => Action()
-            ..account = accountHarvest
+            ..account =SeedsScope.accountHarvest.value
             ..name = actionNameClaimRefund
             ..authorization = [
               Authorization()
@@ -262,7 +263,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = accountAccounts
+        ..account = SeedsScope.accountAccounts.value
         ..name = actionName
         ..authorization = [
           Authorization()
@@ -301,8 +302,8 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     print('[http] get organization account');
 
     final request = createRequest(
-      code: accountOrgs,
-      scope: accountOrgs,
+      code: SeedsScope.accountOrgs,
+      scope: SeedsScope.accountOrgs.value,
       lowerBound: accountName,
       upperBound: accountName,
       table: SeedsTable.tableOrganization,

--- a/lib/datasource/remote/api/profile_repository.dart
+++ b/lib/datasource/remote/api/profile_repository.dart
@@ -20,8 +20,8 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     print('[http] get seeds getProfile $accountName');
 
     final request = createRequest(
-      code: SeedsScope.accountAccounts,
-      scope: SeedsScope.accountAccounts.value,
+      code: SeedsCode.accountAccounts,
+      scope: SeedsCode.accountAccounts.value,
       table: SeedsTable.tableUsers,
       lowerBound: accountName,
       upperBound: accountName,
@@ -69,7 +69,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = SeedsScope.accountAccounts.value
+        ..account = SeedsCode.accountAccounts.value
         ..name = actionNameUpdate
         ..authorization = [
           Authorization()
@@ -98,7 +98,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
   Future<Result<ScoreModel>> getScore({
     required String account,
-    SeedsScope contractName = SeedsScope.accountHarvest,
+    SeedsCode contractName = SeedsCode.accountHarvest,
     String? scope,
     required SeedsTable tableName,
     String fieldName = "rank",
@@ -127,8 +127,8 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     print('[http] get Referred Accounts $accountName');
 
     final request = createRequest(
-      code: SeedsScope.accountAccounts,
-      scope: SeedsScope.accountAccounts.value,
+      code: SeedsCode.accountAccounts,
+      scope: SeedsCode.accountAccounts.value,
       table: SeedsTable.tableRefs,
       lowerBound: accountName,
       upperBound: accountName,
@@ -150,7 +150,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = SeedsScope.accountToken.value
+        ..account = SeedsCode.accountToken.value
         ..name = actionNameTransfer
         ..authorization = [
           Authorization()
@@ -159,7 +159,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
         ]
         ..data = {
           'from': accountName,
-          'to': SeedsScope.accountHarvest.value,
+          'to': SeedsCode.accountHarvest.value,
           'quantity': '${amount.toStringAsFixed(4)} $currencySeedsCode',
           'memo': '',
         }
@@ -178,7 +178,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = SeedsScope.accountHarvest.value
+        ..account = SeedsCode.accountHarvest.value
         ..name = actionNameUnplant
         ..authorization = [
           Authorization()
@@ -209,7 +209,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     final transaction = buildFreeTransaction(
         List.from(requestIds.map(
           (id) => Action()
-            ..account =SeedsScope.accountHarvest.value
+            ..account =SeedsCode.accountHarvest.value
             ..name = actionNameClaimRefund
             ..authorization = [
               Authorization()
@@ -263,7 +263,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = SeedsScope.accountAccounts.value
+        ..account = SeedsCode.accountAccounts.value
         ..name = actionName
         ..authorization = [
           Authorization()
@@ -302,8 +302,8 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     print('[http] get organization account');
 
     final request = createRequest(
-      code: SeedsScope.accountOrgs,
-      scope: SeedsScope.accountOrgs.value,
+      code: SeedsCode.accountOrgs,
+      scope: SeedsCode.accountOrgs.value,
       lowerBound: accountName,
       upperBound: accountName,
       table: SeedsTable.tableOrganization,

--- a/lib/datasource/remote/api/profile_repository.dart
+++ b/lib/datasource/remote/api/profile_repository.dart
@@ -3,6 +3,7 @@ import 'package:async/async.dart';
 import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/remote/api/eos_repository.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
 import 'package:seeds/datasource/remote/model/organization_model.dart';
@@ -20,7 +21,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
       code: accountAccounts,
       scope: accountAccounts,
-      table: tableUsers,
+      table: SeedsTable.tableUsers,
       lowerBound: accountName,
       upperBound: accountName,
     );
@@ -98,7 +99,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     required String account,
     String contractName = accountHarvest,
     String? scope,
-    required String tableName,
+    required SeedsTable tableName,
     String fieldName = "rank",
   }) async {
     print('[http] get score $account $tableName');
@@ -127,7 +128,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
       code: accountAccounts,
       scope: accountAccounts,
-      table: tableRefs,
+      table: SeedsTable.tableRefs,
       lowerBound: accountName,
       upperBound: accountName,
       indexPosition: 2,
@@ -304,7 +305,7 @@ class ProfileRepository extends NetworkRepository with EosRepository {
       scope: accountOrgs,
       lowerBound: accountName,
       upperBound: accountName,
-      table: tableOrganization,
+      table: SeedsTable.tableOrganization,
       limit: 10,
     );
 

--- a/lib/datasource/remote/api/proposals_repository.dart
+++ b/lib/datasource/remote/api/proposals_repository.dart
@@ -25,8 +25,8 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
 
     final ms = DateTime.now().toUtc().millisecondsSinceEpoch;
     final request = createRequest(
-      code: SeedsScope.accountCycle,
-      scope: SeedsScope.accountCycle.value,
+      code: SeedsCode.accountCycle,
+      scope: SeedsCode.accountCycle.value,
       table: SeedsTable.tableMoonphases,
       limit: 4,
       lowerBound: '${(ms / 1000).round()}',
@@ -46,8 +46,8 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get vote cycle');
 
     final request = createRequest(
-      code: SeedsScope.accountFunds,
-      scope: SeedsScope.accountFunds.value,
+      code: SeedsCode.accountFunds,
+      scope: SeedsCode.accountFunds.value,
       table: SeedsTable.tableCycleStats,
       // ignore: avoid_redundant_argument_values
       limit: 1,
@@ -68,8 +68,8 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get proposals type - ${proposalType.type}');
 
     final request = createRequest(
-      code: SeedsScope.accountFunds,
-      scope: SeedsScope.accountFunds.value,
+      code: SeedsCode.accountFunds,
+      scope: SeedsCode.accountFunds.value,
       table: SeedsTable.tableProps,
       lowerBound: proposalType.proposalStage,
       upperBound: proposalType.proposalStage,
@@ -97,7 +97,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get referendums: stage = [$scope]');
 
     final request = createRequest(
-      code: SeedsScope.accountRules,
+      code: SeedsCode.accountRules,
       scope: scope,
       table: SeedsTable.tableReferendums,
       limit: 100,
@@ -121,7 +121,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
   Future<Result<List<SupportLevelModel>>> getSupportLevel(String scope) {
     print('[http] get support level for scope: $scope');
 
-    final request = createRequest(code: SeedsScope.accountFunds, scope: scope, table: SeedsTable.tableSupport);
+    final request = createRequest(code: SeedsCode.accountFunds, scope: scope, table: SeedsTable.tableSupport);
 
     final proposalsURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
@@ -137,7 +137,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get vote for proposal: $proposalId');
 
     final request = createRequest(
-      code: SeedsScope.accountFunds,
+      code: SeedsCode.accountFunds,
       scope: '$proposalId',
       table: SeedsTable.tableProposalVotes,
       lowerBound: account,
@@ -159,7 +159,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get vote for referendum: $referendumId');
 
     final request = createRequest(
-      code: SeedsScope.accountRules,
+      code: SeedsCode.accountRules,
       scope: '$referendumId',
       table: SeedsTable.tableReferendumVoters,
       lowerBound: account,
@@ -182,7 +182,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = SeedsScope.accountFunds.value
+        ..account = SeedsCode.accountFunds.value
         ..name = amount.isNegative ? actionNameAgainst : actionNameFavour
         ..authorization = [
           Authorization()
@@ -205,7 +205,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = SeedsScope.accountRules.value
+        ..account = SeedsCode.accountRules.value
         ..name = amount.isNegative ? actionNameAgainst : actionNameFavour
         ..authorization = [
           Authorization()
@@ -244,7 +244,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get delegate for $account');
 
     final request = createRequest(
-      code: SeedsScope.accountFunds,
+      code: SeedsCode.accountFunds,
       scope: voiceScope,
       table: SeedsTable.tableDelegates,
       lowerBound: account,
@@ -265,7 +265,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get delegators for $account');
 
     final request = createRequest(
-      code: SeedsScope.accountFunds,
+      code: SeedsCode.accountFunds,
       indexPosition: 2,
       scope: voiceScope,
       table: SeedsTable.tableDelegates,
@@ -307,7 +307,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     required String scope,
   }) =>
       Action()
-        ..account = SeedsScope.accountFunds.value
+        ..account = SeedsCode.accountFunds.value
         ..name = proposalActionNameDelegate
         ..authorization = [
           Authorization()
@@ -325,7 +325,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     required String scope,
   }) =>
       Action()
-        ..account = SeedsScope.accountFunds.value
+        ..account = SeedsCode.accountFunds.value
         ..name = proposalActionNameUndelegate
         ..authorization = [
           Authorization()

--- a/lib/datasource/remote/api/proposals_repository.dart
+++ b/lib/datasource/remote/api/proposals_repository.dart
@@ -16,7 +16,6 @@ import 'package:seeds/datasource/remote/model/support_level_model.dart';
 import 'package:seeds/datasource/remote/model/transaction_response.dart';
 import 'package:seeds/datasource/remote/model/vote_cycle_model.dart';
 import 'package:seeds/datasource/remote/model/vote_model.dart';
-import 'package:seeds/domain-shared/app_constants.dart';
 import 'package:seeds/screens/explore_screens/vote_screens/vote/interactor/viewmodels/proposal_type_model.dart';
 
 class ProposalsRepository extends NetworkRepository with EosRepository {
@@ -177,7 +176,8 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
         .catchError((error) => mapHttpError(error));
   }
 
-  Future<Result<TransactionResponse>> voteProposal({required int id, required int amount, required String accountName}) {
+  Future<Result<TransactionResponse>> voteProposal(
+      {required int id, required int amount, required String accountName}) {
     print('[eos] vote proposal $id ($amount)');
 
     final transaction = buildFreeTransaction([
@@ -200,7 +200,8 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
         .catchError((error) => mapEosError(error));
   }
 
-  Future<Result<TransactionResponse>> voteReferendum({required int id, required int amount, required String accountName}) {
+  Future<Result<TransactionResponse>> voteReferendum(
+      {required int id, required int amount, required String accountName}) {
     print('[eos] vote referendum $id ($amount)');
 
     final transaction = buildFreeTransaction([

--- a/lib/datasource/remote/api/proposals_repository.dart
+++ b/lib/datasource/remote/api/proposals_repository.dart
@@ -4,6 +4,7 @@ import 'package:async/async.dart';
 import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/remote/api/eos_repository.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/delegate_model.dart';
 import 'package:seeds/datasource/remote/model/delegator_model.dart';
@@ -25,7 +26,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
       code: accountCycle,
       scope: accountCycle,
-      table: tableMoonphases,
+      table: SeedsTable.tableMoonphases,
       limit: 4,
       lowerBound: '${(ms / 1000).round()}',
     );
@@ -46,7 +47,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
       code: accountFunds,
       scope: accountFunds,
-      table: tableCycleStats,
+      table: SeedsTable.tableCycleStats,
       // ignore: avoid_redundant_argument_values
       limit: 1,
       reverse: true,
@@ -68,7 +69,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
       code: accountFunds,
       scope: accountFunds,
-      table: tableProps,
+      table: SeedsTable.tableProps,
       lowerBound: proposalType.proposalStage,
       upperBound: proposalType.proposalStage,
       limit: 100,
@@ -97,7 +98,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
       code: accountRules,
       scope: scope,
-      table: tableReferendums,
+      table: SeedsTable.tableReferendums,
       limit: 100,
       reverse: isReverse,
     );
@@ -119,7 +120,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
   Future<Result<List<SupportLevelModel>>> getSupportLevel(String scope) {
     print('[http] get support level for scope: $scope');
 
-    final request = createRequest(code: accountFunds, scope: scope, table: tableSupport);
+    final request = createRequest(code: accountFunds, scope: scope, table: SeedsTable.tableSupport);
 
     final proposalsURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
@@ -137,7 +138,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
       code: accountFunds,
       scope: '$proposalId',
-      table: tableProposalVotes,
+      table: SeedsTable.tableProposalVotes,
       lowerBound: account,
       upperBound: account,
       limit: 10,
@@ -159,7 +160,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
       code: accountRules,
       scope: '$referendumId',
-      table: tableReferendumVoters,
+      table: SeedsTable.tableReferendumVoters,
       lowerBound: account,
       upperBound: account,
       limit: 10,
@@ -244,7 +245,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     final request = createRequest(
       code: accountFunds,
       scope: voiceScope,
-      table: tableDelegates,
+      table: SeedsTable.tableDelegates,
       lowerBound: account,
       upperBound: account,
     );
@@ -266,7 +267,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
       code: accountFunds,
       indexPosition: 2,
       scope: voiceScope,
-      table: tableDelegates,
+      table: SeedsTable.tableDelegates,
       lowerBound: account,
       upperBound: account,
       limit: 100,

--- a/lib/datasource/remote/api/proposals_repository.dart
+++ b/lib/datasource/remote/api/proposals_repository.dart
@@ -4,6 +4,7 @@ import 'package:async/async.dart';
 import 'package:eosdart/eosdart.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/remote/api/eos_repository.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/delegate_model.dart';
@@ -24,8 +25,8 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
 
     final ms = DateTime.now().toUtc().millisecondsSinceEpoch;
     final request = createRequest(
-      code: accountCycle,
-      scope: accountCycle,
+      code: SeedsScope.accountCycle,
+      scope: SeedsScope.accountCycle.value,
       table: SeedsTable.tableMoonphases,
       limit: 4,
       lowerBound: '${(ms / 1000).round()}',
@@ -45,8 +46,8 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get vote cycle');
 
     final request = createRequest(
-      code: accountFunds,
-      scope: accountFunds,
+      code: SeedsScope.accountFunds,
+      scope: SeedsScope.accountFunds.value,
       table: SeedsTable.tableCycleStats,
       // ignore: avoid_redundant_argument_values
       limit: 1,
@@ -67,8 +68,8 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get proposals type - ${proposalType.type}');
 
     final request = createRequest(
-      code: accountFunds,
-      scope: accountFunds,
+      code: SeedsScope.accountFunds,
+      scope: SeedsScope.accountFunds.value,
       table: SeedsTable.tableProps,
       lowerBound: proposalType.proposalStage,
       upperBound: proposalType.proposalStage,
@@ -96,7 +97,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get referendums: stage = [$scope]');
 
     final request = createRequest(
-      code: accountRules,
+      code: SeedsScope.accountRules,
       scope: scope,
       table: SeedsTable.tableReferendums,
       limit: 100,
@@ -120,7 +121,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
   Future<Result<List<SupportLevelModel>>> getSupportLevel(String scope) {
     print('[http] get support level for scope: $scope');
 
-    final request = createRequest(code: accountFunds, scope: scope, table: SeedsTable.tableSupport);
+    final request = createRequest(code: SeedsScope.accountFunds, scope: scope, table: SeedsTable.tableSupport);
 
     final proposalsURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
@@ -136,7 +137,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get vote for proposal: $proposalId');
 
     final request = createRequest(
-      code: accountFunds,
+      code: SeedsScope.accountFunds,
       scope: '$proposalId',
       table: SeedsTable.tableProposalVotes,
       lowerBound: account,
@@ -158,7 +159,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get vote for referendum: $referendumId');
 
     final request = createRequest(
-      code: accountRules,
+      code: SeedsScope.accountRules,
       scope: '$referendumId',
       table: SeedsTable.tableReferendumVoters,
       lowerBound: account,
@@ -181,7 +182,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = accountFunds
+        ..account = SeedsScope.accountFunds.value
         ..name = amount.isNegative ? actionNameAgainst : actionNameFavour
         ..authorization = [
           Authorization()
@@ -204,7 +205,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
 
     final transaction = buildFreeTransaction([
       Action()
-        ..account = accountRules
+        ..account = SeedsScope.accountRules.value
         ..name = amount.isNegative ? actionNameAgainst : actionNameFavour
         ..authorization = [
           Authorization()
@@ -243,7 +244,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get delegate for $account');
 
     final request = createRequest(
-      code: accountFunds,
+      code: SeedsScope.accountFunds,
       scope: voiceScope,
       table: SeedsTable.tableDelegates,
       lowerBound: account,
@@ -264,7 +265,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     print('[http] get delegators for $account');
 
     final request = createRequest(
-      code: accountFunds,
+      code: SeedsScope.accountFunds,
       indexPosition: 2,
       scope: voiceScope,
       table: SeedsTable.tableDelegates,
@@ -306,7 +307,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     required String scope,
   }) =>
       Action()
-        ..account = accountFunds
+        ..account = SeedsScope.accountFunds.value
         ..name = proposalActionNameDelegate
         ..authorization = [
           Authorization()
@@ -324,7 +325,7 @@ class ProposalsRepository extends NetworkRepository with EosRepository {
     required String scope,
   }) =>
       Action()
-        ..account = accountFunds
+        ..account = SeedsScope.accountFunds.value
         ..name = proposalActionNameUndelegate
         ..authorization = [
           Authorization()

--- a/lib/datasource/remote/api/rates_repository.dart
+++ b/lib/datasource/remote/api/rates_repository.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/fiat_rate_model.dart';
 import 'package:seeds/datasource/remote/model/rate_model.dart';
@@ -35,7 +36,7 @@ class RatesRepository extends NetworkRepository {
     final params = createRequest(
       code: "delphioracle",
       scope: "tlosusd",
-      table: "datapoints",
+      table: SeedsTable.tableDatapoints,
       // ignore: avoid_redundant_argument_values
       limit: 1,
     );

--- a/lib/datasource/remote/api/rates_repository.dart
+++ b/lib/datasource/remote/api/rates_repository.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/fiat_rate_model.dart';
@@ -34,7 +35,7 @@ class RatesRepository extends NetworkRepository {
     print('[http] get telos rate USD');
 
     final params = createRequest(
-      code: "delphioracle",
+      code: SeedsScope.accountdelphioracle,
       scope: "tlosusd",
       table: SeedsTable.tableDatapoints,
       // ignore: avoid_redundant_argument_values

--- a/lib/datasource/remote/api/rates_repository.dart
+++ b/lib/datasource/remote/api/rates_repository.dart
@@ -35,7 +35,7 @@ class RatesRepository extends NetworkRepository {
     print('[http] get telos rate USD');
 
     final params = createRequest(
-      code: SeedsScope.accountdelphioracle,
+      code: SeedsCode.accountdelphioracle,
       scope: "tlosusd",
       table: SeedsTable.tableDatapoints,
       // ignore: avoid_redundant_argument_values

--- a/lib/datasource/remote/api/seeds_history_repository.dart
+++ b/lib/datasource/remote/api/seeds_history_repository.dart
@@ -12,8 +12,8 @@ class SeedsHistoryRepository extends NetworkRepository {
     print('[http] get seeds seeds history for account: $userAccount ');
 
     final String request = createRequest(
-      code: SeedsScope.historySeeds,
-      scope: SeedsScope.historySeeds.value,
+      code: SeedsCode.historySeeds,
+      scope: SeedsCode.historySeeds.value,
       table: SeedsTable.tableTotals,
       lowerBound: userAccount,
       upperBound: userAccount,

--- a/lib/datasource/remote/api/seeds_history_repository.dart
+++ b/lib/datasource/remote/api/seeds_history_repository.dart
@@ -4,7 +4,6 @@ import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/seeds_history_model.dart';
-import 'package:seeds/domain-shared/app_constants.dart';
 
 ///Seeds History Table
 class SeedsHistoryRepository extends NetworkRepository {

--- a/lib/datasource/remote/api/seeds_history_repository.dart
+++ b/lib/datasource/remote/api/seeds_history_repository.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/seeds_history_model.dart';
 import 'package:seeds/domain-shared/app_constants.dart';
@@ -12,7 +13,7 @@ class SeedsHistoryRepository extends NetworkRepository {
     final String request = createRequest(
       code: historySeeds,
       scope: historySeeds,
-      table: tableTotals,
+      table: SeedsTable.tableTotals,
       lowerBound: userAccount,
       upperBound: userAccount,
     );

--- a/lib/datasource/remote/api/seeds_history_repository.dart
+++ b/lib/datasource/remote/api/seeds_history_repository.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/seeds_history_model.dart';
@@ -11,8 +12,8 @@ class SeedsHistoryRepository extends NetworkRepository {
     print('[http] get seeds seeds history for account: $userAccount ');
 
     final String request = createRequest(
-      code: historySeeds,
-      scope: historySeeds,
+      code: SeedsScope.historySeeds,
+      scope: SeedsScope.historySeeds.value,
       table: SeedsTable.tableTotals,
       lowerBound: userAccount,
       upperBound: userAccount,

--- a/lib/datasource/remote/api/voice_repository.dart
+++ b/lib/datasource/remote/api/voice_repository.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/voice_model.dart';
 import 'package:seeds/domain-shared/app_constants.dart';
@@ -12,7 +13,7 @@ class VoiceRepository extends NetworkRepository {
     final request = createRequest(
       code: accountFunds,
       scope: accountFunds,
-      table: tableVoice,
+      table: SeedsTable.tableVoice,
       lowerBound: userAccount,
       upperBound: userAccount,
     );
@@ -32,7 +33,7 @@ class VoiceRepository extends NetworkRepository {
     final request = createRequest(
       code: accountFunds,
       scope: 'alliance',
-      table: tableVoice,
+      table: SeedsTable.tableVoice,
       lowerBound: userAccount,
       upperBound: userAccount,
     );
@@ -52,7 +53,7 @@ class VoiceRepository extends NetworkRepository {
     final request = createRequest(
       code: accountFunds,
       scope: 'milestone',
-      table: tableVoice,
+      table: SeedsTable.tableVoice,
       lowerBound: userAccount,
       upperBound: userAccount,
     );
@@ -72,7 +73,7 @@ class VoiceRepository extends NetworkRepository {
     final request = createRequest(
         code: accountRules,
         scope: accountRules,
-        table: tableBalances,
+        table: SeedsTable.tableBalances,
         lowerBound: userAccount,
         upperBound: userAccount);
 

--- a/lib/datasource/remote/api/voice_repository.dart
+++ b/lib/datasource/remote/api/voice_repository.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/voice_model.dart';
@@ -11,8 +12,8 @@ class VoiceRepository extends NetworkRepository {
     final voiceURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-      code: accountFunds,
-      scope: accountFunds,
+      code: SeedsScope.accountFunds,
+      scope: SeedsScope.accountFunds.value,
       table: SeedsTable.tableVoice,
       lowerBound: userAccount,
       upperBound: userAccount,
@@ -31,7 +32,7 @@ class VoiceRepository extends NetworkRepository {
     final voiceURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-      code: accountFunds,
+      code: SeedsScope.accountFunds,
       scope: 'alliance',
       table: SeedsTable.tableVoice,
       lowerBound: userAccount,
@@ -51,7 +52,7 @@ class VoiceRepository extends NetworkRepository {
     final voiceURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-      code: accountFunds,
+      code: SeedsScope.accountFunds,
       scope: 'milestone',
       table: SeedsTable.tableVoice,
       lowerBound: userAccount,
@@ -71,8 +72,8 @@ class VoiceRepository extends NetworkRepository {
     final voiceURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-        code: accountRules,
-        scope: accountRules,
+        code: SeedsScope.accountRules,
+        scope: SeedsScope.accountRules.value,
         table: SeedsTable.tableBalances,
         lowerBound: userAccount,
         upperBound: userAccount);

--- a/lib/datasource/remote/api/voice_repository.dart
+++ b/lib/datasource/remote/api/voice_repository.dart
@@ -4,7 +4,6 @@ import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/network_repository.dart';
 import 'package:seeds/datasource/remote/model/voice_model.dart';
-import 'package:seeds/domain-shared/app_constants.dart';
 
 class VoiceRepository extends NetworkRepository {
   Future<Result<VoiceModel>> getCampaignVoice(String userAccount) {

--- a/lib/datasource/remote/api/voice_repository.dart
+++ b/lib/datasource/remote/api/voice_repository.dart
@@ -12,8 +12,8 @@ class VoiceRepository extends NetworkRepository {
     final voiceURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-      code: SeedsScope.accountFunds,
-      scope: SeedsScope.accountFunds.value,
+      code: SeedsCode.accountFunds,
+      scope: SeedsCode.accountFunds.value,
       table: SeedsTable.tableVoice,
       lowerBound: userAccount,
       upperBound: userAccount,
@@ -32,7 +32,7 @@ class VoiceRepository extends NetworkRepository {
     final voiceURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-      code: SeedsScope.accountFunds,
+      code: SeedsCode.accountFunds,
       scope: 'alliance',
       table: SeedsTable.tableVoice,
       lowerBound: userAccount,
@@ -52,7 +52,7 @@ class VoiceRepository extends NetworkRepository {
     final voiceURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-      code: SeedsScope.accountFunds,
+      code: SeedsCode.accountFunds,
       scope: 'milestone',
       table: SeedsTable.tableVoice,
       lowerBound: userAccount,
@@ -72,8 +72,8 @@ class VoiceRepository extends NetworkRepository {
     final voiceURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
 
     final request = createRequest(
-        code: SeedsScope.accountRules,
-        scope: SeedsScope.accountRules.value,
+        code: SeedsCode.accountRules,
+        scope: SeedsCode.accountRules.value,
         table: SeedsTable.tableBalances,
         lowerBound: userAccount,
         upperBound: userAccount);

--- a/lib/domain-shared/app_constants.dart
+++ b/lib/domain-shared/app_constants.dart
@@ -9,20 +9,6 @@ const String androidPacakageName = 'com.joinseeds.seedswallet';
 const String iosBundleId = 'com.joinseeds.seedslight';
 const String iosAppStoreId = '1507143650';
 
-/// Accounts
-const String accountAccounts = 'accts.seeds';
-const String accountCycle = 'cycle.seeds';
-const String accountEosio = 'eosio';
-const String accountFunds = 'funds.seeds';
-const String accountGuards = 'guard.seeds';
-const String accountHarvest = 'harvst.seeds';
-const String accountJoin = 'join.seeds';
-const String accountToken = 'token.seeds';
-const String accountRules = 'rules.seeds';
-const String accountSettgs = 'settgs.seeds';
-const String historySeeds = 'histry.seeds';
-const String accountOrgs = 'orgs.seeds';
-
 /// Actions
 const String transferAction = 'transfer';
 

--- a/lib/screens/profile_screens/citizenship/interactor/usecases/get_citizenship_data_use_case.dart
+++ b/lib/screens/profile_screens/citizenship/interactor/usecases/get_citizenship_data_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/planted_repository.dart';
 import 'package:seeds/datasource/remote/api/profile_repository.dart';
 import 'package:seeds/datasource/remote/api/seeds_history_repository.dart';
@@ -14,7 +15,7 @@ class GetCitizenshipDataUseCase {
     final futures = [
       _plantedRepository.getPlanted(account),
       _seedsHistoryRepository.getNumberOfTransactions(account),
-      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: "cbs"),
+      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: SeedsTable.tableCbs),
     ];
     return Future.wait(futures);
   }

--- a/lib/screens/profile_screens/citizenship/interactor/usecases/get_citizenship_data_use_case.dart
+++ b/lib/screens/profile_screens/citizenship/interactor/usecases/get_citizenship_data_use_case.dart
@@ -16,7 +16,7 @@ class GetCitizenshipDataUseCase {
     final futures = [
       _plantedRepository.getPlanted(account),
       _seedsHistoryRepository.getNumberOfTransactions(account),
-      _profileRepository.getScore(account: account, contractName: SeedsScope.accountAccounts, tableName: SeedsTable.tableCbs),
+      _profileRepository.getScore(account: account, contractName: SeedsCode.accountAccounts, tableName: SeedsTable.tableCbs),
     ];
     return Future.wait(futures);
   }

--- a/lib/screens/profile_screens/citizenship/interactor/usecases/get_citizenship_data_use_case.dart
+++ b/lib/screens/profile_screens/citizenship/interactor/usecases/get_citizenship_data_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/planted_repository.dart';
 import 'package:seeds/datasource/remote/api/profile_repository.dart';
@@ -15,7 +16,7 @@ class GetCitizenshipDataUseCase {
     final futures = [
       _plantedRepository.getPlanted(account),
       _seedsHistoryRepository.getNumberOfTransactions(account),
-      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: SeedsTable.tableCbs),
+      _profileRepository.getScore(account: account, contractName: SeedsScope.accountAccounts, tableName: SeedsTable.tableCbs),
     ];
     return Future.wait(futures);
   }

--- a/lib/screens/profile_screens/contribution/interactor/usecases/get_profile_scores_use_case.dart
+++ b/lib/screens/profile_screens/contribution/interactor/usecases/get_profile_scores_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/profile_repository.dart';
 
 class GetProfileScoresUseCase {
@@ -8,11 +9,11 @@ class GetProfileScoresUseCase {
   Future<List<Result>> run() {
     final account = settingsStorage.accountName;
     final futures = [
-      _profileRepository.getScore(account: account, tableName: "cspoints"),
-      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: "cbs"),
-      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: "rep"),
-      _profileRepository.getScore(account: account, tableName: "planted"),
-      _profileRepository.getScore(account: account, tableName: "txpoints"),
+      _profileRepository.getScore(account: account, tableName: SeedsTable.tableCspoints),
+      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: SeedsTable.tableCbs),
+      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: SeedsTable.tableRep),
+      _profileRepository.getScore(account: account, tableName: SeedsTable.tablePlanted),
+      _profileRepository.getScore(account: account, tableName: SeedsTable.tableTxpoints),
     ];
     return Future.wait(futures);
   }

--- a/lib/screens/profile_screens/contribution/interactor/usecases/get_profile_scores_use_case.dart
+++ b/lib/screens/profile_screens/contribution/interactor/usecases/get_profile_scores_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_scopes.dart';
 import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/profile_repository.dart';
 
@@ -10,8 +11,10 @@ class GetProfileScoresUseCase {
     final account = settingsStorage.accountName;
     final futures = [
       _profileRepository.getScore(account: account, tableName: SeedsTable.tableCspoints),
-      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: SeedsTable.tableCbs),
-      _profileRepository.getScore(account: account, contractName: "accts.seeds", tableName: SeedsTable.tableRep),
+      _profileRepository.getScore(
+          account: account, contractName: SeedsScope.accountAccounts, tableName: SeedsTable.tableCbs),
+      _profileRepository.getScore(
+          account: account, contractName: SeedsScope.accountAccounts, tableName: SeedsTable.tableRep),
       _profileRepository.getScore(account: account, tableName: SeedsTable.tablePlanted),
       _profileRepository.getScore(account: account, tableName: SeedsTable.tableTxpoints),
     ];

--- a/lib/screens/profile_screens/contribution/interactor/usecases/get_profile_scores_use_case.dart
+++ b/lib/screens/profile_screens/contribution/interactor/usecases/get_profile_scores_use_case.dart
@@ -12,9 +12,9 @@ class GetProfileScoresUseCase {
     final futures = [
       _profileRepository.getScore(account: account, tableName: SeedsTable.tableCspoints),
       _profileRepository.getScore(
-          account: account, contractName: SeedsScope.accountAccounts, tableName: SeedsTable.tableCbs),
+          account: account, contractName: SeedsCode.accountAccounts, tableName: SeedsTable.tableCbs),
       _profileRepository.getScore(
-          account: account, contractName: SeedsScope.accountAccounts, tableName: SeedsTable.tableRep),
+          account: account, contractName: SeedsCode.accountAccounts, tableName: SeedsTable.tableRep),
       _profileRepository.getScore(account: account, tableName: SeedsTable.tablePlanted),
       _profileRepository.getScore(account: account, tableName: SeedsTable.tableTxpoints),
     ];

--- a/lib/screens/profile_screens/profile/interactor/usecases/get_profile_values_use_case.dart
+++ b/lib/screens/profile_screens/profile/interactor/usecases/get_profile_values_use_case.dart
@@ -1,4 +1,5 @@
 import 'package:seeds/datasource/local/settings_storage.dart';
+import 'package:seeds/datasource/remote/api/http_repo/seeds_tables.dart';
 import 'package:seeds/datasource/remote/api/profile_repository.dart';
 import 'package:seeds/datasource/remote/model/organization_model.dart';
 import 'package:seeds/datasource/remote/model/profile_model.dart';
@@ -20,7 +21,7 @@ class GetProfileValuesUseCase extends NoInputUseCase<GetProfileValuesResponse> {
     final account = settingsStorage.accountName;
     final futures = [
       _profileRepository.getProfile(account),
-      _profileRepository.getScore(account: account, tableName: "cspoints"),
+      _profileRepository.getScore(account: account, tableName: SeedsTable.tableCspoints),
       _profileRepository.getOrganizationAccount(account),
       _profileRepository.canResident(account),
       _profileRepository.canCitizen(account),


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

No Story

### 🕵️‍♂️ Notes for Code Reviewer

Locking param types for creating http network calls. We must now pass an enum instead of a string. 

This is avoid people creating and repeating strings around the app. 

### 👯‍♀️ Paired with

Solo
