### PR TITLE
Paste recovery words feature

### DIFF
--- a/lib/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart
+++ b/lib/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart
@@ -19,6 +19,7 @@ class ImportKeyBloc extends Bloc<ImportKeyEvent, ImportKeyState> {
     on<OnPrivateKeyChange>(_onPrivateKeyChange);
     on<FindAccountByKey>(_findAccountByKey);
     on<OnWordChange>(_onWordChange);
+    on<OnWordsPasted>(_onWordsPasted);
     on<FindAccountFromWords>(_findAccountFromWords);
     on<AccountSelected>((event, emit) => emit(state.copyWith(accountSelected: event.account)));
   }
@@ -54,10 +55,20 @@ class ImportKeyBloc extends Bloc<ImportKeyEvent, ImportKeyState> {
     }
   }
 
+  bool _areAllWordsEntered(final Map<int, String> words) {
+    return words.length == 12 && !words.containsValue('');
+  }
+
   void _onWordChange(OnWordChange event, Emitter<ImportKeyState> emit) {
     final Map<int, String> enteredWords = Map.from(state.userEnteredWords);
     enteredWords[event.wordIndex] = event.word;
-    emit(state.copyWith(userEnteredWords: enteredWords, enableButton: state.areAllWordsEntered));
+    emit(state.copyWith(userEnteredWords: enteredWords, enableButton: _areAllWordsEntered(enteredWords)));
+  }
+
+  void _onWordsPasted(OnWordsPasted event, Emitter<ImportKeyState> emit) {
+    final words = event.words.asMap();
+    print("enable button ${_areAllWordsEntered(words)}");
+    emit(state.copyWith(userEnteredWords: words, enableButton: _areAllWordsEntered(words)));
   }
 
   void _findAccountFromWords(FindAccountFromWords event, Emitter<ImportKeyState> emit) {

--- a/lib/screens/authentication/import_key/interactor/viewmodels/import_key_event.dart
+++ b/lib/screens/authentication/import_key/interactor/viewmodels/import_key_event.dart
@@ -46,6 +46,15 @@ class OnWordChange extends ImportKeyEvent {
   String toString() => 'OnWordChange: { word: $word index: $wordIndex}';
 }
 
+class OnWordsPasted extends ImportKeyEvent {
+  final List<String> words;
+
+  const OnWordsPasted(this.words);
+
+  @override
+  String toString() => 'OnWordsPasted: { words: $words }';
+}
+
 class FindAccountFromWords extends ImportKeyEvent {
   const FindAccountFromWords();
 

--- a/lib/screens/authentication/import_key/interactor/viewmodels/import_key_state.dart
+++ b/lib/screens/authentication/import_key/interactor/viewmodels/import_key_state.dart
@@ -19,10 +19,6 @@ class ImportKeyState extends Equatable {
     this.accountSelected,
   });
 
-  bool get areAllWordsEntered {
-    return userEnteredWords.length == 12 && !userEnteredWords.containsValue('');
-  }
-
   @override
   List<Object?> get props => [
         pageState,


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

On recovery, allow user to paste words (DRAFT)

- [ ] Needs design @JGDoh 
- [ ] More testing
- [ ] Detect if clipboard has words? 
The problem with that is then the app would just load a user's clipboard without asking permission - I don't like it when apps do that, and on iOS this is now prominently displayed by the system (we have no control over this). 

Whenever an app accesses the clipboard, iOS shows a big snackbar that the app was pasting. 

Upside would be if we do it, then we know whether the clipboard has valid values, e.g. 12 words, and we could show the paste option prominently when valid words are detected, and hide it when they're not detected. 

In any case I think privacy concerns are more important. IMO better to only access the clipboard on an explicit user action.

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [ ] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Not sure this is the right approach to fill in the text fields - I need to keep track of text controllers, but Autocomplete also wants to track them. 

It does work though, also with later on editing the text fields, pasting other words, etc. 

Also finds the account. The screen video does not use real words since I don't want to post real private keys on GH...

### 🙈 Screenshots

https://user-images.githubusercontent.com/65412/151361578-e6a45275-251b-4f84-a36c-a9a4a306f88a.mov



### 👯‍♀️ Paired with
