### PR TITLE
Hive boxes removed on switch account and logout

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.71'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/lib/datasource/local/cache_repository.dart
+++ b/lib/datasource/local/cache_repository.dart
@@ -14,6 +14,9 @@ class CacheRepository {
 
   bool _boxIsClosed(Box box) => !box.isOpen;
 
+  /// Deletes all currently open boxes from disk.
+  Future<void> clear() => Hive.deleteFromDisk();
+
   Future<MemberModelCacheItem?> getMemberCacheItem(String account) async {
     final box = await Hive.openBox<MemberModelCacheItem>(_membersBox);
     if (_boxIsClosed(box)) {

--- a/lib/domain-shared/shared_use_cases/remove_account_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/remove_account_use_case.dart
@@ -1,3 +1,4 @@
+import 'package:seeds/datasource/local/cache_repository.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/domain-shared/shared_use_cases/account_use_case.dart';
 
@@ -5,6 +6,7 @@ class RemoveAccountUseCase extends AccountUseCase {
   Future<void> run() async {
     final String oldAccountName = settingsStorage.accountName;
     await settingsStorage.removeAccount();
+    await const CacheRepository().clear();
     //ignore: unawaited_futures
     updateFirebaseToken(oldAccount: oldAccountName);
   }

--- a/lib/domain-shared/shared_use_cases/switch_account_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/switch_account_use_case.dart
@@ -1,11 +1,13 @@
+import 'package:seeds/datasource/local/cache_repository.dart';
 import 'package:seeds/datasource/local/models/auth_data_model.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/domain-shared/shared_use_cases/account_use_case.dart';
 
 class SwitchAccountUseCase extends AccountUseCase {
-  void run(String accountName, AuthDataModel authData) {
+  Future<void> run(String accountName, AuthDataModel authData) async {
     final String oldAccountName = settingsStorage.accountName;
-    settingsStorage.switchAccount(accountName, authData);
+    await settingsStorage.switchAccount(accountName, authData);
+    await const CacheRepository().clear();
     //ignore: unawaited_futures
     updateFirebaseToken(oldAccount: oldAccountName, newAccount: accountName);
   }

--- a/lib/screens/profile_screens/profile/components/edit_profile_pic_bottom_sheet/interactor/viewmodels/pick_image_bloc.dart
+++ b/lib/screens/profile_screens/profile/components/edit_profile_pic_bottom_sheet/interactor/viewmodels/pick_image_bloc.dart
@@ -17,7 +17,7 @@ class PickImageBloc extends Bloc<PickImageEvent, PickImageState> {
     try {
       final image = await ImagePicker().pickImage(source: event.source, imageQuality: 50, maxWidth: 2000);
       if (image != null) {
-        final croppedFile = await ImageCropper.cropImage(
+        final croppedFile = await ImageCropper().cropImage(
           sourcePath: image.path,
           aspectRatioPresets: [CropAspectRatioPreset.square],
           compressQuality: 50,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   firebase_remote_config: ^0.11.0+2
   shimmer: ^2.0.0
   share: ^2.0.4
-  image_cropper: ^1.4.1
+  image_cropper: ^1.5.0
   carousel_slider: ^4.0.0
   qr_flutter: ^4.0.0
   image_picker: ^0.8.4+4


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1572 

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

You can confirm these boxes were removed successfully by looking at the member bloc first load after a switch account or logout it retrieve null values for members box:

<img width="674" alt="Captura de Pantalla 2022-02-20 a la(s) 12 29 15" src="https://user-images.githubusercontent.com/42857405/154858281-a8939023-ba8c-489d-8f35-6c5220ba63fd.png">

### 👯‍♀️ Paired with

"nobody"
