### PR TITLE
fix symbol_code serialization bug in eosdart library

### DIFF
--- a/lib/crypto/eosdart/src/serialize.dart
+++ b/lib/crypto/eosdart/src/serialize.dart
@@ -303,10 +303,11 @@ class SerialBuffer {
 
   /// Append a `symbol_code`. Unlike `symbol`, `symbol_code` doesn't include a precision. */
   void pushSymbolCode(String name) {
-    Uint8List a = Uint8List.fromList(utf8.encode(name));
-    while (a.length < 8) {
-      a.add(0);
+    final l = List<int>.from(utf8.encode(name));
+    while(l.length <8) {
+      l.add(0);
     }
+    Uint8List a = Uint8List.fromList(l);
     pushArray(a.sublist(0, 8));
   }
 


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

fix serialization bug in eosdart library which prevented use of action data fields of type symbol_code.

This Rainbow test transaction executed ok from Anchor.
![image](https://user-images.githubusercontent.com/2141014/174658244-bdacb47b-27b1-40dd-9c73-a1a1950d6875.png)
https://telos.eosx.io/tx/5558814d4a4772fc8de2296dce6282c4e42d5424c52d24ee43c860c05be0bc6d 

But using LW to scan the QR gives this error
![image](https://user-images.githubusercontent.com/2141014/174657816-c5143935-4812-43f9-ba81-fce2ce0a12f0.png)

### ✅ Checklist

- [x] ~~Github issue~~ Explanation details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Uint8List is a fixed-length type.

Not sure why this wasn't a problem before. No Seeds actions with symbol_code type? Change in Uint8List growability with some Dart update? 

### 🙈 Screenshots


### 👯‍♀️ Paired with

"nobody"
