### PR TITLE
Handle Passport 12 Words backups (Mnemonic)

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -311,13 +311,13 @@
 				"${BUILT_PRODUCTS_DIR}/leveldb-library/leveldb.framework",
 				"${BUILT_PRODUCTS_DIR}/local_auth/local_auth.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
-				"${BUILT_PRODUCTS_DIR}/path_provider_ios/path_provider_ios.framework",
+				"${BUILT_PRODUCTS_DIR}/path_provider/path_provider.framework",
 				"${BUILT_PRODUCTS_DIR}/qr_code_scanner/qr_code_scanner.framework",
 				"${BUILT_PRODUCTS_DIR}/share/share.framework",
 				"${BUILT_PRODUCTS_DIR}/shared_preferences_ios/shared_preferences_ios.framework",
 				"${BUILT_PRODUCTS_DIR}/sqflite/sqflite.framework",
 				"${BUILT_PRODUCTS_DIR}/uni_links/uni_links.framework",
-				"${BUILT_PRODUCTS_DIR}/url_launcher_ios/url_launcher_ios.framework",
+				"${BUILT_PRODUCTS_DIR}/url_launcher/url_launcher.framework",
 				"${BUILT_PRODUCTS_DIR}/webview_flutter_wkwebview/webview_flutter_wkwebview.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -349,13 +349,13 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/leveldb.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/local_auth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_ios.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/qr_code_scanner.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/share.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences_ios.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqflite.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/uni_links.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher_ios.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/webview_flutter_wkwebview.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/lib/datasource/local/auth_service.dart
+++ b/lib/datasource/local/auth_service.dart
@@ -1,4 +1,3 @@
-
 import 'package:hdkey/hdkey.dart';
 import 'package:seeds/crypto/eosdart_ecc/eosdart_ecc.dart';
 import 'package:seeds/datasource/local/models/auth_data_model.dart';
@@ -18,6 +17,10 @@ class AuthService {
   /// Creates a private key/12 words pair. From words
   AuthDataModel createPrivateKeyFromWords(List<String> words) {
     return AuthDataModel(_createPrivateKeyFrom12Words(words), words);
+  }
+
+  AuthDataModel privateKeyFromSeedsGlobalPassportWords(List<String> words) {
+    return AuthDataModel(createPrivateKeyFrom12WordsBip39(words), words);
   }
 
   /// Creates a private key from 12 words list

--- a/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
@@ -13,7 +13,7 @@ class GetWordsFromPrivateKey {
       final words = item.toList();
       return GenerateKeyFromRecoveryWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey ||
           GenerateKeyFromSeedsPassportWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey;
-    });
+    }, orElse: () => "");
 
     if (wordsString.isNotEmpty) {
       return wordsString.toList();

--- a/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
@@ -15,11 +15,7 @@ class GetWordsFromPrivateKey {
           GenerateKeyFromSeedsPassportWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey;
     }, orElse: () => "");
 
-    if (wordsString.isNotEmpty) {
-      return wordsString.toList();
-    } else {
-      return [];
-    }
+    return wordsString.isNotEmpty ? wordsString.toList() : [];
   }
 }
 

--- a/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
@@ -1,28 +1,29 @@
 import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/screens/authentication/import_key/interactor/usecases/generate_key_from_recovery_words_use_case.dart';
