### PR TITLE
Simplified localizations using a buildcontext extension

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,3 +1,10 @@
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
+
+# Because the underlying Localizations widget is created as part of MaterialApp, 
+# and depending on what context we use, calling AppLocalizations.of(context)!
+# may or may not give us an object.
+# But in practice, all our widgets will be descendants of MaterialApp, so 
+# we shouldn't need to use the ! operator everywhere!
+nullable-getter: false

--- a/lib/components/search_user/components/search_user_text_field.dart
+++ b/lib/components/search_user/components/search_user_text_field.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/search_user/interactor/viewmodels/search_user_bloc.dart';
 import 'package:seeds/constants/app_colors.dart';
 import 'package:seeds/domain-shared/page_state.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class SearchUserTextField extends StatefulWidget {
   const SearchUserTextField({Key? key}) : super(key: key);
@@ -27,7 +27,6 @@ class _SearchUserTextFieldState extends State<SearchUserTextField> {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return TextField(
       autofocus: true,
       autocorrect: false,
@@ -57,7 +56,7 @@ class _SearchUserTextFieldState extends State<SearchUserTextField> {
         enabledBorder: _searchBorder,
         focusedBorder: _searchBorder,
         border: const OutlineInputBorder(borderRadius: BorderRadius.all(Radius.circular(8))),
-        hintText: localization.searchUserHintText,
+        hintText: context.loc.searchUserHintText,
       ),
     );
   }

--- a/lib/components/search_user/search_user.dart
+++ b/lib/components/search_user/search_user.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/search_result_row.dart';
 import 'package:seeds/components/search_user/components/search_user_text_field.dart';
 import 'package:seeds/components/search_user/interactor/viewmodels/search_user_bloc.dart';
 import 'package:seeds/datasource/remote/model/profile_model.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/domain-shared/ui_constants.dart';
