### PR TITLE
Update event avatars on user join or leave

### DIFF
--- a/lib/datasource/remote/firebase/regions/firebase_database_regions_repository.dart
+++ b/lib/datasource/remote/firebase/regions/firebase_database_regions_repository.dart
@@ -203,6 +203,12 @@ class FirebaseDatabaseRegionsRepository extends FirebaseDatabaseService {
             .toList());
   }
 
+  Stream<RegionEventModel> getEventRegion(String regionId) {
+    return regionEventCollection.where('id', isEqualTo: regionId).snapshots().asyncMap((QuerySnapshot event) {
+      return RegionEventModel.mapToRegionEventModel(event as QueryDocumentSnapshot<Map<String, dynamic>>);
+    });
+  }
+
   Future<Result<String>> joinEvent(String eventId, String joiningUser) {
     final data = {
       eventUsersKey: FieldValue.arrayUnion([joiningUser]),

--- a/lib/screens/explore_screens/regions_screens/regions_main/components/region_event_card/interactor/viewmodels/region_event_card_bloc.dart
+++ b/lib/screens/explore_screens/regions_screens/regions_main/components/region_event_card/interactor/viewmodels/region_event_card_bloc.dart
@@ -1,5 +1,10 @@
+import 'dart:async';
+
 import 'package:bloc/bloc.dart';
+import 'package:collection/collection.dart' show IterableExtension;
 import 'package:equatable/equatable.dart';
+import 'package:seeds/datasource/remote/firebase/regions/firebase_database_regions_repository.dart';
+import 'package:seeds/datasource/remote/model/firebase_models/region_event_model.dart';
 import 'package:seeds/datasource/remote/model/profile_model.dart';
 import 'package:seeds/screens/explore_screens/regions_screens/regions_main/components/region_event_card/interactor/mappers/region_event_profiles_state_mapper.dart';
 import 'package:seeds/screens/explore_screens/regions_screens/regions_main/components/region_event_card/interactor/usecases/get_first_n_profiles_elements_use_case.dart';
@@ -8,8 +13,23 @@ part 'region_event_card_event.dart';
 part 'region_event_card_state.dart';
 
 class RegionEventCardBloc extends Bloc<RegionEventCardEvent, RegionEventCardState> {
-  RegionEventCardBloc() : super(RegionEventCardState.initial()) {
+  late StreamSubscription<List<RegionEventModel>> _eventListener;
+
+  RegionEventCardBloc(RegionEventModel event) : super(RegionEventCardState.initial()) {
+    _eventListener = FirebaseDatabaseRegionsRepository().getEventsForRegion(event.regionAccount).listen((events) {
+      final found = events.singleWhereOrNull((i) => i.id == event.id);
+      if (found != null) {
+        add(OnLoadRegionEventMembers(found.users));
+      }
+    });
+
     on<OnLoadRegionEventMembers>(_onLoadRegionEventMembers);
+  }
+
+  @override
+  Future<void> close() {
+    _eventListener.cancel();
+    return super.close();
   }
 
   Future<void> _onLoadRegionEventMembers(OnLoadRegionEventMembers event, Emitter<RegionEventCardState> emit) async {
@@ -20,5 +40,3 @@ class RegionEventCardBloc extends Bloc<RegionEventCardEvent, RegionEventCardStat
     }
   }
 }
-
-// TODO(RAUL): We need update these card avatars when a user join or leave.

--- a/lib/screens/explore_screens/regions_screens/regions_main/components/region_event_card/region_event_card.dart
+++ b/lib/screens/explore_screens/regions_screens/regions_main/components/region_event_card/region_event_card.dart
@@ -18,7 +18,7 @@ class RegionEventCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => RegionEventCardBloc()..add(OnLoadRegionEventMembers(event.users)),
+      create: (_) => RegionEventCardBloc(event)..add(OnLoadRegionEventMembers(event.users)),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8.0),
         child: InkWell(


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1618 

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Refresh event card avatars when a user join or leaves that region event.

### 👯‍♀️ Paired with

"nobody"
