### PR TITLE
Global SnackBars [1/2]

### DIFF
--- a/lib/blocs/root/root_bloc.dart
+++ b/lib/blocs/root/root_bloc.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:seeds/domain-shared/event_bus/event_bus.dart';
+import 'package:seeds/domain-shared/event_bus/events.dart';
+
+part 'root_event.dart';
+part 'root_state.dart';
+
+class RootBloc extends Bloc<RootEvent, RootState> {
+  late StreamSubscription _snackSubscription;
+
+  RootBloc() : super(RootState.initial()) {
+    _snackSubscription = eventBus.on<ShowSnackBar>().listen((event) async => add(OnRootBusEventRecived(event)));
+    on<OnRootBusEventRecived>((event, emit) => emit(state.copyWith(busEvent: event.busEvent)));
+    on<ClearRootBusEvent>((event, emit) => emit(state.copyWith()));
+  }
+
+  @override
+  Future<void> close() async {
+    await _snackSubscription.cancel();
+    return super.close();
+  }
+}

--- a/lib/blocs/root/root_event.dart
+++ b/lib/blocs/root/root_event.dart
@@ -1,0 +1,27 @@
+part of 'root_bloc.dart';
+
+abstract class RootEvent extends Equatable {
+  const RootEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class OnRootBusEventRecived extends RootEvent {
+  final BusEvent busEvent;
+
+  const OnRootBusEventRecived(this.busEvent);
+
+  @override
+  List<Object> get props => [busEvent];
+
+  @override
+  String toString() => 'OnRootBusEventRecived { BusEvent: ${busEvent.runtimeType} }';
+}
+
+class ClearRootBusEvent extends RootEvent {
+  const ClearRootBusEvent();
+
+  @override
+  String toString() => 'ClearRootBusEvent';
+}

--- a/lib/blocs/root/root_state.dart
+++ b/lib/blocs/root/root_state.dart
@@ -1,0 +1,16 @@
+part of 'root_bloc.dart';
+
+class RootState extends Equatable {
+  final BusEvent? busEvent;
+
+  const RootState({this.busEvent});
+
+  @override
+  List<Object?> get props => [busEvent];
+
+  RootState copyWith({BusEvent? busEvent}) {
+    return RootState(busEvent: busEvent);
+  }
+
+  factory RootState.initial() => const RootState();
+}

--- a/lib/components/snack.dart
+++ b/lib/components/snack.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:seeds/constants/app_colors.dart';
+
+enum SnackType { info, success, failure }
+
+class Snack extends SnackBar {
+  final String title;
+  final ScaffoldMessengerState scaffoldMessengerState;
+
+  factory Snack(title, scaffoldMessengerState, SnackType type) {
+    late Color color;
+    Duration duration = const Duration(seconds: 4);
+    switch (type) {
+      case SnackType.success:
+        color = AppColors.canopy;
+        break;
+      case SnackType.failure:
+        color = AppColors.red;
+        duration = const Duration(seconds: 6);
+        break;
+      default:
+        color = AppColors.grey;
+    }
+    return Snack._(title, scaffoldMessengerState, color: color, duration: duration);
+  }
+
+  Snack._(this.title, this.scaffoldMessengerState, {Key? key, required Color color, required Duration duration})
+      : super(
+          key: key,
+          backgroundColor: color,
+          duration: duration,
+          content: Row(
+            children: [
+              Expanded(child: Text(title, textAlign: TextAlign.center)),
+              InkWell(
+                onTap: () => scaffoldMessengerState.hideCurrentSnackBar(),
+                child: const Icon(Icons.close),
+              ),
+            ],
+          ),
+        );
+
+  void show() => scaffoldMessengerState.showSnackBar(this);
+}

--- a/lib/domain-shared/event_bus/events.dart
+++ b/lib/domain-shared/event_bus/events.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:seeds/components/snack.dart';
 import 'package:seeds/datasource/remote/model/transaction_model.dart';
 
 /// --- EVENT BUS EVENTS
@@ -17,4 +18,13 @@ class OnNewTransactionEventBus extends BusEvent<OnNewTransactionEventBus> {
 
 class OnFiatCurrencyChangedEventBus extends BusEvent<OnNewTransactionEventBus> {
   const OnFiatCurrencyChangedEventBus();
+}
+
+class ShowSnackBar extends BusEvent<OnNewTransactionEventBus> {
+  final String message;
+  final SnackType snackType;
+
+  const ShowSnackBar(this.message) : snackType = SnackType.info;
+  const ShowSnackBar.success(this.message) : snackType = SnackType.success;
+  const ShowSnackBar.failure(this.message) : snackType = SnackType.failure;
 }

--- a/lib/screens/authentication/verification/verification_screen.dart
+++ b/lib/screens/authentication/verification/verification_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:seeds/blocs/authentication/viewmodels/authentication_bloc.dart';
 import 'package:seeds/constants/app_colors.dart';
+import 'package:seeds/domain-shared/event_bus/event_bus.dart';
+import 'package:seeds/domain-shared/event_bus/events.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/i18n/authentication/verification/verification.i18n.dart';
 import 'package:seeds/screens/authentication/verification/components/passcode_created_dialog.dart';
@@ -29,16 +31,7 @@ class VerificationScreen extends StatelessWidget {
                 final pageCommand = state.pageCommand;
                 BlocProvider.of<VerificationBloc>(context).add(const ClearVerificationPageCommand());
                 if (pageCommand is PasscodeNotMatch) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      backgroundColor: AppColors.canopy,
-                      content: Text(
-                        'Pincode does not match'.i18n,
-                        textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.subtitle2,
-                      ),
-                    ),
-                  );
+                  eventBus.fire(ShowSnackBar.success('Pincode does not match'.i18n));
                 } else if (pageCommand is BiometricAuthorized) {
                   final authenticationBloc = BlocProvider.of<AuthenticationBloc>(context);
                   if (_securityBloc == null) {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1521 

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Added:

- Root bloc: to launch global events, I don't want to overload the other global blocs (Authetication, DeepLinks, Rates) so I crearte a new one the name was dififcult to chose (I consider names like: Main, SeedsApp, etc..) but I'm sure root fits very well to be the most top bloc in the app.
- Bus event with several named constructors.
- Logic in the SeedsApp to handle the global snack bar.
- First implementation on verification screen.

### 🙈 Screenshots
I enter wrong the pin to fire the snack bar, first time wait for close, sencond i press the close icon.
<img src="https://user-images.githubusercontent.com/42857405/150603675-c06ef777-0b4e-4d53-8e4a-5a4963af6221.gif" width="250">

### 👯‍♀️ Paired with

"nobody"