-
+import 'package:seeds/utils/build_context_extension.dart';
 
 class SearchUser extends StatelessWidget {
   final String? title;
@@ -25,7 +24,6 @@ class SearchUser extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return BlocProvider<SearchUserBloc>(
       create: (_) => SearchUserBloc(noShowUsers, filterByCitizenshipStatus),
       child: Column(
@@ -57,7 +55,7 @@ class SearchUser extends StatelessWidget {
                   if (state.pageState == PageState.success && state.users.isEmpty) {
                     return Padding(
                       padding: const EdgeInsets.all(16.0),
-                      child: Center(child: Text(localization.searchUserNoUserFound)),
+                      child: Center(child: Text(context.loc.searchUserNoUserFound)),
                     );
                   } else {
                     return Expanded(

--- a/lib/constants/system_accounts.dart
+++ b/lib/constants/system_accounts.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/datasource/remote/model/profile_model.dart';
-
+import 'package:seeds/utils/build_context_extension.dart';
 
 // Seeds system accounts with special icons. Harvest account, onboarding account, etc.
 
@@ -42,13 +41,12 @@ class SystemAccounts {
 
   // Used to provide a localized display name for system accounts instead of using ProfileModel.nickname
   static String? getLocalizedDisplayNameForSystemAccount(String accountName, BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     if (accountName == 'join.seeds') {
-      return localization.constantOnboardingContract;
+      return context.loc.constantOnboardingContract;
     } else if (accountName == 'tlosto.seeds') {
-      return localization.constantExchangeContract;
+      return context.loc.constantExchangeContract;
     } else if (accountName == 'harvst.seeds') {
-      return localization.constantHarvestContract;
+      return context.loc.constantHarvestContract;
     } else {
       return null;
     }

--- a/lib/domain-shared/global_error.dart
+++ b/lib/domain-shared/global_error.dart
@@ -1,14 +1,13 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 enum GlobalError { unknown }
 
 extension LocalizedGlobalError on GlobalError {
   String localizedDescription(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     switch (this) {
       case GlobalError.unknown:
-        return localization.globalUnknownError;
+        return context.loc.globalUnknownError;
     }
   }
 }

--- a/lib/screens/authentication/import_key/import_key_errors.dart
+++ b/lib/screens/authentication/import_key/import_key_errors.dart
@@ -1,20 +1,19 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 enum ImportKeyError { invalidPrivateKey, noAccountsFound, unableToLoadAccount, noPublicKeyFound }
 
 extension LocalizedImportKeyError on ImportKeyError {
   String localizedDescription(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     switch (this) {
       case ImportKeyError.invalidPrivateKey:
-        return localization.importKeyInvalidPrivateKeyError;
+        return context.loc.importKeyInvalidPrivateKeyError;
       case ImportKeyError.noAccountsFound:
-        return localization.importKeyNoAccountsFoundError;
+        return context.loc.importKeyNoAccountsFoundError;
       case ImportKeyError.unableToLoadAccount:
-        return localization.importKeyUnableToLoadAccountError;
+        return context.loc.importKeyUnableToLoadAccountError;
       case ImportKeyError.noPublicKeyFound:
-        return localization.importKeyNoPublicKeyFoundError;
+        return context.loc.importKeyNoPublicKeyFoundError;
     }
   }
 }

--- a/lib/screens/authentication/import_key/import_key_screen.dart
+++ b/lib/screens/authentication/import_key/import_key_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/flat_button_long.dart';
 import 'package:seeds/components/text_form_field_custom.dart';
 import 'package:seeds/constants/app_colors.dart';
@@ -10,6 +9,7 @@ import 'package:seeds/design/app_theme.dart';
 import 'package:seeds/navigation/navigation_service.dart';
 import 'package:seeds/screens/authentication/import_key/components/import_key_accounts_widget.dart';
 import 'package:seeds/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class ImportKeyScreen extends StatefulWidget {
   const ImportKeyScreen({Key? key}) : super(key: key);
@@ -45,7 +45,6 @@ class _ImportKeyScreenState extends State<ImportKeyScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return BlocProvider(
       create: (_) => _importKeyBloc,
       child: BlocBuilder<ImportKeyBloc, ImportKeyState>(
@@ -54,7 +53,7 @@ class _ImportKeyScreenState extends State<ImportKeyScreen> {
             bottomSheet: Padding(
               padding: const EdgeInsets.all(16),
               child: FlatButtonLong(
-                  title: localization.importKeySearchButtonTitle,
+                  title: context.loc.importKeySearchButtonTitle,
                   onPressed: () => _onSubmitted(),
                   enabled: state.enableButton),
             ),
@@ -71,7 +70,7 @@ class _ImportKeyScreenState extends State<ImportKeyScreen> {
                       children: [
                         TextFormFieldCustom(
                           autofocus: true,
-                          labelText: localization.importKeyPrivateKeyFieldPlaceholder,
+                          labelText: context.loc.importKeyPrivateKeyFieldPlaceholder,
                           suffixIcon: IconButton(
                             icon: const Icon(Icons.paste, color: AppColors.white),
                             onPressed: () async {
@@ -104,7 +103,7 @@ class _ImportKeyScreenState extends State<ImportKeyScreen> {
                         style: Theme.of(context).textTheme.subtitle2,
                         children: <TextSpan>[
                           TextSpan(
-                              text: localization.importKeyImportUsingRecoveryPhraseActionLink,
+                              text: context.loc.importKeyImportUsingRecoveryPhraseActionLink,
                               style: Theme.of(context).textTheme.subtitle2Green2,
                               recognizer: TapGestureRecognizer()
                                 ..onTap = () {
@@ -112,7 +111,7 @@ class _ImportKeyScreenState extends State<ImportKeyScreen> {
                                   NavigationService.of(context).navigateTo(Routes.importWords);
                                 }),
                           const TextSpan(text: " "),
-                          TextSpan(text: localization.importKeyImportUsingRecoveryPhraseDescription),
+                          TextSpan(text: context.loc.importKeyImportUsingRecoveryPhraseDescription),
                         ],
                       ),
                     ),

--- a/lib/screens/authentication/import_key/import_words_screen.dart
+++ b/lib/screens/authentication/import_key/import_words_screen.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/flat_button_long.dart';
 import 'package:seeds/design/app_theme.dart';
 import 'package:seeds/domain-shared/ui_constants.dart';
 import 'package:seeds/navigation/navigation_service.dart';
 import 'package:seeds/screens/authentication/import_key/components/import_key_accounts_widget.dart';
 import 'package:seeds/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 import 'package:seeds/utils/mnemonic_code/words_list.dart';
 
 const _numberOfWords = 12;
@@ -18,7 +18,6 @@ class ImportWordsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return BlocProvider(
       create: (_) => ImportKeyBloc(),
       child: BlocBuilder<ImportKeyBloc, ImportKeyState>(
@@ -27,7 +26,7 @@ class ImportWordsScreen extends StatelessWidget {
             bottomSheet: Padding(
               padding: const EdgeInsets.all(16),
               child: FlatButtonLong(
-                title: localization.importKeySearchButtonTitle,
+                title: context.loc.importKeySearchButtonTitle,
                 onPressed: () {
                   FocusScope.of(context).unfocus();
                   BlocProvider.of<ImportKeyBloc>(context).add(const FindAccountFromWords());
@@ -44,7 +43,7 @@ class ImportWordsScreen extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       Text(
-                        localization.importKeyImportUsingRecoveryPhraseTitle,
+                        context.loc.importKeyImportUsingRecoveryPhraseTitle,
                         style: Theme.of(context).textTheme.subtitle3,
                         textAlign: TextAlign.left,
                       ),
@@ -107,7 +106,7 @@ class ImportWordsScreen extends StatelessWidget {
                             style: Theme.of(context).textTheme.subtitle2,
                             children: <TextSpan>[
                               TextSpan(
-                                text: localization.importKeyImportUsingPrivateKeyActionLink,
+                                text: context.loc.importKeyImportUsingPrivateKeyActionLink,
                                 style: Theme.of(context).textTheme.subtitle2Green2,
                                 recognizer: TapGestureRecognizer()
                                   ..onTap = () {
@@ -116,7 +115,7 @@ class ImportWordsScreen extends StatelessWidget {
                                   },
                               ),
                               const TextSpan(text: " "),
-                              TextSpan(text: localization.importKeyImportUsingPrivateKeyDescription),
+                              TextSpan(text: context.loc.importKeyImportUsingPrivateKeyDescription),
                             ],
                           ),
                         ),

--- a/lib/screens/authentication/login_screen.dart
+++ b/lib/screens/authentication/login_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:seeds/components/flat_button_long.dart';
 import 'package:seeds/components/flat_button_long_outlined.dart';
@@ -9,6 +8,7 @@ import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
 import 'package:seeds/design/app_theme.dart';
 import 'package:seeds/navigation/navigation_service.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 const int _approxWidgetHeight = 450;
 
@@ -17,7 +17,6 @@ class LoginScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     final double height = MediaQuery.of(context).size.height;
     return Scaffold(
       bottomSheet: Padding(
@@ -35,10 +34,10 @@ class LoginScreen extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Text(localization.loginRecoverAccountActionSegment1, style: Theme.of(context).textTheme.subtitle2),
-              Text(localization.loginRecoverAccountActionLink,
+              Text(context.loc.loginRecoverAccountActionSegment1, style: Theme.of(context).textTheme.subtitle2),
+              Text(context.loc.loginRecoverAccountActionLink,
                   style: Theme.of(context).textTheme.subtitle2HighEmphasisGreen1),
-              Text(localization.loginRecoverAccountActionSegment2, style: Theme.of(context).textTheme.subtitle2),
+              Text(context.loc.loginRecoverAccountActionSegment2, style: Theme.of(context).textTheme.subtitle2),
             ],
           ),
         ),
@@ -61,14 +60,14 @@ class LoginScreen extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(localization.loginFirstTimeHere, style: Theme.of(context).textTheme.subtitle2),
+                    Text(context.loc.loginFirstTimeHere, style: Theme.of(context).textTheme.subtitle2),
                     const SizedBox(height: 10),
                     FlatButtonLong(
                       onPressed: () => NavigationService.of(context).navigateTo(Routes.signup),
-                      title: localization.loginClaimInviteCodeButtonTitle,
+                      title: context.loc.loginClaimInviteCodeButtonTitle,
                     ),
                     const SizedBox(height: 40),
-                    Text(localization.loginAlreadyHaveAnAccount, style: Theme.of(context).textTheme.subtitle2),
+                    Text(context.loc.loginAlreadyHaveAnAccount, style: Theme.of(context).textTheme.subtitle2),
                     const SizedBox(height: 10),
                     FlatButtonLongOutlined(
                       onPressed: () {
@@ -80,7 +79,7 @@ class LoginScreen extends StatelessWidget {
                           NavigationService.of(context).navigateTo(Routes.importKey);
                         }
                       },
-                      title: localization.loginImportAccountButtonTitle,
+                      title: context.loc.loginImportAccountButtonTitle,
                     )
                   ],
                 ),

--- a/lib/screens/authentication/onboarding/components/pages/onboarding_page_1.dart
+++ b/lib/screens/authentication/onboarding/components/pages/onboarding_page_1.dart
@@ -1,19 +1,18 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:seeds/screens/authentication/onboarding/components/onboarding_pages.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class FirstPage extends StatelessWidget {
   const FirstPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return OnboardingPage(
       onboardingImage: "assets/images/onboarding/onboarding5.png",
       topPadding: 30,
-      title: localization.onboardingTransactionsTitle,
-      subTitle: localization.onboardingTransactionsSubtitle,
+      title: context.loc.onboardingTransactionsTitle,
+      subTitle: context.loc.onboardingTransactionsSubtitle,
       topLeaf1: Positioned(
         right: 80,
         top: -10,

--- a/lib/screens/authentication/onboarding/components/pages/onboarding_page_2.dart
+++ b/lib/screens/authentication/onboarding/components/pages/onboarding_page_2.dart
@@ -1,20 +1,19 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:seeds/constants/app_colors.dart';
 import 'package:seeds/screens/authentication/onboarding/components/onboarding_pages.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class SecondPage extends StatelessWidget {
   const SecondPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return OnboardingPage(
       onboardingImage: "assets/images/onboarding/onboarding1.png",
       topPadding: 50,
-      title: localization.onboardingCampaignsTitle,
-      subTitle: localization.onboardingCampaignsSubtitle,
+      title: context.loc.onboardingCampaignsTitle,
+      subTitle: context.loc.onboardingCampaignsSubtitle,
       topLeaf1: Positioned(
         left: 40,
         top: 40,

--- a/lib/screens/authentication/onboarding/components/pages/onboarding_page_3.dart
+++ b/lib/screens/authentication/onboarding/components/pages/onboarding_page_3.dart
@@ -1,20 +1,19 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:seeds/constants/app_colors.dart';
 import 'package:seeds/screens/authentication/onboarding/components/onboarding_pages.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class ThirdPage extends StatelessWidget {
   const ThirdPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return OnboardingPage(
       onboardingImage: "assets/images/onboarding/onboarding3.png",
       topPadding: 50,
-      title: localization.onboardingEconomyTitle,
-      subTitle: localization.onboardingEconomySubtitle,
+      title: context.loc.onboardingEconomyTitle,
+      subTitle: context.loc.onboardingEconomySubtitle,
       topLeaf1: Positioned(
         right: -20,
         top: -90,

--- a/lib/screens/authentication/onboarding/onboarding_screen.dart
+++ b/lib/screens/authentication/onboarding/onboarding_screen.dart
@@ -1,11 +1,11 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/dots_indicator.dart';
 import 'package:seeds/navigation/navigation_service.dart';
 import 'package:seeds/screens/authentication/onboarding/components/pages/onboarding_page_1.dart';
 import 'package:seeds/screens/authentication/onboarding/components/pages/onboarding_page_2.dart';
 import 'package:seeds/screens/authentication/onboarding/components/pages/onboarding_page_3.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({Key? key}) : super(key: key);
@@ -39,7 +39,6 @@ class OnboardingState extends State<OnboardingScreen> {
   @override
   Widget build(BuildContext context) {
     final double height = MediaQuery.of(context).size.height;
-    final localization = AppLocalizations.of(context)!;
     return Scaffold(
       body: SafeArea(
         top: false,
@@ -75,7 +74,7 @@ class OnboardingState extends State<OnboardingScreen> {
                             child: InkWell(
                               onTap: () => NavigationService.of(context).navigateTo(Routes.login, null, true),
                               child: Text(
-                                localization.onboardingJoinButtonTitle,
+                                context.loc.onboardingJoinButtonTitle,
                                 maxLines: 2,
                                 overflow: TextOverflow.ellipsis,
                                 style: Theme.of(context).textTheme.subtitle1,

--- a/lib/screens/authentication/recover/recover_account_found/recover_account_found_errors.dart
+++ b/lib/screens/authentication/recover/recover_account_found/recover_account_found_errors.dart
@@ -1,16 +1,15 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
-enum RecoverAccountFoundError{ noGuardians, unknown}
+enum RecoverAccountFoundError { noGuardians, unknown }
 
 extension LocalizedRecoverAccountErrors on RecoverAccountFoundError {
   String localizedDescription(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     switch (this) {
       case RecoverAccountFoundError.noGuardians:
-        return localization.recoverAccountFoundMapperNoGuardiansError;
+        return context.loc.recoverAccountFoundMapperNoGuardiansError;
       case RecoverAccountFoundError.unknown:
-        return localization.recoverAccountFoundMapperUnknownError;
+        return context.loc.recoverAccountFoundMapperUnknownError;
     }
   }
 }

--- a/lib/screens/authentication/recover/recover_account_found/recover_account_found_screen.dart
+++ b/lib/screens/authentication/recover/recover_account_found/recover_account_found_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/blocs/authentication/viewmodels/authentication_bloc.dart';
 import 'package:seeds/components/divider_jungle.dart';
 import 'package:seeds/components/flat_button_long.dart';
@@ -19,6 +18,7 @@ import 'package:seeds/screens/authentication/recover/recover_account_found/compo
 import 'package:seeds/screens/authentication/recover/recover_account_found/interactor/viewmodels/recover_account_found_bloc.dart';
 import 'package:seeds/screens/authentication/recover/recover_account_found/interactor/viewmodels/recover_account_found_page_command.dart';
 import 'package:seeds/screens/authentication/recover/recover_account_found/recover_account_found_errors.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 import 'package:share/share.dart';
 
 class RecoverAccountFoundScreen extends StatelessWidget {
@@ -28,7 +28,6 @@ class RecoverAccountFoundScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     // ignore: cast_nullable_to_non_nullable
     final String userAccount = ModalRoute.of(context)!.settings.arguments as String;
-    final localization = AppLocalizations.of(context)!;
     return BlocProvider(
       create: (_) => RecoverAccountFoundBloc(userAccount)..add(const FetchInitialData()),
       child: BlocConsumer<RecoverAccountFoundBloc, RecoverAccountFoundState>(
@@ -38,7 +37,7 @@ class RecoverAccountFoundScreen extends StatelessWidget {
           BlocProvider.of<RecoverAccountFoundBloc>(context).add(const ClearRecoverPageCommand());
 
           if (pageCommand is ShowLinkCopied) {
-            eventBus.fire(ShowSnackBar.success(localization.recoverAccountFoundShowLinkCopied));
+            eventBus.fire(ShowSnackBar.success(context.loc.recoverAccountFoundShowLinkCopied));
           } else if (pageCommand is ShowErrorMessage) {
             eventBus.fire(ShowSnackBar(pageCommand.message));
           } else if (pageCommand is CancelRecoveryProcess) {
@@ -56,7 +55,7 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                 appBar: AppBar(
                   title: Padding(
                       padding: const EdgeInsets.only(left: 16),
-                      child: Text(localization.recoverAccountFoundAppBarTitle)),
+                      child: Text(context.loc.recoverAccountFoundAppBarTitle)),
                   automaticallyImplyLeading: false,
                   actions: [
                     Padding(
@@ -76,7 +75,6 @@ class RecoverAccountFoundScreen extends StatelessWidget {
   }
 
   Widget buildBody(RecoverAccountFoundState state, BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     switch (state.pageState) {
       case PageState.initial:
         return const SizedBox.shrink();
@@ -84,9 +82,8 @@ class RecoverAccountFoundScreen extends StatelessWidget {
         return const FullPageLoadingIndicator();
       case PageState.failure:
         return FullPageErrorIndicator(
-          errorMessage:
-              state.error?.localizedDescription(context) ?? GlobalError.unknown.localizedDescription(context),
-          buttonTitle: localization.recoverAccountFoundFullPageErrorIndicatorTitle,
+          errorMessage: state.error?.localizedDescription(context) ?? GlobalError.unknown.localizedDescription(context),
+          buttonTitle: context.loc.recoverAccountFoundFullPageErrorIndicatorTitle,
           buttonOnPressed: () => BlocProvider.of<RecoverAccountFoundBloc>(context).add(const OnCancelProcessTapped()),
         );
       case PageState.success:
@@ -103,7 +100,7 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                           padding: const EdgeInsets.only(left: 8, right: 8, top: 8),
                           child: TextFormFieldCustom(
                             enabled: false,
-                            labelText: localization.recoverAccountFoundLinkTitle,
+                            labelText: context.loc.recoverAccountFoundLinkTitle,
                             suffixIcon: const SizedBox.shrink(),
                             controller: TextEditingController(text: state.linkToActivateGuardians?.toString()),
                           ),
@@ -134,7 +131,7 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                           const SizedBox(width: 24),
                           Flexible(
                             child: Text(
-                              localization.recoverAccountFoundGuardiansAcceptedTitle,
+                              context.loc.recoverAccountFoundGuardiansAcceptedTitle,
                               style: Theme.of(context).textTheme.buttonLowEmphasis,
                             ),
                           ),
@@ -158,7 +155,7 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                     Padding(
                       padding: const EdgeInsets.all(16),
                       child: FlatButtonLong(
-                        title: localization.recoverAccountFoundFullPageErrorIndicatorTitle,
+                        title: context.loc.recoverAccountFoundFullPageErrorIndicatorTitle,
                         onPressed: () =>
                             BlocProvider.of<RecoverAccountFoundBloc>(context).add(const OnCancelProcessTapped()),
                       ),
@@ -173,7 +170,7 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                 padding: const EdgeInsets.all(horizontalEdgePadding),
                 child: FlatButtonLong(
                   enabled: state.recoveryStatus == RecoveryStatus.readyToClaimAccount,
-                  title: localization.recoverAccountFoundClaimButtonTitle,
+                  title: context.loc.recoverAccountFoundClaimButtonTitle,
                   onPressed: () => BlocProvider.of<RecoverAccountFoundBloc>(context).add(const OnClaimAccountTapped()),
                 ),
               ),
@@ -187,7 +184,7 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                         Padding(
                           padding: const EdgeInsets.all(16.0),
                           child: Text(
-                            localization.recoverAccountFoundAllGuardiansAcceptedTitle,
+                            context.loc.recoverAccountFoundAllGuardiansAcceptedTitle,
                             style: Theme.of(context).textTheme.subtitle2LowEmphasis,
                             textAlign: TextAlign.center,
                           ),
@@ -226,7 +223,7 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                             ),
                             Padding(
                               padding: const EdgeInsets.only(top: 14),
-                              child: Text(localization.recoverAccountFoundHoursLeft,
+                              child: Text(context.loc.recoverAccountFoundHoursLeft,
                                   style: Theme.of(context).textTheme.subtitle2),
                             )
                           ],
@@ -235,7 +232,7 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                         if (state.recoveryStatus == RecoveryStatus.readyToClaimAccount)
                           Row(
                             mainAxisAlignment: MainAxisAlignment.center,
-                            children: [Text(localization.recoverAccountFoundRecoveredTitle), Text(state.userAccount)],
+                            children: [Text(context.loc.recoverAccountFoundRecoveredTitle), Text(state.userAccount)],
                           ),
                         const SizedBox(height: 150),
                       ],

--- a/lib/screens/authentication/recover/recover_account_search/recover_account_search_errors.dart
+++ b/lib/screens/authentication/recover/recover_account_search/recover_account_search_errors.dart
@@ -1,20 +1,19 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 enum RecoverAccountSearchError { noActiveGuardians, unableToLoadGuardians, unableToLoadAccount, invalidAccount }
 
 extension LocalizedRecoverAccountErrors on RecoverAccountSearchError {
   String localizedDescription(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     switch (this) {
       case RecoverAccountSearchError.noActiveGuardians:
-        return localization.recoverAccountSearchErrorNoActiveGuardians;
+        return context.loc.recoverAccountSearchErrorNoActiveGuardians;
       case RecoverAccountSearchError.unableToLoadGuardians:
-        return localization.recoverAccountSearchErrorLoadingGuardians;
+        return context.loc.recoverAccountSearchErrorLoadingGuardians;
       case RecoverAccountSearchError.unableToLoadAccount:
-        return localization.recoverAccountSearchErrorLoadingAccount;
+        return context.loc.recoverAccountSearchErrorLoadingAccount;
       case RecoverAccountSearchError.invalidAccount:
-        return localization.recoverAccountSearchErrorNoValidAccount;
+        return context.loc.recoverAccountSearchErrorNoValidAccount;
     }
   }
 }

--- a/lib/screens/authentication/recover/recover_account_search/recover_account_search_screen.dart
+++ b/lib/screens/authentication/recover/recover_account_search/recover_account_search_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/flat_button_long.dart';
 import 'package:seeds/components/quadstate_clipboard_icon_button.dart';
 import 'package:seeds/components/search_result_row.dart';
@@ -14,6 +13,7 @@ import 'package:seeds/navigation/navigation_service.dart';
 import 'package:seeds/screens/authentication/recover/recover_account_search/interactor/viewmodels/recover_account_page_command.dart';
 import 'package:seeds/screens/authentication/recover/recover_account_search/interactor/viewmodels/recover_account_search_bloc.dart';
 import 'package:seeds/screens/authentication/recover/recover_account_search/recover_account_search_errors.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 import 'package:seeds/utils/debouncer.dart';
 
 class RecoverAccountSearchScreen extends StatefulWidget {
@@ -52,13 +52,12 @@ class _RecoverAccountSearchScreenState extends State<RecoverAccountSearchScreen>
           }
         },
         builder: (context, state) {
-          final localization = AppLocalizations.of(context)!;
           return Scaffold(
             appBar: AppBar(),
             bottomSheet: Padding(
               padding: const EdgeInsets.all(horizontalEdgePadding),
               child: FlatButtonLong(
-                title: localization.recoverAccountSearchButtonTitle,
+                title: context.loc.recoverAccountSearchButtonTitle,
                 enabled: state.isGuardianActive,
                 onPressed: () => BlocProvider.of<RecoverAccountSearchBloc>(context).add(const OnNextButtonTapped()),
               ),
@@ -72,7 +71,7 @@ class _RecoverAccountSearchScreenState extends State<RecoverAccountSearchScreen>
                     TextFormFieldCustom(
                       maxLength: 12,
                       counterText: null,
-                      labelText: localization.recoverAccountSearchTextFormTitle,
+                      labelText: context.loc.recoverAccountSearchTextFormTitle,
                       controller: _keyController,
                       suffixIcon: QuadStateClipboardIconButton(
                         isChecked: state.isGuardianActive,

--- a/lib/screens/authentication/sign_up/claim_invite_screen.dart
+++ b/lib/screens/authentication/sign_up/claim_invite_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/blocs/deeplink/viewmodels/deeplink_bloc.dart';
 import 'package:seeds/components/scanner/scanner_view.dart';
 import 'package:seeds/constants/app_colors.dart';
@@ -11,6 +10,7 @@ import 'package:seeds/navigation/navigation_service.dart';
 import 'package:seeds/screens/authentication/sign_up/components/invite_link_fail_dialog.dart';
 import 'package:seeds/screens/authentication/sign_up/viewmodels/page_commands.dart';
 import 'package:seeds/screens/authentication/sign_up/viewmodels/signup_bloc.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class ClaimInviteScreen extends StatefulWidget {
   const ClaimInviteScreen({Key? key}) : super(key: key);
@@ -32,7 +32,6 @@ class _ClaimInviteScreenState extends State<ClaimInviteScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return BlocListener<SignupBloc, SignupState>(
       listenWhen: (_, current) => current.pageCommand != null,
       listener: (context, state) async {
@@ -59,7 +58,7 @@ class _ClaimInviteScreenState extends State<ClaimInviteScreen> {
           final view = state.claimInviteView;
           switch (view) {
             case ClaimInviteView.scanner:
-              return Scaffold(appBar: AppBar(title: Text(localization.signUpScanQRCode)), body: _scannerWidget);
+              return Scaffold(appBar: AppBar(title: Text(context.loc.signUpScanQRCode)), body: _scannerWidget);
             case ClaimInviteView.processing:
             case ClaimInviteView.success:
             case ClaimInviteView.fail:
@@ -80,7 +79,7 @@ class _ClaimInviteScreenState extends State<ClaimInviteScreen> {
                                 ),
                                 const SizedBox(height: 30),
                                 Text(
-                                  localization.signUpProcessingYourInvitation,
+                                  context.loc.signUpProcessingYourInvitation,
                                   style: Theme.of(context).textTheme.headline7,
                                 )
                               ],
@@ -90,7 +89,7 @@ class _ClaimInviteScreenState extends State<ClaimInviteScreen> {
                               children: [
                                 const CustomPaint(size: Size(70, 70), painter: InviteLinkSuccess()),
                                 const SizedBox(height: 30),
-                                Text(localization.signUpSuccess, style: Theme.of(context).textTheme.headline7),
+                                Text(context.loc.signUpSuccess, style: Theme.of(context).textTheme.headline7),
                               ],
                             ),
                         ],

--- a/lib/screens/authentication/sign_up/components/invite_link_fail_dialog.dart
+++ b/lib/screens/authentication/sign_up/components/invite_link_fail_dialog.dart
@@ -1,22 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/custom_dialog.dart';
 import 'package:seeds/constants/app_colors.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class InviteLinkFailDialog extends StatelessWidget {
   const InviteLinkFailDialog({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return CustomDialog(
       icon: const Icon(Icons.cancel_outlined, size: 60, color: AppColors.red),
-      singleLargeButtonTitle: localization.signUpCloseButtonTitle,
+      singleLargeButtonTitle: context.loc.signUpCloseButtonTitle,
       children: [
-        Text(localization.signUpInviteCodeErrorTitle, style: Theme.of(context).textTheme.headline6),
+        Text(context.loc.signUpInviteCodeErrorTitle, style: Theme.of(context).textTheme.headline6),
         const SizedBox(height: 24.0),
         Text(
-          localization.signUpInviteCodeErrorDescription,
+          context.loc.signUpInviteCodeErrorDescription,
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.subtitle2,
         ),

--- a/lib/screens/authentication/sign_up/create_account_name_screen.dart
+++ b/lib/screens/authentication/sign_up/create_account_name_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/flat_button_long.dart';
 import 'package:seeds/components/full_page_loading_indicator.dart';
 import 'package:seeds/components/quadstate_clipboard_icon_button.dart';
@@ -13,6 +12,7 @@ import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/screens/authentication/sign_up/signup_errors.dart';
 import 'package:seeds/screens/authentication/sign_up/viewmodels/page_commands.dart';
 import 'package:seeds/screens/authentication/sign_up/viewmodels/signup_bloc.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 import 'package:seeds/utils/debouncer.dart';
 
 class CreateAccountNameScreen extends StatefulWidget {
@@ -41,7 +41,6 @@ class _CreateAccountNameStateScreen extends State<CreateAccountNameScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return WillPopScope(
       onWillPop: _navigateBack,
       child: BlocConsumer<SignupBloc, SignupState>(
@@ -72,7 +71,7 @@ class _CreateAccountNameStateScreen extends State<CreateAccountNameScreen> {
                           key: _usernameFormKey,
                           child: TextFormFieldCustom(
                             maxLength: 12,
-                            labelText: localization.signUpUsernameTitle,
+                            labelText: context.loc.signUpUsernameTitle,
                             controller: _keyController,
                             errorText: state.error?.localizedDescription(context),
                             suffixIcon: QuadStateClipboardIconButton(
@@ -89,12 +88,12 @@ class _CreateAccountNameStateScreen extends State<CreateAccountNameScreen> {
                         const SizedBox(height: 10),
                         Expanded(
                           child: Text(
-                            localization.signUpUsernameDescription,
+                            context.loc.signUpUsernameDescription,
                             style: Theme.of(context).textTheme.subtitle2OpacityEmphasis,
                           ),
                         ),
                         FlatButtonLong(
-                          title: localization.signUpCreateAccountButtonTitle,
+                          title: context.loc.signUpCreateAccountButtonTitle,
                           onPressed: state.isNextButtonActive
                               ? () {
                                   FocusScope.of(context).unfocus();

--- a/lib/screens/authentication/sign_up/create_display_name_screen.dart
+++ b/lib/screens/authentication/sign_up/create_display_name_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/flat_button_long.dart';
 import 'package:seeds/components/text_form_field_custom.dart';
 import 'package:seeds/design/app_theme.dart';
 import 'package:seeds/screens/authentication/sign_up/viewmodels/signup_bloc.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 import 'package:seeds/utils/string_extension.dart';
 
 class CreateDisplayNameScreen extends StatefulWidget {
@@ -36,7 +36,6 @@ class _CreateDisplayNameStateScreen extends State<CreateDisplayNameScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return WillPopScope(
       onWillPop: _navigateBack,
       child: BlocBuilder<SignupBloc, SignupState>(
@@ -51,23 +50,23 @@ class _CreateDisplayNameStateScreen extends State<CreateDisplayNameScreen> {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: <Widget>[
                     TextFormFieldCustom(
-                      labelText: localization.signUpFullNameTitle,
+                      labelText: context.loc.signUpFullNameTitle,
                       onFieldSubmitted: (_) => _onNextPressed(),
                       maxLength: 36,
                       controller: _keyController,
                       validator: (value) {
                         if (value.isNullOrEmpty) {
-                          return localization.signUpNameCannotBeEmpty;
+                          return context.loc.signUpNameCannotBeEmpty;
                         }
                         return null;
                       },
                     ),
                     Expanded(
                         child: Text(
-                      localization.signUpFullNameDescription,
+                      context.loc.signUpFullNameDescription,
                       style: Theme.of(context).textTheme.subtitle2OpacityEmphasis,
                     )),
-                    FlatButtonLong(onPressed: _onNextPressed(), title: localization.signUpNextButtonTitle),
+                    FlatButtonLong(onPressed: _onNextPressed(), title: context.loc.signUpNextButtonTitle),
                   ],
                 ),
               ),

--- a/lib/screens/authentication/sign_up/signup_errors.dart
+++ b/lib/screens/authentication/sign_up/signup_errors.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 enum SignUpError {
   failedToCreateAccount,
@@ -17,30 +17,29 @@ enum SignUpError {
 
 extension LocalizedSignUpError on SignUpError {
   String localizedDescription(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     switch (this) {
       case SignUpError.failedToCreateAccount:
-        return localization.signUpErrorFailedToCreateAccount;
+        return context.loc.signUpErrorFailedToCreateAccount;
       case SignUpError.usernameAlreadyTaken:
-        return localization.signUpErrorUsernameAlreadyTaken;
+        return context.loc.signUpErrorUsernameAlreadyTaken;
       case SignUpError.noInvitesFound:
-        return localization.signUpErrorNoInvitesFound;
+        return context.loc.signUpErrorNoInvitesFound;
       case SignUpError.inviteAlreadyClaimed:
-        return localization.signUpErrorInviteAlreadyClaimed;
+        return context.loc.signUpErrorInviteAlreadyClaimed;
       case SignUpError.inviteHashNotFound:
-        return localization.signUpErrorInviteHashNotFound;
+        return context.loc.signUpErrorInviteHashNotFound;
       case SignUpError.qRCodeScanFailed:
-        return localization.signUpErrorQRCodeScanFailed;
+        return context.loc.signUpErrorQRCodeScanFailed;
       case SignUpError.validationFailedSelectUsername:
-        return localization.signUpErrorValidationFailedSelectUsername;
+        return context.loc.signUpErrorValidationFailedSelectUsername;
       case SignUpError.validationFailedOnlyNumbers15:
-        return localization.signUpErrorValidationFailedOnlyNumbers15;
+        return context.loc.signUpErrorValidationFailedOnlyNumbers15;
       case SignUpError.validationFailedNameLowercaseOnly:
-        return localization.signUpErrorValidationFailedNameLowercaseOnly;
+        return context.loc.signUpErrorValidationFailedNameLowercaseOnly;
       case SignUpError.validationFailedNoSpecialCharactersOrSpaces:
-        return localization.signUpErrorValidationFailedNoSpecialCharactersOrSpaces;
+        return context.loc.signUpErrorValidationFailedNoSpecialCharactersOrSpaces;
       case SignUpError.validationFailedUsernameMustBe12Characters:
-        return localization.signUpErrorValidationFailedUsernameMustBe12Characters;
+        return context.loc.signUpErrorValidationFailedUsernameMustBe12Characters;
     }
   }
 }

--- a/lib/screens/explore_screens/explore/components/explore_card.dart
+++ b/lib/screens/explore_screens/explore/components/explore_card.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/constants/app_colors.dart';
 import 'package:seeds/design/app_theme.dart';
 import 'package:seeds/domain-shared/ui_constants.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class ExploreCard extends StatelessWidget {
   final String title;
@@ -26,7 +26,6 @@ class ExploreCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return InkWell(
       borderRadius: BorderRadius.circular(defaultCardBorderRadius),
       onTap: onTap,
@@ -40,7 +39,7 @@ class ExploreCard extends StatelessWidget {
           alignment: AlignmentDirectional.bottomStart,
           children: [
             if (backgroundImage != null) Image.asset(backgroundImage!),
-            if (title == localization.explorerSwapItemTitle)
+            if (title == context.loc.explorerSwapItemTitle)
               LayoutBuilder(builder: (context, constrains) {
                 return ClipRRect(
                   borderRadius: const BorderRadius.only(

--- a/lib/screens/explore_screens/explore/components/flag_user_info_dialog.dart
+++ b/lib/screens/explore_screens/explore/components/flag_user_info_dialog.dart
@@ -1,39 +1,38 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/custom_dialog.dart';
 import 'package:seeds/components/flat_button_long.dart';
 import 'package:seeds/design/app_theme.dart';
 import 'package:seeds/images/explore/red_exclamation_circle.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class FlagUserInfoDialog extends StatelessWidget {
   const FlagUserInfoDialog({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return CustomDialog(
       icon: const CustomPaint(size: Size(60, 60), painter: RedExclamationCircle()),
       children: [
-        Text(localization.explorerFlagInfoDialogTitle, style: Theme.of(context).textTheme.button1),
+        Text(context.loc.explorerFlagInfoDialogTitle, style: Theme.of(context).textTheme.button1),
         const SizedBox(height: 30.0),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8.0),
           child: Column(
             children: [
               Text(
-                localization.explorerFlagInfoDialogSubTitle,
+                context.loc.explorerFlagInfoDialogSubTitle,
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.subtitle2,
               ),
               const SizedBox(height: 36.0),
               Text(
-                localization.explorerFlagInfoDialogSubTitlePartTwo,
+                context.loc.explorerFlagInfoDialogSubTitlePartTwo,
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.subtitle2,
               ),
               const SizedBox(height: 36.0),
               FlatButtonLong(
-                title: localization.explorerFlagInfoDialogButtonTitle,
+                title: context.loc.explorerFlagInfoDialogButtonTitle,
                 onPressed: () => Navigator.of(context).pop(),
               ),
               const SizedBox(height: 10.0),

--- a/lib/screens/explore_screens/explore/explore_screen.dart
+++ b/lib/screens/explore_screens/explore/explore_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/constants/app_colors.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
@@ -19,6 +18,7 @@ import 'package:seeds/screens/explore_screens/explore/components/flag_user_info_
 import 'package:seeds/screens/explore_screens/explore/interactor/viewmodels/explore_bloc.dart';
 import 'package:seeds/screens/explore_screens/explore/interactor/viewmodels/explore_item.dart';
 import 'package:seeds/screens/explore_screens/explore/interactor/viewmodels/explore_page_command.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class ExploreScreen extends StatelessWidget {
@@ -26,45 +26,44 @@ class ExploreScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     final List<ExploreItem> _exploreItems = [
       ExploreItem(
-          title: localization.explorerInviteItemTitle,
+          title: context.loc.explorerInviteItemTitle,
           icon: const Padding(
               padding: EdgeInsets.only(left: 6.0), child: CustomPaint(size: Size(40, 40), painter: InvitePerson())),
           onTapEvent: const OnExploreCardTapped(Routes.createInvite)),
       ExploreItem(
-          title: localization.explorerVouchItemTitle,
+          title: context.loc.explorerVouchItemTitle,
           icon: const CustomPaint(size: Size(35, 41), painter: Vouch()),
           onTapEvent: const OnExploreCardTapped(Routes.vouch)),
       ExploreItem(
-          title: localization.explorerFlagItemTitle,
+          title: context.loc.explorerFlagItemTitle,
           icon: const CustomPaint(size: Size(41, 41), painter: ExclamationCircle()),
           onTapEvent: const OnFlagUserTap()),
       ExploreItem(
-        title: localization.explorerVoteItemTitle,
+        title: context.loc.explorerVoteItemTitle,
         icon: const Padding(
             padding: EdgeInsets.only(right: 6.0), child: CustomPaint(size: Size(40, 40), painter: Vote())),
         onTapEvent: const OnExploreCardTapped(Routes.vote),
       ),
       ExploreItem(
-        title: localization.explorerPlantItemTitle,
+        title: context.loc.explorerPlantItemTitle,
         icon: const CustomPaint(size: Size(31, 41), painter: PlantSeeds()),
         onTapEvent: const OnExploreCardTapped(Routes.plantSeeds),
       ),
       ExploreItem(
-        title: localization.explorerUnplantItemTitle,
+        title: context.loc.explorerUnplantItemTitle,
         icon: const CustomPaint(size: Size(31, 41), painter: PlantSeeds()),
         onTapEvent: const OnExploreCardTapped(Routes.unPlantSeeds),
       ),
       ExploreItem(
-        title: localization.explorerSwapItemTitle,
+        title: context.loc.explorerSwapItemTitle,
         icon: const CustomPaint(size: Size(24, 24), painter: SwapSeeds()),
         iconUseCircleBackground: false,
         onTapEvent: const OnExploreCardTapped(Routes.swapSeeds),
       ),
       ExploreItem(
-        title: localization.explorerGetSeedsItemTitle,
+        title: context.loc.explorerGetSeedsItemTitle,
         icon: const CustomPaint(size: Size(9, 22), painter: SeedsSymbol()),
         backgroundIconColor: AppColors.white,
         backgroundImage: 'assets/images/explore/get_seeds_card.png',
@@ -79,7 +78,7 @@ class ExploreScreen extends StatelessWidget {
     ];
     List<ExploreItem> items = _exploreItems;
     if (!remoteConfigurations.featureFlagP2PEnabled) {
-      items = _exploreItems.where((i) => i.title != localization.explorerSwapItemTitle).toList();
+      items = _exploreItems.where((i) => i.title != context.loc.explorerSwapItemTitle).toList();
     }
     return BlocProvider(
       create: (_) => ExploreBloc(),
@@ -103,7 +102,7 @@ class ExploreScreen extends StatelessWidget {
         },
         builder: (context, _) {
           return Scaffold(
-            appBar: AppBar(title: Text(localization.explorerAppBarTitle)),
+            appBar: AppBar(title: Text(context.loc.explorerAppBarTitle)),
             body: GridView.count(
               padding: const EdgeInsets.all(18),
               crossAxisSpacing: 18,

--- a/lib/screens/profile_screens/security/components/biometric_enabled_dialog.dart
+++ b/lib/screens/profile_screens/security/components/biometric_enabled_dialog.dart
@@ -1,23 +1,22 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/components/custom_dialog.dart';
 import 'package:seeds/constants/app_colors.dart';
 import 'package:seeds/design/app_theme.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class BiometricEnabledDialog extends StatelessWidget {
   const BiometricEnabledDialog({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return CustomDialog(
       icon: const Icon(Icons.fingerprint, size: 52, color: AppColors.green1),
-      singleLargeButtonTitle: localization.securityBiometricEnabledConfirmationButtonTitle,
+      singleLargeButtonTitle: context.loc.securityBiometricEnabledConfirmationButtonTitle,
       children: [
-        Text(localization.securityBiometricEnabledTitle, style: Theme.of(context).textTheme.button1),
+        Text(context.loc.securityBiometricEnabledTitle, style: Theme.of(context).textTheme.button1),
         const SizedBox(height: 24.0),
         Text(
-          localization.securityBiometricEnabledDescription,
+          context.loc.securityBiometricEnabledDescription,
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.subtitle2,
         ),

--- a/lib/screens/profile_screens/security/components/guardian_security_card.dart
+++ b/lib/screens/profile_screens/security/components/guardian_security_card.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:seeds/components/divider_jungle.dart';
 import 'package:seeds/components/notification_badge.dart';
@@ -7,6 +6,7 @@ import 'package:seeds/constants/app_colors.dart';
 import 'package:seeds/design/app_theme.dart';
 import 'package:seeds/domain-shared/ui_constants.dart';
 import 'package:seeds/screens/profile_screens/security/interactor/viewmodels/security_bloc.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 
 class GuardianSecurityCard extends StatelessWidget {
   final GuardiansStatus? guardiansStatus;
@@ -18,20 +18,19 @@ class GuardianSecurityCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     Widget guardianStatus;
     switch (guardiansStatus) {
       case GuardiansStatus.active:
         guardianStatus =
-            Text(localization.securityGuardiansStatusActive, style: const TextStyle(color: AppColors.green1));
+            Text(context.loc.securityGuardiansStatusActive, style: const TextStyle(color: AppColors.green1));
         break;
       case GuardiansStatus.inactive:
         guardianStatus =
-            Text(localization.securityGuardiansStatusInactive, style: const TextStyle(color: AppColors.red));
+            Text(context.loc.securityGuardiansStatusInactive, style: const TextStyle(color: AppColors.red));
         break;
       case GuardiansStatus.readyToActivate:
         guardianStatus =
-            Text(localization.securityGuardiansStatusReadyToActivate, style: const TextStyle(color: AppColors.orange));
+            Text(context.loc.securityGuardiansStatusReadyToActivate, style: const TextStyle(color: AppColors.orange));
         break;
       default:
         guardianStatus = Container(height: 16, width: 16, child: const Center(child: CircularProgressIndicator()));
@@ -74,7 +73,7 @@ class GuardianSecurityCard extends StatelessWidget {
                                 children: [
                                   Flexible(
                                     child: Text(
-                                      localization.securityGuardiansHeader,
+                                      context.loc.securityGuardiansHeader,
                                       style: Theme.of(context).textTheme.button,
                                     ),
                                   ),
@@ -94,7 +93,7 @@ class GuardianSecurityCard extends StatelessWidget {
                           children: [
                             Flexible(
                               child: Text(
-                                localization.securityGuardiansDescription,
+                                context.loc.securityGuardiansDescription,
                                 style: Theme.of(context).textTheme.subtitle3,
                               ),
                             )

--- a/lib/screens/profile_screens/security/security_screen.dart
+++ b/lib/screens/profile_screens/security/security_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:seeds/blocs/authentication/viewmodels/authentication_bloc.dart';
 import 'package:seeds/components/full_page_error_indicator.dart';
 import 'package:seeds/components/full_page_loading_indicator.dart';
@@ -12,6 +11,7 @@ import 'package:seeds/screens/profile_screens/security/components/biometric_enab
 import 'package:seeds/screens/profile_screens/security/components/guardian_security_card.dart';
 import 'package:seeds/screens/profile_screens/security/components/security_card.dart';
 import 'package:seeds/screens/profile_screens/security/interactor/viewmodels/security_bloc.dart';
+import 'package:seeds/utils/build_context_extension.dart';
 import 'package:share/share.dart';
 
 class SecurityScreen extends StatelessWidget {
@@ -19,9 +19,8 @@ class SecurityScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final localization = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(title: Text(localization.securityTitle)),
+      appBar: AppBar(title: Text(context.loc.securityTitle)),
       body: BlocProvider(
         create: (context) =>
             SecurityBloc(BlocProvider.of<AuthenticationBloc>(context))..add(const SetUpInitialValues()),
@@ -67,8 +66,8 @@ class SecurityScreen extends StatelessWidget {
                       children: [
                         SecurityCard(
                           icon: const Icon(Icons.update),
-                          title: localization.securityExportPrivateKeyTitle,
-                          description: localization.securityExportPrivateKeyDescription,
+                          title: context.loc.securityExportPrivateKeyTitle,
+                          description: context.loc.securityExportPrivateKeyDescription,
                           onTap: () => Share.share(settingsStorage.privateKey!),
                         ),
                         BlocBuilder<SecurityBloc, SecurityState>(
@@ -86,8 +85,8 @@ class SecurityScreen extends StatelessWidget {
                         if (state.shouldShowExportRecoveryPhrase)
                           SecurityCard(
                             icon: const Icon(Icons.insert_drive_file),
-                            title: localization.security12WordRecoveryPhraseTitle,
-                            description: localization.security12WordRecoveryPhraseDescription,
+                            title: context.loc.security12WordRecoveryPhraseTitle,
+                            description: context.loc.security12WordRecoveryPhraseDescription,
                             onTap: () {
                               NavigationService.of(context).navigateTo(Routes.recoveryPhrase);
                             },
@@ -96,7 +95,7 @@ class SecurityScreen extends StatelessWidget {
                           const SizedBox.shrink(),
                         SecurityCard(
                           icon: const Icon(Icons.lock_outline),
-                          title: localization.securitySecureWithPinTitle,
+                          title: context.loc.securitySecureWithPinTitle,
                           titleWidget: BlocBuilder<SecurityBloc, SecurityState>(
                             buildWhen: (previous, current) => previous.isSecurePasscode != current.isSecurePasscode,
                             builder: (context, state) {
@@ -109,11 +108,11 @@ class SecurityScreen extends StatelessWidget {
                               );
                             },
                           ),
-                          description: localization.securitySecureWithPinDescription,
+                          description: context.loc.securitySecureWithPinDescription,
                         ),
                         SecurityCard(
                           icon: const Icon(Icons.fingerprint),
-                          title: localization.securitySecureWithTouchFaceIDTitle,
+                          title: context.loc.securitySecureWithTouchFaceIDTitle,
                           titleWidget: BlocBuilder<SecurityBloc, SecurityState>(
                             builder: (context, state) {
                               return Switch(
@@ -128,7 +127,7 @@ class SecurityScreen extends StatelessWidget {
                               );
                             },
                           ),
-                          description: localization.securitySecureWithTouchFaceIDDescription,
+                          description: context.loc.securitySecureWithTouchFaceIDDescription,
                         ),
                       ],
                     ),

--- a/lib/utils/build_context_extension.dart
+++ b/lib/utils/build_context_extension.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+extension LocalizedBuildContext on BuildContext {
+  /// Returns the localization instance
+  AppLocalizations get loc => AppLocalizations.of(this);
+}


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

No issue

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

1. No more boilerplate of to declare the variable (`final localization = AppLocalizations.of(context)!`) over and over again.
2. VSCode refuses to show app_localizations.dart as one of the available options, (it is easier to detect the import of an extension).
3. The `of` method now not returns a nullable, we are not forced anymore to use the `!` operator.
4. I think this change improves the readability and is more elegant.

### 👯‍♀️ Paired with

"nobody"