+import 'package:seeds/screens/authentication/import_key/interactor/usecases/generate_key_from_seeds_passport_words_use_case.dart';
 
 class GetWordsFromPrivateKey {
   /// If the private key has words, it returns the list of words
-  /// separated by a dash (-), otherwise an empty list.
+  /// otherwise an empty list.
   List<String> run() {
     final String privateKey = settingsStorage.privateKey!;
 
-    ///-------IS PRIVATE KEY 12 WORDS TYPE
-    // Convert all words into private keys
-    final List<String> privateKeysListFromWords = settingsStorage.recoveryWords
-        .map((i) => GenerateKeyFromRecoveryWordsUseCase().run(i.split('-')))
-        .toList()
-        .map((i) => '${i.eOSPrivateKey}')
-        .toList();
-    // Verify if there is a match with the selected private key
-    final bool is12WordsAccount = privateKeysListFromWords.contains(privateKey);
-    if (is12WordsAccount) {
-      final int wordsIndex = privateKeysListFromWords.indexOf(privateKey);
-      // Since the storage recover words and privateKeysListFromWords are map 1:1
-      // the index will be the same to get the target words
-      return settingsStorage.recoveryWords[wordsIndex].split('-');
+    final wordsString = settingsStorage.recoveryWords.firstWhere((item) {
+      final words = item.toList();
+      return GenerateKeyFromRecoveryWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey ||
+          GenerateKeyFromSeedsPassportWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey;
+    });
+
+    if (wordsString.isNotEmpty) {
+      return wordsString.toList();
     } else {
       return [];
     }
+  }
+}
+
+extension WordListString on String {
+  List<String> toList() {
+    return split("-");
   }
 }

--- a/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
@@ -21,6 +21,6 @@ class GetWordsFromPrivateKey {
 
 extension WordListString on String {
   List<String> toWordList() {
-    return split("-");
+    return split('-');
   }
 }

--- a/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
@@ -5,6 +5,7 @@ import 'package:seeds/screens/authentication/import_key/interactor/usecases/gene
 class GetWordsFromPrivateKey {
   /// If the private key has words, it returns the list of words
   /// otherwise an empty list.
+  /// Handles both passport and seeds light wallet style 12 words keys
   List<String> run() {
     final String privateKey = settingsStorage.privateKey!;
 

--- a/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
@@ -10,17 +10,17 @@ class GetWordsFromPrivateKey {
     final String privateKey = settingsStorage.privateKey!;
 
     final wordsString = settingsStorage.recoveryWords.firstWhere((item) {
-      final words = item.toList();
+      final words = item.toWordList();
       return GenerateKeyFromRecoveryWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey ||
           GenerateKeyFromSeedsPassportWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey;
     }, orElse: () => "");
 
-    return wordsString.isNotEmpty ? wordsString.toList() : [];
+    return wordsString.isNotEmpty ? wordsString.toWordList() : [];
   }
 }
 
 extension WordListString on String {
-  List<String> toList() {
+  List<String> toWordList() {
     return split("-");
   }
 }

--- a/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
@@ -13,7 +13,7 @@ class GetWordsFromPrivateKey {
       final words = item.toWordList();
       return GenerateKeyFromRecoveryWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey ||
           GenerateKeyFromSeedsPassportWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey;
-    }, orElse: () => "");
+    }, orElse: () => '');
 
     return wordsString.isNotEmpty ? wordsString.toWordList() : [];
   }

