### PR TITLE
Rebuild app on switch account when passcode is disabled

### DIFF
--- a/lib/blocs/authentication/viewmodels/authentication_bloc.dart
+++ b/lib/blocs/authentication/viewmodels/authentication_bloc.dart
@@ -47,8 +47,15 @@ class AuthenticationBloc extends Bloc<AuthenticationEvent, AuthenticationState> 
       await StopRecoveryUseCase().run();
     }
     await SaveAccountUseCase().run(accountName: event.account, authData: event.authData);
-    // New account --> re-start auth status
-    add(const InitAuthStatus());
+
+    if (settingsStorage.passcode == null && settingsStorage.passcodeActive == false) {
+      // New account && passcode disabled--> toogle auth status to rebuild app
+      emit(state.copyWith(authStatus: AuthStatus.initial));
+      emit(state.copyWith(authStatus: AuthStatus.unlocked));
+    } else {
+      // New account --> re-start auth status
+      add(const InitAuthStatus());
+    }
   }
 
   void _onRecoverAccount(OnRecoverAccount event, Emitter<AuthenticationState> emit) {
@@ -61,7 +68,7 @@ class AuthenticationBloc extends Bloc<AuthenticationEvent, AuthenticationState> 
     SwitchAccountUseCase().run(event.account, event.authData);
 
     if (settingsStorage.passcode == null && settingsStorage.passcodeActive == false) {
-      // New account && NO passcode --> toogle auth status to rebuild app
+      // New account && passcode disabled --> toogle auth status to rebuild app
       emit(state.copyWith(authStatus: AuthStatus.initial));
       emit(state.copyWith(authStatus: AuthStatus.unlocked));
     } else {

--- a/lib/blocs/authentication/viewmodels/authentication_bloc.dart
+++ b/lib/blocs/authentication/viewmodels/authentication_bloc.dart
@@ -59,8 +59,15 @@ class AuthenticationBloc extends Bloc<AuthenticationEvent, AuthenticationState> 
 
   void _onSwitchAccount(OnSwitchAccount event, Emitter<AuthenticationState> emit) {
     SwitchAccountUseCase().run(event.account, event.authData);
-    // New account --> re-start auth status
-    add(const InitAuthStatus());
+
+    if (settingsStorage.passcode == null && settingsStorage.passcodeActive == false) {
+      // New account && NO passcode --> toogle auth status to rebuild app
+      emit(state.copyWith(authStatus: AuthStatus.initial));
+      emit(state.copyWith(authStatus: AuthStatus.unlocked));
+    } else {
+      // New account --> re-start auth status
+      add(const InitAuthStatus());
+    }
   }
 
   Future<void> _onLogout(OnLogout event, Emitter<AuthenticationState> emit) async {

--- a/lib/blocs/authentication/viewmodels/authentication_bloc.dart
+++ b/lib/blocs/authentication/viewmodels/authentication_bloc.dart
@@ -49,7 +49,7 @@ class AuthenticationBloc extends Bloc<AuthenticationEvent, AuthenticationState> 
     await SaveAccountUseCase().run(accountName: event.account, authData: event.authData);
 
     if (settingsStorage.passcode == null && settingsStorage.passcodeActive == false) {
-      // New account && passcode disabled--> toogle auth status to rebuild app
+      // New account && passcode disabled --> toogle auth status to rebuild app
       emit(state.copyWith(authStatus: AuthStatus.initial));
       emit(state.copyWith(authStatus: AuthStatus.unlocked));
     } else {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1544 

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

The logic works the problem when InitAuthStatus event is fired after the current state is unlocked and yeah the new one would be unlocked too, therefore since the state its the same no rebuild was fired.

**Solution: just force a rebuild for this particular case.**

### 🙈 Screenshots


The add new account also works as expected.

<img src="https://user-images.githubusercontent.com/42857405/152696084-2d106c7b-d0b6-4e48-8713-0ddd79c942f0.gif" width="300">


### 👯‍♀️ Paired with

"nobody"
