### PR TITLE
Bump up to the actual latest version 2.9.0 (80)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: seeds
 description: SEEDS Wallet
 
-version: 2.9.0+79
+version: 2.9.0+80
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

I forgot to merge this into `release/2.9.0`.