### PR TITLE
fix: QRscan errors on float data; deserialization failed on unaligned data

### DIFF
--- a/lib/crypto/eosdart/src/serialize.dart
+++ b/lib/crypto/eosdart/src/serialize.dart
@@ -212,7 +212,9 @@ class SerialBuffer {
 
   // /** Get a `float32` */
   double getFloat32() {
-    return getUint8List(4).buffer.asFloat32List()[0];
+    var rp = readPos;
+    getUint8List(4);
+    return array.buffer.asByteData(rp).getFloat32(0, Endian.little);
   }
 
   // /** Append a `float64` */
@@ -222,7 +224,9 @@ class SerialBuffer {
 
   // /** Get a `float64` */
   double getFloat64() {
-    return getUint8List(8).buffer.asFloat64List()[0];
+    var rp = readPos;
+    getUint8List(8);
+    return array.buffer.asByteData(rp).getFloat64(0, Endian.little);
   }
 
   /// Append a `name` */


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Wallet produces corrupted floating point data when scanning a transaction QR

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [ ] I have tested all my changes.

WARNING: I have tested these changes in another repository; however this repo does not build for me (flutter pub version solving failed).

### 🕵️‍♂️ Notes for Code Reviewer


### 🙈 Screenshots


Here is an example transaction QR code with floating point field (Weighting) which gives the error
![image](https://github.com/localscale/localscale-wallet/assets/2141014/71bd28d4-8eb6-420c-a5df-6e1f3d2d33b3)


| before fix | after fix |
| --- | --- |
| ![image](https://github.com/localscale/localscale-wallet/assets/2141014/0efee61f-829f-4ca6-991e-6e503c237d10) | ![image](https://github.com/localscale/localscale-wallet/assets/2141014/139d6676-2533-4f68-9bbb-046080e9a4ef) |

Note: this fix is pushed upstream at https://github.com/primes-network/eosdart/pull/46
