### PR TITLE
Lw 1862 - addition

### DIFF
--- a/lib/navigation/navigation_service.dart
+++ b/lib/navigation/navigation_service.dart
@@ -188,20 +188,10 @@ class NavigationService {
   final _cupertinoRoutes = {
     Routes.citizenship,
   };
-  StreamController<String>? _streamRouteListener;
 
   static NavigationService of(BuildContext context) => RepositoryProvider.of<NavigationService>(context);
 
-  // ignore: use_setters_to_change_properties
-  void addListener(StreamController<String> listener) {
-    _streamRouteListener = listener;
-  }
-
   Future<dynamic> navigateTo(String routeName, [Object? arguments, bool replace = false]) async {
-    if (_streamRouteListener != null) {
-      _streamRouteListener?.add(routeName);
-    }
-
     if (_appRoutes[routeName] != null) {
       if (replace) {
         return appNavigatorKey.currentState?.pushReplacementNamed(routeName, arguments: arguments);
@@ -235,6 +225,25 @@ class NavigationService {
 
   Future<dynamic> pushAndRemoveAll(String routeName, [Object? arguments]) async {
     return appNavigatorKey.currentState?.pushNamedAndRemoveUntil(routeName, (route) => false);
+  }
+
+  /// Push LW App.
+  ///
+  /// If there is a route in stack and is verification, pop any other on top.
+  Future<dynamic> pushApp() async {
+    if (currentRouteName() != null && currentRouteName() == Routes.verification) {
+      return appNavigatorKey.currentState?.popUntil((route) => route.settings.name != Routes.verification);
+    }
+    return pushAndRemoveAll(Routes.app);
+  }
+
+  String? currentRouteName() {
+    String? currentPath;
+    appNavigatorKey.currentState?.popUntil((route) {
+      currentPath = route.settings.name;
+      return true;
+    });
+    return currentPath;
   }
 
   Future<dynamic> pushAndRemoveUntil({required String route, required String from, Object? arguments}) async {

--- a/lib/seeds_app.dart
+++ b/lib/seeds_app.dart
@@ -75,10 +75,13 @@ class SeedsApp extends StatelessWidget {
                               break;
                             case AuthStatus.emptyPasscode:
                             case AuthStatus.locked:
-                              navigator.pushAndRemoveAll(Routes.verification);
+                              if (navigator.currentRouteName() == null) {
+                                navigator.pushAndRemoveAll(Routes.app);
+                              }
+                              navigator.navigateTo(Routes.verification);
                               break;
                             case AuthStatus.unlocked:
-                              navigator.pushAndRemoveAll(Routes.app);
+                              navigator.pushApp();
                               break;
                             default:
                               navigator.pushAndRemoveAll(Routes.splash);


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1862 

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

I did not like that the stack always gets destroyed by the PIN code. 

That's not iOS standard, in any case - view stack of an app should be preserved.

#### Discussion
Argument could be made either way since it's a 10 minute timeout in reality and after 10 minutes maybe users have actually forgotten where they are. 

Downsides:

- At app startup when there's not a screen set yet - then we need to set a screen (code does this)
- Second caveat is route name returns null when a modal dialog is showing. 

Upsides:
- Preserves widget state when user returns
- Doesn't reload main wallet screen when user returns - this is actually maybe the biggest reason to do this right now. I don't like when the main screen reloads - but if we destroy all widgets and rebuild the tree then necessarily they have to reload. 
- Prepared for when / if we allow users to set the timeout (example 1 minute)
- Edge cases like kiosk mode? Not sure. They could just turn off PIN code.

I think an ideal solution would 
- Have a separate timeout when we reset to main wallet screen, e.g. after 30 minutes
- Does not reload the main wallet screen (e.g. no destroy widget, just switch to it)

#### Testing procedure

Testing by changing the value to 5 seconds
```
      //_timer = Timer(const Duration(minutes: 10), () {
      _timer = Timer(const Duration(seconds: 5), () {
        if (state.authStatus == AuthStatus.unlocked && settingsStorage.passcodeActive) {
          add(const StartTimeoutAuth());
        }
```

### 🙈 Screenshots

https://user-images.githubusercontent.com/65412/171352847-389211f9-cef7-4e03-bd0b-a55d958060a2.mov



### 👯‍♀️ Paired with

@RaulUrtecho 