--- a/lib/screens/authentication/import_key/interactor/mappers/import_key_state_mapper.dart
+++ b/lib/screens/authentication/import_key/interactor/mappers/import_key_state_mapper.dart
@@ -6,22 +6,30 @@ import 'package:seeds/screens/authentication/import_key/import_key_errors.dart';
 import 'package:seeds/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart';
 
 class ImportKeyStateMapper extends StateMapper {
-  ImportKeyState mapResultsToState(ImportKeyState currentState, List<Result> results, AuthDataModel authData) {
+  ImportKeyState mapResultsToState({
+    required ImportKeyState currentState,
+    required AuthDataModel authData,
+    required List<Result> results,
+    AuthDataModel? alternateAuthData,
+    List<Result> alternateResults = const [],
+  }) {
+    final List<Result> goodResults = results.isNotEmpty ? results : alternateResults;
+    final AuthDataModel? goodAuthData = results.isNotEmpty ? authData : alternateAuthData;
     // No account found. Show error
-    if (results.isEmpty) {
+    if (goodResults.isEmpty) {
       return currentState.copyWith(pageState: PageState.failure, error: ImportKeyError.NoAccountsFound);
     }
 
     // Accounts found, but errors fetching data happened.
-    if (areAllResultsError(results)) {
+    if (areAllResultsError(goodResults)) {
       return currentState.copyWith(pageState: PageState.failure, error: ImportKeyError.UnableToLoadAccount);
     } else {
-      final List<ProfileModel> profiles = results
+      final List<ProfileModel> profiles = goodResults
           .where((Result result) => result.isValue)
           .map((Result result) => result.asValue!.value as ProfileModel)
           .toList();
 
-      return currentState.copyWith(pageState: PageState.success, accounts: profiles, authData: authData);
+      return currentState.copyWith(pageState: PageState.success, accounts: profiles, authData: goodAuthData);
     }
   }
 }

--- a/lib/screens/authentication/import_key/interactor/usecases/generate_key_from_seeds_passport_words_use_case.dart
+++ b/lib/screens/authentication/import_key/interactor/usecases/generate_key_from_seeds_passport_words_use_case.dart
@@ -1,0 +1,9 @@
+import 'package:seeds/datasource/local/auth_service.dart';
+import 'package:seeds/datasource/local/models/auth_data_model.dart';
+
+/// Uses 12 words recovery phrase to generate the private key.
+class GenerateKeyFromSeedsPassportWordsUseCase {
+  AuthDataModel run(List<String> recoveryWords) {
+    return AuthService().privateKeyFromSeedsGlobalPassportWords(recoveryWords);
+  }
+}

--- a/lib/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart
+++ b/lib/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart
@@ -30,13 +30,16 @@ class ImportKeyBloc extends Bloc<ImportKeyEvent, ImportKeyState> {
   Future<void> _findAccountByKey(FindAccountByKey event, Emitter<ImportKeyState> emit) async {
     emit(state.copyWith(pageState: PageState.loading));
     final publicKey = CheckPrivateKeyUseCase().isKeyValid(event.privateKey);
+    final alternatePublicKey =
+        event.alternatePrivateKey != null ? CheckPrivateKeyUseCase().isKeyValid(event.alternatePrivateKey!) : null;
+
     if (publicKey == null || publicKey.isEmpty) {
       emit(state.copyWith(pageState: PageState.failure, error: ImportKeyError.InvalidPrivateKey));
     } else {
       final results = await ImportKeyUseCase().run(publicKey);
-      final List<Result> alternateResults = event.alternatePrivateKey != null
-          ? await ImportKeyUseCase().run(CheckPrivateKeyUseCase().isKeyValid(event.alternatePrivateKey!)!)
-          : [];
+      final List<Result> alternateResults =
+          alternatePublicKey != null ? await ImportKeyUseCase().run(alternatePublicKey) : [];
+
       emit(
         ImportKeyStateMapper().mapResultsToState(
           currentState: state,

--- a/lib/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart
+++ b/lib/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart
@@ -59,11 +59,10 @@ class ImportKeyBloc extends Bloc<ImportKeyEvent, ImportKeyState> {
 
   void _findAccountFromWords(FindAccountFromWords event, Emitter<ImportKeyState> emit) {
     final authData = GenerateKeyFromRecoveryWordsUseCase().run(state.userEnteredWords.values.toList());
-    final authDataCompatibility =
-        GenerateKeyFromSeedsPassportWordsUseCase().run(state.userEnteredWords.values.toList());
+    final alternateAuthData = GenerateKeyFromSeedsPassportWordsUseCase().run(state.userEnteredWords.values.toList());
     add(FindAccountByKey(
       privateKey: authData.eOSPrivateKey.toString(),
-      alternatePrivateKey: authDataCompatibility.eOSPrivateKey.toString(),
+      alternatePrivateKey: alternateAuthData.eOSPrivateKey.toString(),
       words: authData.words,
     ));
   }

--- a/lib/screens/authentication/import_key/interactor/viewmodels/import_key_event.dart
+++ b/lib/screens/authentication/import_key/interactor/viewmodels/import_key_event.dart
@@ -9,9 +9,10 @@ abstract class ImportKeyEvent extends Equatable {
 
 class FindAccountByKey extends ImportKeyEvent {
   final String privateKey;
+  final String? alternatePrivateKey;
   final List<String> words;
 
-  const FindAccountByKey({required this.privateKey, required this.words});
+  const FindAccountByKey({required this.privateKey, this.alternatePrivateKey, required this.words});
 
   @override
   String toString() => 'FindAccountByKey';


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1488 

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

How it works: 
Check both light wallet and passport 12 word methods for key - only one of them will work any given time, since the chances of hitting a random key are the same as the chances cracking someone's key - basically won't happen.

Testcase A

- Created account testingsaaaaa on the global passport, noted down the recovery words
- Open LW, go to import account, import these words
- Works!! Woohoo.

Testcase B
- Import private key 
- Works!

Testcase C
- Create new LW account, store words, recover words
- Works!

### 🙈 Screenshots

Brand new passport account - created on the seeds global passport

![IMG_69915D311D17-1](https://user-images.githubusercontent.com/65412/150948361-692a4d4b-3662-4a08-b058-3d6ec336cce2.jpeg)

Entering words - note the account was found! This took 1 second. 

![Simulator Screen Shot - iPhone 13 - 2022-01-25 at 17 14 21](https://user-images.githubusercontent.com/65412/150948434-00398950-ff51-418a-ac6e-5d1009766629.jpg)

Inside the account
![Simulator Screen Shot - iPhone 13 - 2022-01-25 at 17 14 42](https://user-images.githubusercontent.com/65412/150948514-706df263-1b2f-4c03-9408-54703b922161.png)


### 👯‍♀️ Paired with