### PR TITLE
hypha contract moved to a new place

### DIFF
--- a/lib/datasource/remote/model/token_model.dart
+++ b/lib/datasource/remote/model/token_model.dart
@@ -65,7 +65,7 @@ const husdToken = TokenModel(
 
 const hyphaToken = TokenModel(
   chainName: "Telos",
-  contract: "token.hypha",
+  contract: "hypha.hypha",
   symbol: "HYPHA",
   name: "Hypha",
   backgroundImage: 'assets/images/wallet/currency_info_cards/hypha/background.jpg',


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

token.hypha is no longer valid

we are using hypha.hypha contract instead

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

token.hypha contract was hacked and is no longer ours

We migrate all balances to hypha.hypha

### 🙈 Screenshots
### 👯‍♀️ Paired with