### PR TITLE
fix eos serialize/deserialize for bool type

### DIFF
--- a/lib/crypto/eosdart/src/serialize.dart
+++ b/lib/crypto/eosdart/src/serialize.dart
@@ -630,7 +630,7 @@ Map<String, Type> createInitialTypes() {
         buffer.push([data == null ? 1 : 0]);
       },
       deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
-        return buffer.get();
+        return buffer.get()!=0;
       },
     ),
     "uint8": createType(

--- a/lib/crypto/eosdart/src/serialize.dart
+++ b/lib/crypto/eosdart/src/serialize.dart
@@ -627,7 +627,7 @@ Map<String, Type> createInitialTypes() {
     "bool": createType(
       name: 'bool',
       serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
-        buffer.push([data == null ? 1 : 0]);
+        buffer.push([data == true ? 1 : 0]);
       },
       deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.get()!=0;


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

A bug in eosdart incorrectly deserializes a bool type into type int. If a transaction is deserialized (e.g. from QR or esr code) then reserialized, it will become badly formed. This is a problem when the LW is used as a general purpose signing wallet. _Update:_ there's a bug in the bool-type serializer as well. 

### ✅ Checklist

- [ x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

I am aware that this PR generates a lot of linter complaints. This is not related to the code changes in this PR and I have not tracked it down. This may be a bit sloppy but I found these bugs in the rainbow_apk side branch and wrote this PR quickly to make sure the fixes get into master.

### 🙈 Screenshots

Example
![image](https://user-images.githubusercontent.com/2141014/190276684-39dde6f0-715a-4a78-8da6-aa9ba7e2e3fb.png)    
![image](https://user-images.githubusercontent.com/2141014/190277933-266cd84d-c928-4245-a5fa-3a061d13be6b.png)


Before & after bugfix

![image](https://user-images.githubusercontent.com/2141014/190277649-79e3742a-840e-4819-9827-0933d770da52.png)

### 👯‍♀️ Paired with

"nobody" 
