### PR TITLE
Fix black bars on flag screen

### DIFF
--- a/lib/screens/explore_screens/flag/flags/flag_screen.dart
+++ b/lib/screens/explore_screens/flag/flags/flag_screen.dart
@@ -20,10 +20,11 @@ class FlagScreen extends StatelessWidget {
       create: (_) => FlagBloc()..add(const LoadUsersFlags()),
       child: BlocBuilder<FlagBloc, FlagState>(
         builder: (context, FlagState state) {
-          return SafeArea(
-            child: Scaffold(
-              appBar: AppBar(title: const Text('Flag')),
-              bottomSheet: Padding(
+          return Scaffold(
+            appBar: AppBar(title: const Text('Flag')),
+            bottomSheet: SafeArea(
+              minimum: const EdgeInsets.only(bottom: 16),
+              child: Padding(
                 padding: const EdgeInsets.all(16.0),
                 child: FlatButtonLong(
                   title: 'Flag a User',
@@ -37,7 +38,9 @@ class FlagScreen extends StatelessWidget {
                   },
                 ),
               ),
-              body: BlocBuilder<FlagBloc, FlagState>(
+            ),
+            body: SafeArea(
+              child: BlocBuilder<FlagBloc, FlagState>(
                 builder: (context, state) {
                   switch (state.pageState) {
                     case PageState.initial:


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1550

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Those Black bars show when we add the safeArea widget before the scaffold. 
For now I added the safeArea in the buddy of the scaffold. Please review screenshots for another Idea I had (: 

![image](https://user-images.githubusercontent.com/51983923/152287673-7a269987-5f8b-4b23-bcaf-31450de6b228.png)

 https://medium.com/flutter-community/flutter-widget-safe-area-the-whole-picture-523287ff69cf
![image](https://user-images.githubusercontent.com/51983923/152287501-1e3be5be-07be-437e-8d9e-327736925c79.png)

### 🙈 Screenshots

Is hard to make it looks nice for both android and IOS, however if we add a safeArea before scaffold 
and then set top safeArea to false we get: 
![image](https://user-images.githubusercontent.com/51983923/152288141-2ecbb6df-19e6-4e6a-93c8-ab3a1c9dc059.png)
![image](https://user-images.githubusercontent.com/51983923/152288147-1c7bf67d-b961-4f27-9700-f0df2cc9b48c.png)

It would show the black bar only in the bottom and it would look nice for both IOS and android. 
If you guys like this solution I will implemented on issue#1536

Down side for IOS will be having the bottom black bar

Now : 
![image](https://user-images.githubusercontent.com/51983923/152288760-f42add05-035d-4493-a2c5-b9a36e7d1783.png)

With Fix: 
![image](https://user-images.githubusercontent.com/51983923/152288772-45897dcf-c690-4c00-9bbf-0de332df5510.png)


### 👯‍♀️ Paired with

 "nobody"
