### PR TITLE
fix typo and get string in case there's no default

### DIFF
--- a/lib/datasource/remote/firebase/firebase_remote_config.dart
+++ b/lib/datasource/remote/firebase/firebase_remote_config.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:seeds/datasource/remote/model/firebase_eos_servers.dart';
 
-const String _activeEOSEndpointKey = 'eos_enpoints';
+const String _activeEOSEndpointKey = 'eos_endpoints';
 const String _hyphaEndPointKey = 'hypha_end_point';
 const String _defaultEndPointUrlKey = 'default_end_point';
 const String _defaultV2EndPointUrlKey = 'default_v2_end_point';
@@ -118,7 +118,7 @@ class _FirebaseRemoteConfigService {
               : _testnetEosEndpoints
           : _remoteConfig.getString(_activeEOSEndpointKey))
       .firstWhere((FirebaseEosServer element) => element.isDefault!,
-          orElse: () => parseEosServers(_remoteConfig.getString(_eosEndpoints)).first);
+          orElse: () => parseEosServers(_remoteConfig.getString(_activeEOSEndpointKey)).first);
 }
 
 // A function that converts a response body into a List<FirebaseEosServer>.


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

I found these bugs while looking for the cause of someone not being able to import keys

While these are not the case, they may cause other problems. 

the eos_enpoint (no "d") I mitigated by creating that entry on the remote for the time being, duplicated from the original "eos_endpoints". I am not sure why anything was working... probably running on hard-coded defaults, I assume. Which is good. 

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [ ] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

one typo, one error (eos_endpoints variable is not a key, it's the default value, and using this to look up remote config will return empty or error)

### 🙈 Screenshots
### 👯‍♀️ Paired with
