### PR TITLE
Migrate TextTheme and dependencies for latest version of Flutter

### DIFF
--- a/lib/components/custom_dialog.dart
+++ b/lib/components/custom_dialog.dart
@@ -126,7 +126,7 @@ class CustomDialog extends StatelessWidget {
                 child: CircleAvatar(
                   backgroundColor: Colors.transparent,
                   radius: _avatarRadius,
-                  child: Container(
+                  child: DecoratedBox(
                     decoration: BoxDecoration(
                       color: AppColors.white,
                       shape: BoxShape.circle,

--- a/lib/components/error_dialog.dart
+++ b/lib/components/error_dialog.dart
@@ -8,16 +8,22 @@ class ErrorDialog extends StatelessWidget {
   final String details;
   final VoidCallback? onRightButtonPressed;
 
-  const ErrorDialog({super.key, required this.title, required this.details, this.onRightButtonPressed});
+  const ErrorDialog(
+      {super.key,
+      required this.title,
+      required this.details,
+      this.onRightButtonPressed});
 
   Future<void> show(BuildContext context) {
-    return showDialog<void>(context: context, barrierDismissible: false, builder: (_) => this);
+    return showDialog<void>(
+        context: context, barrierDismissible: false, builder: (_) => this);
   }
 
   @override
   Widget build(BuildContext context) {
     return CustomDialog(
-      icon: const CustomPaint(size: Size(60, 60), painter: RedExclamationCircle()),
+      icon: const CustomPaint(
+          size: Size(60, 60), painter: RedExclamationCircle()),
       rightButtonTitle: 'Retry',
       onRightButtonPressed: () {
         Navigator.of(context).pop();
@@ -27,11 +33,11 @@ class ErrorDialog extends StatelessWidget {
       children: [
         Text(
           title,
-          style: Theme.of(context).textTheme.headline6,
+          style: Theme.of(context).textTheme.titleLarge,
           overflow: TextOverflow.ellipsis,
         ),
         const SizedBox(height: 20.0),
-        Text(details, style: Theme.of(context).textTheme.subtitle2),
+        Text(details, style: Theme.of(context).textTheme.titleSmall),
       ],
     );
   }

--- a/lib/components/full_page_error_indicator.dart
+++ b/lib/components/full_page_error_indicator.dart
@@ -8,7 +8,8 @@ class FullPageErrorIndicator extends StatelessWidget {
   final String? buttonTitle;
   final VoidCallback? buttonOnPressed;
 
-  const FullPageErrorIndicator({this.errorMessage, this.buttonTitle, this.buttonOnPressed, super.key});
+  const FullPageErrorIndicator(
+      {this.errorMessage, this.buttonTitle, this.buttonOnPressed, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +20,10 @@ class FullPageErrorIndicator extends StatelessWidget {
           child: Center(
             child: Text(
               errorMessage ?? GlobalError.unknown.localizedDescription(context),
-              style: Theme.of(context).textTheme.subtitle2!.copyWith(color: AppColors.red1),
+              style: Theme.of(context)
+                  .textTheme
+                  .titleSmall!
+                  .copyWith(color: AppColors.red1),
             ),
           ),
         ),
@@ -27,7 +31,8 @@ class FullPageErrorIndicator extends StatelessWidget {
       if (buttonTitle != null && buttonOnPressed != null)
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
-          child: FlatButtonLong(title: buttonTitle!, onPressed: buttonOnPressed),
+          child:
+              FlatButtonLong(title: buttonTitle!, onPressed: buttonOnPressed),
         ),
     ]);
   }

--- a/lib/components/member_info_row.dart
+++ b/lib/components/member_info_row.dart
@@ -31,19 +31,23 @@ class MemberInfoRow extends StatelessWidget {
                     children: [
                       Flexible(
                         child: Text(
-                          member.nickname.isNotEmpty ? member.nickname : member.account,
+                          member.nickname.isNotEmpty
+                              ? member.nickname
+                              : member.account,
                           overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.button,
+                          style: Theme.of(context).textTheme.labelLarge,
                         ),
                       ),
                       Text(
                         member.statusString,
-                        style: Theme.of(context).textTheme.button,
+                        style: Theme.of(context).textTheme.labelLarge,
                       ),
                     ],
                   ),
                   const SizedBox(height: 8),
-                  Text(member.account, style: Theme.of(context).textTheme.subtitle2OpacityEmphasis)
+                  Text(member.account,
+                      style:
+                          Theme.of(context).textTheme.subtitle2OpacityEmphasis)
                 ],
               ),
             ),

--- a/lib/components/search_result_row.dart
+++ b/lib/components/search_result_row.dart
@@ -34,20 +34,25 @@ class SearchResultRow extends StatelessWidget {
                       children: [
                         Flexible(
                           child: Text(
-                            member.nickname.isNotEmpty ? member.nickname : member.account,
+                            member.nickname.isNotEmpty
+                                ? member.nickname
+                                : member.account,
                             overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.button,
+                            style: Theme.of(context).textTheme.labelLarge,
                           ),
                         ),
                         const SizedBox(width: 10),
                         Text(
                           member.statusString,
-                          style: Theme.of(context).textTheme.button,
+                          style: Theme.of(context).textTheme.labelLarge,
                         ),
                       ],
                     ),
                     const SizedBox(height: 8),
-                    Text(member.account, style: Theme.of(context).textTheme.subtitle2OpacityEmphasis)
+                    Text(member.account,
+                        style: Theme.of(context)
+                            .textTheme
+                            .subtitle2OpacityEmphasis)
                   ],
                 ),
               ),

--- a/lib/components/search_user/search_user.dart
+++ b/lib/components/search_user/search_user.dart
@@ -29,18 +29,22 @@ class SearchUser extends StatelessWidget {
       child: Column(
         children: [
           const Padding(
-            padding: EdgeInsets.only(right: horizontalEdgePadding, left: horizontalEdgePadding, top: 10),
+            padding: EdgeInsets.only(
+                right: horizontalEdgePadding,
+                left: horizontalEdgePadding,
+                top: 10),
             child: SearchUserTextField(),
           ),
           if (title != null)
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: horizontalEdgePadding),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: horizontalEdgePadding),
               child: Align(
                 alignment: Alignment.centerLeft,
                 child: Column(
                   children: [
                     const SizedBox(height: 20),
-                    Text(title!, style: Theme.of(context).textTheme.subtitle2),
+                    Text(title!, style: Theme.of(context).textTheme.titleSmall),
                   ],
                 ),
               ),
@@ -52,10 +56,12 @@ class SearchUser extends StatelessWidget {
                 case PageState.loading:
                 case PageState.failure:
                 case PageState.success:
-                  if (state.pageState == PageState.success && state.users.isEmpty) {
+                  if (state.pageState == PageState.success &&
+                      state.users.isEmpty) {
                     return Padding(
                       padding: const EdgeInsets.all(16.0),
-                      child: Center(child: Text(context.loc.searchUserNoUserFound)),
+                      child: Center(
+                          child: Text(context.loc.searchUserNoUserFound)),
                     );
                   } else {
                     return Expanded(

--- a/lib/components/select_picture_box/select_picture_box.dart
+++ b/lib/components/select_picture_box/select_picture_box.dart
@@ -34,7 +34,11 @@ class SelectPictureBox extends StatelessWidget {
             dashPattern: [8, 4],
             strokeWidth: 2,
             color: AppColors.grey,
-            child: Ink(height: 200, child: Container(width: width, child: imageState(pictureBoxState, context)))));
+            child: Ink(
+                height: 200,
+                child: Container(
+                    width: width,
+                    child: imageState(pictureBoxState, context)))));
   }
 
   Widget imageState(PictureBoxState pictureState, BuildContext context) {
@@ -46,7 +50,7 @@ class SelectPictureBox extends StatelessWidget {
           Row(mainAxisAlignment: MainAxisAlignment.center, children: [
             const Icon(Icons.add),
             const SizedBox(width: 6),
-            Text(title, style: Theme.of(context).textTheme.subtitle2)
+            Text(title, style: Theme.of(context).textTheme.titleSmall)
           ])
         ]);
       case PictureBoxState.imagePicked:

--- a/lib/components/snack.dart
+++ b/lib/components/snack.dart
@@ -24,11 +24,9 @@ class Snack extends SnackBar {
     return Snack._(title, scaffoldMessengerState, color: color, duration: duration);
   }
 
-  Snack._(this.title, this.scaffoldMessengerState, {Key? key, required Color color, required Duration duration})
+  Snack._(this.title, this.scaffoldMessengerState, {required Color color, required super.duration})
       : super(
-          key: key,
           backgroundColor: color,
-          duration: duration,
           content: Row(
             children: [
               Expanded(child: Text(title, textAlign: TextAlign.center)),

--- a/lib/components/text_form_field_custom.dart
+++ b/lib/components/text_form_field_custom.dart
@@ -76,20 +76,24 @@ class TextFormFieldCustom extends StatelessWidget {
         maxLines: maxLines,
         enabled: enabled,
         validator: validator,
-        style: Theme.of(context).textTheme.subtitle2,
+        style: Theme.of(context).textTheme.titleSmall,
         decoration: InputDecoration(
           suffixText: suffixText,
-          suffixStyle: Theme.of(context).textTheme.subtitle2,
+          suffixStyle: Theme.of(context).textTheme.titleSmall,
           suffixIcon: suffixIcon,
-          focusedBorder: const OutlineInputBorder(borderSide: BorderSide(color: AppColors.canopy)),
+          focusedBorder: const OutlineInputBorder(
+              borderSide: BorderSide(color: AppColors.canopy)),
           counterText: counterText,
           hintText: hintText,
           labelText: labelText,
           errorText: errorText,
           errorMaxLines: 2,
           errorStyle: const TextStyle(color: Colors.red, wordSpacing: 4.0),
-          labelStyle: Theme.of(context).textTheme.subtitle3.copyWith(color: AppColors.white),
-          hintStyle: Theme.of(context).textTheme.button,
+          labelStyle: Theme.of(context)
+              .textTheme
+              .subtitle3
+              .copyWith(color: AppColors.white),
+          hintStyle: Theme.of(context).textTheme.labelLarge,
           contentPadding: const EdgeInsets.all(16.0),
           border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
         ),

--- a/lib/crypto/dart_esr/src/encoding_options.dart
+++ b/lib/crypto/dart_esr/src/encoding_options.dart
@@ -44,7 +44,7 @@ class DefaultAbiProvider implements AbiProvider {
 class DefaultTextEncoder implements TextEncoder {
   @override
   Uint8List encode(String input) {
-    return utf8.encode(input) as Uint8List;
+    return utf8.encode(input);
   }
 }
 

--- a/lib/crypto/dart_esr/src/signing_request_manager.dart
+++ b/lib/crypto/dart_esr/src/signing_request_manager.dart
@@ -470,7 +470,7 @@ class SigningRequestManager {
       case 'action':
         return [Action.fromJson(Map<String, dynamic>.from(req[1]))];
       case 'action[]':
-        print("*** actions: ${req.toString()}");
+        print("*** actions: $req");
 
         final actions = req[1] as List;
         final List<Action> resultActions = List.from(actions.map(
@@ -674,7 +674,7 @@ class ResolvedSigningRequest {
       refBlockNnum = int.parse(payload.rbn!);
       refBlockPrefix = int.parse(payload.rid!);
     } catch (e) {
-      print("Error fromPayload: ${e.toString()}");
+      print("Error fromPayload: $e");
     }
 
     return request.resolve(

--- a/lib/crypto/dart_esr/zlib/src/util/archive_exception.dart
+++ b/lib/crypto/dart_esr/zlib/src/util/archive_exception.dart
@@ -1,5 +1,4 @@
 /// An exception thrown when there was a problem in the archive library.
 class ArchiveException extends FormatException {
-  ArchiveException(String message, [dynamic source, int? offset])
-      : super(message, source, offset);
+  ArchiveException(super.message, [super.source, super.offset]);
 }

--- a/lib/crypto/eosdart/src/client.dart
+++ b/lib/crypto/eosdart/src/client.dart
@@ -194,7 +194,7 @@ class EOSClient {
   /// Get required key by transaction from EOS blockchain
   Future<RequiredKeys> getRequiredKeys(Transaction transaction, List<String> availableKeys) async {
     final NodeInfo info = await getInfo();
-    final Block refBlock = await getBlock((info.headBlockNum).toString());
+    final Block refBlock = await getBlock(info.headBlockNum.toString());
     Transaction trx = await _fullFill(transaction, refBlock);
     trx = await _serializeActions(trx);
 

--- a/lib/crypto/eosdart/src/models/abi.dart
+++ b/lib/crypto/eosdart/src/models/abi.dart
@@ -5,11 +5,11 @@ import 'dart:typed_data';
 
 import 'package:json_annotation/json_annotation.dart';
 
-import './conversion_helper.dart';
 import '../eosdart_base.dart';
 import '../jsons.dart';
 import '../numeric.dart';
 import '../serialize.dart' as ser;
+import './conversion_helper.dart';
 
 part 'abi.g.dart';
 
@@ -65,7 +65,7 @@ class AbiResp with ConversionHelper {
       var b = t.deserialize!(t, buffer);
       return Abi.fromJson(json.decode(json.encode(b)));
     } catch (e) {
-      print(e.toString());
+      print(e);
       return null;
     }
   }

--- a/lib/crypto/eosdart/src/models/conversion_helper.dart
+++ b/lib/crypto/eosdart/src/models/conversion_helper.dart
@@ -17,7 +17,7 @@ mixin ConversionHelper {
   }
 
   static Uint8List base64ToBuffer(String base64String) {
-    return utf8.encode(base64String) as Uint8List;
+    return utf8.encode(base64String);
   }
 
   static String bufferToBase64(Uint8List buffer) {

--- a/lib/crypto/eosdart/src/models/transaction.dart
+++ b/lib/crypto/eosdart/src/models/transaction.dart
@@ -1,12 +1,13 @@
 // ignore_for_file: always_use_package_imports, unnecessary_this, prefer_final_locals
 
 import 'dart:typed_data';
+
 import 'package:json_annotation/json_annotation.dart';
 
-import './action.dart';
-import './conversion_helper.dart';
 import '../eosdart_base.dart';
 import '../serialize.dart' as ser;
+import './action.dart';
+import './conversion_helper.dart';
 
 part 'transaction.g.dart';
 

--- a/lib/crypto/eosdart/src/numeric.dart
+++ b/lib/crypto/eosdart/src/numeric.dart
@@ -244,8 +244,8 @@ Uint8List digestSha256X2(Uint8List data) {
 IKey stringToKey(String s, KeyType type, int size, String suffix) {
   var whole = base58ToBinary(size + 4, s);
 
-  var result;
-  var digest;
+  IKey result;
+  List<int> digest;
   if (suffix == '') {
     result = IKey(type, whole.sublist(1,size));
     digest = digestSha256X2(whole.sublist(0,size));

--- a/lib/crypto/eosdart/src/serialize.dart
+++ b/lib/crypto/eosdart/src/serialize.dart
@@ -446,8 +446,8 @@ Type createType(
     void Function(Type self, SerialBuffer buffer, Object data, {SerializerState state, bool allowExtensions})?
         serialize,
     Object? Function(Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions})? deserialize,
-    String? baseName: "",
-    List<Field>? fields: const [],
+    String? baseName = "",
+    List<Field>? fields = const [],
     Type? extensionOf}) {
   var t = Type(
       aliasOfName: aliasOfName,

--- a/lib/crypto/eosdart_ecc/src/key.dart
+++ b/lib/crypto/eosdart_ecc/src/key.dart
@@ -157,7 +157,7 @@ class EOSPrivateKey extends EOSKey {
 
   /// Sign the string data using the private key
   EOSSignature signString(String data) {
-    return sign(utf8.encode(data) as Uint8List);
+    return sign(utf8.encode(data));
   }
 
   /// Sign the SHA256 hashed data using the private key

--- a/lib/crypto/eosdart_ecc/src/key_base.dart
+++ b/lib/crypto/eosdart_ecc/src/key_base.dart
@@ -33,7 +33,7 @@ abstract class EOSKey {
     } else {
       Uint8List check = key;
       if (keyType != null) {
-        check = concat(key, utf8.encode(keyType) as Uint8List);
+        check = concat(key, utf8.encode(keyType));
       }
       newChecksum = RIPEMD160Digest().process(check).sublist(0, 4);
     }
@@ -52,7 +52,7 @@ abstract class EOSKey {
 
     Uint8List keyBuffer = key;
     if (keyType != null) {
-      keyBuffer = concat(key, utf8.encode(keyType) as Uint8List);
+      keyBuffer = concat(key, utf8.encode(keyType));
     }
     Uint8List checksum = RIPEMD160Digest().process(keyBuffer).sublist(0, 4);
     return base58.encode(concat(key, checksum));

--- a/lib/datasource/local/biometrics_service.dart
+++ b/lib/datasource/local/biometrics_service.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:local_auth/local_auth.dart';
 import 'package:local_auth_android/local_auth_android.dart';
-import 'package:local_auth_ios/local_auth_ios.dart';
+import 'package:local_auth_darwin/local_auth_darwin.dart';
 
 class BiometricsService {
   final LocalAuthentication _localAuth;

--- a/lib/datasource/remote/api/esr_callback_repository.dart
+++ b/lib/datasource/remote/api/esr_callback_repository.dart
@@ -34,17 +34,18 @@ import 'package:seeds/datasource/remote/api/http_repo/http_repository.dart';
 /// At the moment can't justify the effort for a generic implementation.
 
 class ESRCallbackRepository extends HttpRepository {
-  Future<Result<bool>> callback(String _callbackUrl, String transactionId) {
-    print("[http] issue callback $_callbackUrl");
+  Future<Result<bool>> callback(String callbackUrl, String transactionId) {
+    print("[http] issue callback $callbackUrl");
 
-    final callbackUrl = fillTemplate(_callbackUrl, transactionId);
-    final uri = Uri.parse(callbackUrl);
+    final callbackURL = fillTemplate(callbackUrl, transactionId);
+    final uri = Uri.parse(callbackURL);
     final params = jsonEncode(uri.queryParameters);
     final postURI = Uri(scheme: uri.scheme, host: uri.host, path: uri.path);
 
     return http
         .post(postURI, headers: headers, body: params)
-        .then((http.Response response) => mapHttpResponse<bool>(response, (dynamic body) {
+        .then((http.Response response) =>
+            mapHttpResponse<bool>(response, (dynamic body) {
               return true;
             }))
         .catchError((error) => mapHttpError(error));

--- a/lib/datasource/remote/api/guardians_repository.dart
+++ b/lib/datasource/remote/api/guardians_repository.dart
@@ -217,7 +217,7 @@ class GuardiansRepository extends EosRepository with HttpRepository {
 
     final permissionsMap = _requiredAuthToJson(permission.requiredAuth!);
 
-    print('converted JSPN: ${permissionsMap.toString()}');
+    print('converted JSPN: $permissionsMap');
     final accountName = settingsStorage.accountName;
 
     final actions = [

--- a/lib/datasource/remote/api/invite_repository.dart
+++ b/lib/datasource/remote/api/invite_repository.dart
@@ -91,7 +91,7 @@ class InviteRepository extends HttpRepository with EosRepository {
     print('[http] find invite by hash');
 
     final inviteURL = Uri.parse('$baseURL/v1/chain/get_table_rows');
-    // 'https://node.hypha.earth/v1/chain/get_table_rows'; // todo: Why is this still Hypha when config has changed?
+    // 'https://node.hypha.earth/v1/chain/get_table_rows'; // `todo`: Why is this still Hypha when config has changed?
 
     final request = createRequest(
         code: SeedsCode.accountJoin,

--- a/lib/datasource/remote/api/stat_repository.dart
+++ b/lib/datasource/remote/api/stat_repository.dart
@@ -1,8 +1,6 @@
 import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
 import 'package:seeds/datasource/remote/api/http_repo/http_repository.dart';
-import 'package:seeds/datasource/remote/model/balance_model.dart';
-import 'package:seeds/datasource/remote/model/token_model.dart';
 import 'package:seeds/datasource/remote/model/stat_model.dart';
 
 class StatRepository extends HttpRepository {
@@ -23,7 +21,8 @@ class StatRepository extends HttpRepository {
 
     return http
         .post(statURL, headers: headers, body: request)
-        .then((http.Response response) => mapHttpResponse<StatModel>(response, (dynamic body) {
+        .then((http.Response response) =>
+            mapHttpResponse<StatModel>(response, (dynamic body) {
               return StatModel.fromJson(body);
             }))
         .catchError((dynamic error) => mapHttpError(error));

--- a/lib/datasource/remote/model/token_model.dart
+++ b/lib/datasource/remote/model/token_model.dart
@@ -3,12 +3,11 @@ import 'package:async/async.dart';
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
-import 'package:json_schema2/json_schema2.dart';
+import 'package:json_schema/json_schema.dart';
 import 'package:seeds/datasource/remote/api/tokenmodels_repository.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_remote_config.dart';
 import 'package:seeds/domain-shared/shared_use_cases/get_token_models_use_case.dart';
 import 'package:seeds/screens/wallet/components/tokens_cards/components/currency_info_card.dart';
-
 
 class TokenModel extends Equatable {
   static const seedsEcosysUsecase = 'seedsecosys';
@@ -29,16 +28,15 @@ class TokenModel extends Equatable {
   String get id => "$contract#$symbol";
 
   ImageProvider get backgroundImage {
-    return
-      backgroundImageUrl.startsWith("assets") ?
-      AssetImage(backgroundImageUrl) as ImageProvider :
-      NetworkImage(backgroundImageUrl);
+    return backgroundImageUrl.startsWith("assets")
+        ? AssetImage(backgroundImageUrl) as ImageProvider
+        : NetworkImage(backgroundImageUrl);
   }
+
   ImageProvider get logo {
-    return
-      logoUrl.startsWith("assets") ?
-      AssetImage(logoUrl) as ImageProvider :
-      NetworkImage(logoUrl);
+    return logoUrl.startsWith("assets")
+        ? AssetImage(logoUrl) as ImageProvider
+        : NetworkImage(logoUrl);
   }
 
   const TokenModel({
@@ -56,20 +54,20 @@ class TokenModel extends Equatable {
 
   static Future<Result<void>> installSchema() async {
     final result = await TokenModelsRepository().getSchema();
-      if(result.isValue) {
-        final tmastrSchemaMap = result.asValue!.value;
-        tmastrSchema = JsonSchema.createSchema(tmastrSchemaMap);
-        return Result.value(null);
-      }
-      print('Error getting Token Master schema from chain');
-      return result;
+    if (result.isValue) {
+      final tmastrSchemaMap = result.asValue!.value;
+      tmastrSchema = JsonSchema.create(tmastrSchemaMap);
+      return Result.value(null);
+    }
+    print('Error getting Token Master schema from chain');
+    return result;
   }
 
-  static TokenModel? fromJson(Map<String,dynamic> data) {
-    final Map<String,dynamic> parsedJson = json.decode(data["json"]);
+  static TokenModel? fromJson(Map<String, dynamic> data) {
+    final Map<String, dynamic> parsedJson = json.decode(data["json"]);
     bool extendJson(String dataField, String jsonField) {
       final jsonData = parsedJson[jsonField];
-      if( jsonData != null && jsonData != data[dataField] ) {
+      if (jsonData != null && jsonData != data[dataField]) {
         print('${data[dataField]}: mismatched $dataField in json'
             ' $jsonData, ${data[dataField]}');
         return false;
@@ -78,32 +76,36 @@ class TokenModel extends Equatable {
         return true;
       }
     }
-    if (!( extendJson("chainName", "chain") &&
-           extendJson("contract", "account") &&
-           extendJson("symbolcode", "symbol") &&
-           extendJson("usecases", "usecases"))) {
+
+    if (!(extendJson("chainName", "chain") &&
+        extendJson("contract", "account") &&
+        extendJson("symbolcode", "symbol") &&
+        extendJson("usecases", "usecases"))) {
       return null;
     }
-    if(tmastrSchema == null) {
+    if (tmastrSchema == null) {
       return null;
     }
-    final validationErrors = tmastrSchema!.validateWithErrors(parsedJson);
-    if(validationErrors.isNotEmpty) {
-      print('${data["symbolcode"]}:\t${validationErrors.map((e) => e.toString())}');
+    final validationErrors = tmastrSchema!.validate(parsedJson).errors;
+    if (validationErrors.isNotEmpty) {
+      print(
+          '${data["symbolcode"]}:\t${validationErrors.map((e) => e.toString())}');
       return null;
     }
     return TokenModel(
-        chainName: parsedJson["chain"]!,
-        contract: parsedJson["account"]!,
-        symbol: parsedJson["symbol"]!,
-        name: parsedJson["name"]!,
-        logoUrl: parsedJson["logo"]!,
-        balanceSubTitle: parsedJson["subtitle"] ?? CurrencyInfoCard.defaultBalanceSubtitle,
-        backgroundImageUrl: parsedJson["bg_image"] ?? CurrencyInfoCard.defaultBgImage,
-        overdraw: parsedJson["overdraw"] ?? "allow",
-        precision: parsedJson["precision"] ?? 4,
-        usecases: parsedJson["usecases"],
-      );
+      chainName: parsedJson["chain"]!,
+      contract: parsedJson["account"]!,
+      symbol: parsedJson["symbol"]!,
+      name: parsedJson["name"]!,
+      logoUrl: parsedJson["logo"]!,
+      balanceSubTitle:
+          parsedJson["subtitle"] ?? CurrencyInfoCard.defaultBalanceSubtitle,
+      backgroundImageUrl:
+          parsedJson["bg_image"] ?? CurrencyInfoCard.defaultBgImage,
+      overdraw: parsedJson["overdraw"] ?? "allow",
+      precision: parsedJson["precision"] ?? 4,
+      usecases: parsedJson["usecases"],
+    );
   }
 
   static TokenModel? fromId(String tokenId) {
@@ -118,9 +120,13 @@ class TokenModel extends Equatable {
   List<Object?> get props => [chainName, contract, symbol];
 
   static String getAssetString(String? id, double quantity) {
-    if (id!=null && TokenModel.fromId(id)!=null && contractPrecisions.containsKey(id)) {
+    if (id != null &&
+        TokenModel.fromId(id) != null &&
+        contractPrecisions.containsKey(id)) {
       final symbol = TokenModel.fromId(id)!.symbol;
-      return symbol==null ? "" : "${quantity.toStringAsFixed(contractPrecisions[id]!)} $symbol";
+      return symbol == null
+          ? ""
+          : "${quantity.toStringAsFixed(contractPrecisions[id]!)} $symbol";
     } else {
       return "";
     }
@@ -132,7 +138,7 @@ class TokenModel extends Equatable {
     if (ss.isEmpty) {
       return;
     }
-    contractPrecisions[this.id] = ss.length==1 ? 0 : ss[1].length;
+    contractPrecisions[this.id] = ss.length == 1 ? 0 : ss[1].length;
   }
 
   // enabling 'send' transfer validity checks, e.g. Mutual Credit,
@@ -146,36 +152,42 @@ class TokenModel extends Equatable {
     print("unexpected overdraw field: $overdraw");
     return false;
   }
+
   String? warnTransfer(double insufficiency, String? toAccount) {
     return insufficiency > 0 ? "insufficient balance" : null;
   }
 
-  static Future<void> updateModels(List<String> acceptList, [List<String>? infoList]) async {
-    final selector = TokenModelSelector(acceptList: acceptList, infoList: infoList);
+  static Future<void> updateModels(List<String> acceptList,
+      [List<String>? infoList]) async {
+    final selector =
+        TokenModelSelector(acceptList: acceptList, infoList: infoList);
     final tokenListResult = await GetTokenModelsUseCase().run(selector);
-    if(tokenListResult.isError) {
+    if (tokenListResult.isError) {
       return;
     }
     final tokenList = tokenListResult.asValue!.value;
-    for(final newtoken in tokenList) {
-      allTokens.removeWhere((token) => token.contract==newtoken.contract
-                                       && token.chainName==newtoken.chainName
-                                       && token.symbol==newtoken.symbol);
+    for (final newtoken in tokenList) {
+      allTokens.removeWhere((token) =>
+          token.contract == newtoken.contract &&
+          token.chainName == newtoken.chainName &&
+          token.symbol == newtoken.symbol);
     }
     allTokens.addAll(tokenList);
   }
 
-  static Future<void> installModels(List<String> acceptList, [List<String>? infoList]) async {
-    if( remoteConfigurations.featureFlagTokenMasterListEnabled) {
+  static Future<void> installModels(List<String> acceptList,
+      [List<String>? infoList]) async {
+    if (remoteConfigurations.featureFlagTokenMasterListEnabled) {
       final installResult = await installSchema();
-      if(installResult.isValue) {
+      if (installResult.isValue) {
         allTokens = [seedsToken];
         await updateModels(acceptList, infoList);
         return;
       }
     }
     allTokens = _staticTokenList;
-    contractPrecisions = Map.fromEntries(allTokens.map((t) => MapEntry(t.id , t.precision)));
+    contractPrecisions =
+        Map.fromEntries(allTokens.map((t) => MapEntry(t.id, t.precision)));
   }
 
   static void pruneRemoving(List<String> useCaseList) {
@@ -184,8 +196,8 @@ class TokenModel extends Equatable {
   }
 
   static void pruneKeeping(List<String> useCaseList) {
-    allTokens.removeWhere((token) => !
-    (token.usecases?.any((uc) => useCaseList.contains(uc)) ?? false));
+    allTokens.removeWhere((token) =>
+        !(token.usecases?.any((uc) => useCaseList.contains(uc)) ?? false));
   }
 }
 
@@ -194,20 +206,29 @@ const seedsToken = TokenModel(
   contract: "token.seeds",
   symbol: "SEEDS",
   name: "Seeds",
-  backgroundImageUrl: 'assets/images/wallet/currency_info_cards/seeds/background.jpg',
+  backgroundImageUrl:
+      'assets/images/wallet/currency_info_cards/seeds/background.jpg',
   logoUrl: 'assets/images/wallet/currency_info_cards/seeds/logo.jpg',
   balanceSubTitle: 'Wallet Balance',
   overdraw: "block",
   usecases: ["lightwallet", TokenModel.seedsEcosysUsecase],
 );
 
-final _staticTokenList = [seedsToken, _husdToken, _hyphaToken, _localScaleToken, _starsToken, _telosToken];
+final _staticTokenList = [
+  seedsToken,
+  _husdToken,
+  _hyphaToken,
+  _localScaleToken,
+  _starsToken,
+  _telosToken
+];
 const _husdToken = TokenModel(
   chainName: "Telos",
   contract: "husd.hypha",
   symbol: "HUSD",
   name: "HUSD",
-  backgroundImageUrl: 'assets/images/wallet/currency_info_cards/husd/background.jpg',
+  backgroundImageUrl:
+      'assets/images/wallet/currency_info_cards/husd/background.jpg',
   logoUrl: 'assets/images/wallet/currency_info_cards/husd/logo.jpg',
   balanceSubTitle: 'Wallet Balance',
   overdraw: "block",
@@ -220,7 +241,8 @@ const _hyphaToken = TokenModel(
   contract: "hypha.hypha",
   symbol: "HYPHA",
   name: "Hypha",
-  backgroundImageUrl: 'assets/images/wallet/currency_info_cards/hypha/background.jpg',
+  backgroundImageUrl:
+      'assets/images/wallet/currency_info_cards/hypha/background.jpg',
   logoUrl: 'assets/images/wallet/currency_info_cards/hypha/logo.jpg',
   balanceSubTitle: 'Wallet Balance',
   overdraw: "block",
@@ -233,7 +255,8 @@ const _localScaleToken = TokenModel(
   contract: "token.local",
   symbol: "LSCL",
   name: "LocalScale",
-  backgroundImageUrl: 'assets/images/wallet/currency_info_cards/lscl/background.jpg',
+  backgroundImageUrl:
+      'assets/images/wallet/currency_info_cards/lscl/background.jpg',
   logoUrl: 'assets/images/wallet/currency_info_cards/lscl/logo.png',
   balanceSubTitle: 'Wallet Balance',
   overdraw: "block",
@@ -245,7 +268,8 @@ const _starsToken = TokenModel(
   contract: "star.seeds",
   symbol: "STARS",
   name: "Stars",
-  backgroundImageUrl: 'assets/images/wallet/currency_info_cards/stars/background.jpg',
+  backgroundImageUrl:
+      'assets/images/wallet/currency_info_cards/stars/background.jpg',
   logoUrl: 'assets/images/wallet/currency_info_cards/stars/logo.jpg',
   balanceSubTitle: 'Wallet Balance',
   overdraw: "block",
@@ -257,7 +281,8 @@ const _telosToken = TokenModel(
   contract: "eosio.token",
   symbol: "TLOS",
   name: "Telos",
-  backgroundImageUrl: 'assets/images/wallet/currency_info_cards/tlos/background.png',
+  backgroundImageUrl:
+      'assets/images/wallet/currency_info_cards/tlos/background.png',
   logoUrl: 'assets/images/wallet/currency_info_cards/tlos/logo.png',
   balanceSubTitle: 'Wallet Balance',
   overdraw: "block",

--- a/lib/design/app_color_schemes.dart
+++ b/lib/design/app_color_schemes.dart
@@ -6,8 +6,6 @@ class AppColorSchemes {
   static const ColorScheme darkColorScheme = ColorScheme(
     surfaceTint: Colors.brown,
     primaryContainer: Colors.amber,
-    background: AppColors.primary,
-    onBackground: AppColors.white,
     primary: AppColors.purple,
     secondary: AppColors.green1,
     surface: AppColors.primary,
@@ -37,7 +35,6 @@ class AppColorSchemes {
 
   // TODO(gguij004): not completed, to work on it after the darkScheme.
   static const lightColorScheme = ColorScheme(
-    background: Colors.amber,
     primary: Colors.black,
     secondary: Colors.brown,
     surface: Colors.purpleAccent,
@@ -46,7 +43,6 @@ class AppColorSchemes {
     onError: Colors.redAccent,
     brightness: Brightness.light,
     onSurface: Colors.redAccent,
-    onBackground: Colors.redAccent,
     error: Colors.red,
   );
 }

--- a/lib/design/app_theme.dart
+++ b/lib/design/app_theme.dart
@@ -9,17 +9,20 @@ class SeedsAppTheme {
       useMaterial3: true,
       colorScheme: AppColorSchemes.darkColorScheme,
       appBarTheme: const AppBarTheme(
-          elevation: 0.0, titleTextStyle: TextStyle(fontSize: 18, fontWeight: FontWeight.w600) // headline7
+          elevation: 0.0,
+          titleTextStyle:
+              TextStyle(fontSize: 18, fontWeight: FontWeight.w600) // headline7
           ),
-      scaffoldBackgroundColor: AppColorSchemes.darkColorScheme.background,
-      bottomNavigationBarTheme:
-          BottomNavigationBarThemeData(backgroundColor: AppColorSchemes.darkColorScheme.background),
+      scaffoldBackgroundColor: AppColorSchemes.darkColorScheme.surface,
+      bottomNavigationBarTheme: BottomNavigationBarThemeData(
+          backgroundColor: AppColorSchemes.darkColorScheme.surface),
       fontFamily: 'SFProDisplay',
       textTheme: SeedsTextTheme.darkTheme,
       inputDecorationTheme: SeedsInputDecorationTheme.darkTheme,
       snackBarTheme: SnackBarThemeData(
         behavior: SnackBarBehavior.floating,
-        contentTextStyle: TextStyle(color: AppColorSchemes.darkColorScheme.onBackground),
+        contentTextStyle:
+            TextStyle(color: AppColorSchemes.darkColorScheme.onSurface),
       ),
       indicatorColor: AppColorSchemes.darkColorScheme.secondary,
     );
@@ -35,7 +38,8 @@ class SeedsAppTheme {
       appBarTheme: const AppBarTheme(
         backgroundColor: AppColors.primary,
         elevation: 0.0,
-        titleTextStyle: TextStyle(fontSize: 18, fontWeight: FontWeight.w600), // headline7
+        titleTextStyle:
+            TextStyle(fontSize: 18, fontWeight: FontWeight.w600), // headline7
       ),
       inputDecorationTheme: SeedsInputDecorationTheme.lightTheme,
       snackBarTheme: const SnackBarThemeData(
@@ -58,7 +62,7 @@ class SeedsAppTheme {
   static ThemeData get darkTheme {
     return ThemeData(
       primaryColor: AppColors.primary,
-      scaffoldBackgroundColor: AppColorSchemes.darkColorScheme.background,
+      scaffoldBackgroundColor: AppColorSchemes.darkColorScheme.surface,
       fontFamily: 'SFProDisplay',
       textTheme: SeedsTextTheme.darkTheme,
       brightness: Brightness.dark,
@@ -66,7 +70,8 @@ class SeedsAppTheme {
       appBarTheme: const AppBarTheme(
         backgroundColor: AppColors.primary,
         elevation: 0.0,
-        titleTextStyle: TextStyle(fontSize: 18, fontWeight: FontWeight.w600), // headline7
+        titleTextStyle:
+            TextStyle(fontSize: 18, fontWeight: FontWeight.w600), // headline7
       ),
       inputDecorationTheme: SeedsInputDecorationTheme.darkTheme,
       snackBarTheme: const SnackBarThemeData(
@@ -101,19 +106,34 @@ class SeedsTextTheme {
     return Typography.material2018()
         .englishLike
         .copyWith(
-          headline3:
-              Typography.material2018().englishLike.headline3!.copyWith(fontSize: 42, fontWeight: FontWeight.w600),
-          headline4:
-              Typography.material2018().englishLike.headline4!.copyWith(fontSize: 36, fontWeight: FontWeight.w500),
-          headline5:
-              Typography.material2018().englishLike.headline5!.copyWith(fontSize: 28, fontWeight: FontWeight.w600),
-          headline6:
-              Typography.material2018().englishLike.headline6!.copyWith(fontSize: 22, fontWeight: FontWeight.w500),
-          subtitle1:
-              Typography.material2018().englishLike.subtitle1!.copyWith(fontSize: 18, fontWeight: FontWeight.w500),
-          subtitle2:
-              Typography.material2018().englishLike.subtitle2!.copyWith(fontSize: 14, fontWeight: FontWeight.w400),
-          button: Typography.material2018().englishLike.button!.copyWith(fontSize: 16, fontWeight: FontWeight.w500),
+          displaySmall: Typography.material2018()
+              .englishLike
+              .displaySmall!
+              .copyWith(fontSize: 42, fontWeight: FontWeight.w600),
+          headlineMedium: Typography.material2018()
+              .englishLike
+              .headlineMedium!
+              .copyWith(fontSize: 36, fontWeight: FontWeight.w500),
+          headlineSmall: Typography.material2018()
+              .englishLike
+              .headlineSmall!
+              .copyWith(fontSize: 28, fontWeight: FontWeight.w600),
+          titleLarge: Typography.material2018()
+              .englishLike
+              .titleLarge!
+              .copyWith(fontSize: 22, fontWeight: FontWeight.w500),
+          titleMedium: Typography.material2018()
+              .englishLike
+              .titleMedium!
+              .copyWith(fontSize: 18, fontWeight: FontWeight.w500),
+          titleSmall: Typography.material2018()
+              .englishLike
+              .titleSmall!
+              .copyWith(fontSize: 14, fontWeight: FontWeight.w400),
+          labelLarge: Typography.material2018()
+              .englishLike
+              .labelLarge!
+              .copyWith(fontSize: 16, fontWeight: FontWeight.w500),
         )
         .apply(displayColor: Colors.black, bodyColor: Colors.black);
   }
@@ -122,19 +142,34 @@ class SeedsTextTheme {
     return Typography.material2018()
         .englishLike
         .copyWith(
-          headline3:
-              Typography.material2018().englishLike.headline3!.copyWith(fontSize: 42, fontWeight: FontWeight.w600),
-          headline4:
-              Typography.material2018().englishLike.headline4!.copyWith(fontSize: 36, fontWeight: FontWeight.w500),
-          headline5:
-              Typography.material2018().englishLike.headline5!.copyWith(fontSize: 28, fontWeight: FontWeight.w600),
-          headline6:
-              Typography.material2018().englishLike.headline6!.copyWith(fontSize: 22, fontWeight: FontWeight.w500),
-          subtitle1:
-              Typography.material2018().englishLike.subtitle1!.copyWith(fontSize: 18, fontWeight: FontWeight.w500),
-          subtitle2:
-              Typography.material2018().englishLike.subtitle2!.copyWith(fontSize: 14, fontWeight: FontWeight.w400),
-          button: Typography.material2018().englishLike.button!.copyWith(fontSize: 16, fontWeight: FontWeight.w500),
+          displaySmall: Typography.material2018()
+              .englishLike
+              .displaySmall!
+              .copyWith(fontSize: 42, fontWeight: FontWeight.w600),
+          headlineMedium: Typography.material2018()
+              .englishLike
+              .headlineMedium!
+              .copyWith(fontSize: 36, fontWeight: FontWeight.w500),
+          headlineSmall: Typography.material2018()
+              .englishLike
+              .headlineSmall!
+              .copyWith(fontSize: 28, fontWeight: FontWeight.w600),
+          titleLarge: Typography.material2018()
+              .englishLike
+              .titleLarge!
+              .copyWith(fontSize: 22, fontWeight: FontWeight.w500),
+          titleMedium: Typography.material2018()
+              .englishLike
+              .titleMedium!
+              .copyWith(fontSize: 18, fontWeight: FontWeight.w500),
+          titleSmall: Typography.material2018()
+              .englishLike
+              .titleSmall!
+              .copyWith(fontSize: 14, fontWeight: FontWeight.w400),
+          labelLarge: Typography.material2018()
+              .englishLike
+              .labelLarge!
+              .copyWith(fontSize: 16, fontWeight: FontWeight.w500),
         )
         .apply(displayColor: Colors.white, bodyColor: Colors.white);
   }
@@ -143,114 +178,157 @@ class SeedsTextTheme {
 // Make sure to import this file in order to use this text styles USE: import 'package:seeds/design/app_theme.dart';
 // https://dart.dev/guides/language/extension-methods
 extension CustomStyles on TextTheme {
-  TextStyle get headline7 => const TextStyle(fontSize: 18, fontWeight: FontWeight.w600);
+  TextStyle get headline7 =>
+      const TextStyle(fontSize: 18, fontWeight: FontWeight.w600);
 
-  TextStyle get headline7LowEmphasis => const TextStyle(fontSize: 18, fontWeight: FontWeight.w400);
+  TextStyle get headline7LowEmphasis =>
+      const TextStyle(fontSize: 18, fontWeight: FontWeight.w400);
 
-  TextStyle get headline8 => const TextStyle(fontSize: 20, fontWeight: FontWeight.w500);
+  TextStyle get headline8 =>
+      const TextStyle(fontSize: 20, fontWeight: FontWeight.w500);
 
-  TextStyle get subtitle1HighEmphasis =>
-      Typography.material2018().englishLike.subtitle1!.copyWith(fontSize: 18, fontWeight: FontWeight.w600);
-
-  TextStyle get subtitle2HighEmphasis =>
-      Typography.material2018().englishLike.subtitle2!.copyWith(fontSize: 14, fontWeight: FontWeight.w500);
-
-  TextStyle get subtitle2LowEmphasis =>
-      Typography.material2018().englishLike.subtitle2!.copyWith(fontSize: 14, fontWeight: FontWeight.w300);
-
-  TextStyle get subtitle2OpacityEmphasis => Typography.material2018()
+  TextStyle get subtitle1HighEmphasis => Typography.material2018()
       .englishLike
-      .subtitle2!
-      .copyWith(fontSize: 12, fontWeight: FontWeight.w400, color: Colors.white.withOpacity(0.5));
+      .titleMedium!
+      .copyWith(fontSize: 18, fontWeight: FontWeight.w600);
 
-  TextStyle get subtitle2OpacityBlack => Typography.material2018()
+  TextStyle get subtitle2HighEmphasis => Typography.material2018()
       .englishLike
-      .subtitle2!
-      .copyWith(fontSize: 14, fontWeight: FontWeight.w400, color: Colors.black.withOpacity(0.5));
+      .titleSmall!
+      .copyWith(fontSize: 14, fontWeight: FontWeight.w500);
 
-  TextStyle get subtitle3 =>
-      Typography.material2018().englishLike.subtitle2!.copyWith(fontSize: 12, fontWeight: FontWeight.w400);
+  TextStyle get subtitle2LowEmphasis => Typography.material2018()
+      .englishLike
+      .titleSmall!
+      .copyWith(fontSize: 14, fontWeight: FontWeight.w300);
 
-  TextStyle get subtitle2Green3LowEmphasis => subtitle2LowEmphasis.copyWith(color: AppColors.green3);
+  TextStyle get subtitle2OpacityEmphasis =>
+      Typography.material2018().englishLike.titleSmall!.copyWith(
+          fontSize: 12,
+          fontWeight: FontWeight.w400,
+          color: Colors.white.withOpacity(0.5));
 
-  TextStyle get subtitle2BlackHighEmphasis => subtitle2HighEmphasis.copyWith(color: AppColors.black);
+  TextStyle get subtitle2OpacityBlack =>
+      Typography.material2018().englishLike.titleSmall!.copyWith(
+          fontSize: 14,
+          fontWeight: FontWeight.w400,
+          color: Colors.black.withOpacity(0.5));
 
-  TextStyle get subtitle2HighEmphasisGreen1 => subtitle2HighEmphasis.copyWith(color: AppColors.green1);
+  TextStyle get subtitle3 => Typography.material2018()
+      .englishLike
+      .titleSmall!
+      .copyWith(fontSize: 12, fontWeight: FontWeight.w400);
 
-  TextStyle get subtitle2BlackLowEmphasis => subtitle2LowEmphasis.copyWith(color: AppColors.black);
+  TextStyle get subtitle2Green3LowEmphasis =>
+      subtitle2LowEmphasis.copyWith(color: AppColors.green3);
 
-  TextStyle get subtitle2Black => subtitle2!.copyWith(color: AppColors.black);
+  TextStyle get subtitle2BlackHighEmphasis =>
+      subtitle2HighEmphasis.copyWith(color: AppColors.black);
 
-  TextStyle get subtitle2Green2 => subtitle2!.copyWith(color: AppColors.green2);
+  TextStyle get subtitle2HighEmphasisGreen1 =>
+      subtitle2HighEmphasis.copyWith(color: AppColors.green1);
 
-  TextStyle get subtitle2Darkgreen1L => subtitle2!.copyWith(color: AppColors.primary);
+  TextStyle get subtitle2BlackLowEmphasis =>
+      subtitle2LowEmphasis.copyWith(color: AppColors.black);
 
-  TextStyle get subtitle2OpacityEmphasisBlack => subtitle2OpacityEmphasis.copyWith(color: AppColors.black);
+  TextStyle get subtitle2Black => titleSmall!.copyWith(color: AppColors.black);
+
+  TextStyle get subtitle2Green2 =>
+      titleSmall!.copyWith(color: AppColors.green2);
+
+  TextStyle get subtitle2Darkgreen1L =>
+      titleSmall!.copyWith(color: AppColors.primary);
+
+  TextStyle get subtitle2OpacityEmphasisBlack =>
+      subtitle2OpacityEmphasis.copyWith(color: AppColors.black);
 
   TextStyle get subtitle3Green => subtitle3.copyWith(color: AppColors.green3);
 
   TextStyle get subtitle3Red => subtitle3.copyWith(color: AppColors.red1);
 
-  TextStyle get subtitle3Opacity => subtitle3.copyWith(color: Colors.white.withOpacity(0.5));
+  TextStyle get subtitle3Opacity =>
+      subtitle3.copyWith(color: Colors.white.withOpacity(0.5));
 
-  TextStyle get subtitle3LightGreen6 => subtitle3.copyWith(color: AppColors.lightGreen6);
+  TextStyle get subtitle3LightGreen6 =>
+      subtitle3.copyWith(color: AppColors.lightGreen6);
 
-  TextStyle get subtitle3OpacityEmphasis => Typography.material2018()
+  TextStyle get subtitle3OpacityEmphasis =>
+      Typography.material2018().englishLike.titleSmall!.copyWith(
+          fontSize: 13,
+          fontWeight: FontWeight.w400,
+          color: Colors.white.withOpacity(0.5));
+
+  TextStyle get subtitle3OpacityEmphasisGreen =>
+      subtitle3.copyWith(color: AppColors.green3);
+
+  TextStyle get subtitle3OpacityEmphasisRed =>
+      subtitle3.copyWith(color: AppColors.red1);
+
+  TextStyle get subtitle4 => Typography.material2018()
       .englishLike
-      .subtitle2!
-      .copyWith(fontSize: 13, fontWeight: FontWeight.w400, color: Colors.white.withOpacity(0.5));
-
-  TextStyle get subtitle3OpacityEmphasisGreen => subtitle3.copyWith(color: AppColors.green3);
-
-  TextStyle get subtitle3OpacityEmphasisRed => subtitle3.copyWith(color: AppColors.red1);
-
-  TextStyle get subtitle4 =>
-      Typography.material2018().englishLike.subtitle2!.copyWith(fontSize: 13, fontWeight: FontWeight.w400);
+      .titleSmall!
+      .copyWith(fontSize: 13, fontWeight: FontWeight.w400);
 
   TextStyle get buttonHighEmphasis => Typography.material2018()
       .englishLike
-      .button!
+      .labelLarge!
       .copyWith(fontSize: 16, fontWeight: FontWeight.w500, letterSpacing: 2);
 
-  TextStyle get buttonOpacityEmphasis => Typography.material2018()
+  TextStyle get buttonOpacityEmphasis =>
+      Typography.material2018().englishLike.labelLarge!.copyWith(
+          fontSize: 16,
+          fontWeight: FontWeight.w400,
+          letterSpacing: 2,
+          color: Colors.white.withOpacity(0.5));
+
+  TextStyle get buttonLowEmphasis => Typography.material2018()
       .englishLike
-      .button!
-      .copyWith(fontSize: 16, fontWeight: FontWeight.w400, letterSpacing: 2, color: Colors.white.withOpacity(0.5));
+      .labelLarge!
+      .copyWith(fontSize: 16, fontWeight: FontWeight.w400);
 
-  TextStyle get buttonLowEmphasis =>
-      Typography.material2018().englishLike.button!.copyWith(fontSize: 16, fontWeight: FontWeight.w400);
-
-  TextStyle get button1 =>
-      Typography.material2018().englishLike.button!.copyWith(fontSize: 25, fontWeight: FontWeight.w400);
-
-  TextStyle get button1Black => Typography.material2018().englishLike.button1.copyWith(color: AppColors.darkGreen2);
-
-  TextStyle get buttonWhiteL => Typography.material2018().englishLike.button!.copyWith(color: AppColors.white);
-
-  TextStyle get buttonGreen1 => Typography.material2018().englishLike.button!.copyWith(color: AppColors.green1);
-
-  TextStyle get buttonBlack => Typography.material2018()
+  TextStyle get button1 => Typography.material2018()
       .englishLike
-      .button!
-      .copyWith(fontSize: 16, fontWeight: FontWeight.w500, color: AppColors.black);
+      .labelLarge!
+      .copyWith(fontSize: 25, fontWeight: FontWeight.w400);
 
-  TextStyle get headline4Black => Typography.material2018()
+  TextStyle get button1Black => Typography.material2018()
       .englishLike
-      .headline4!
-      .copyWith(fontSize: 36, fontWeight: FontWeight.w500, color: AppColors.black);
+      .button1
+      .copyWith(color: AppColors.darkGreen2);
 
-  TextStyle get headline6Green => Typography.material2018()
+  TextStyle get buttonWhiteL => Typography.material2018()
       .englishLike
-      .headline6!
-      .copyWith(fontSize: 22, fontWeight: FontWeight.w500, color: AppColors.green3);
+      .labelLarge!
+      .copyWith(color: AppColors.white);
 
-  TextStyle get headline7Green =>
-      headline7.copyWith(fontSize: 22, fontWeight: FontWeight.w500, color: AppColors.green3);
+  TextStyle get buttonGreen1 => Typography.material2018()
+      .englishLike
+      .labelLarge!
+      .copyWith(color: AppColors.green1);
 
-  TextStyle get subtitle1Green1 =>
-      subtitle1!.copyWith(fontSize: 18, fontWeight: FontWeight.w500, letterSpacing: 2, color: AppColors.green1);
+  TextStyle get buttonBlack =>
+      Typography.material2018().englishLike.labelLarge!.copyWith(
+          fontSize: 16, fontWeight: FontWeight.w500, color: AppColors.black);
 
-  TextStyle get subtitle1Red2 => subtitle1Green1.copyWith(color: AppColors.red1);
+  TextStyle get headline4Black =>
+      Typography.material2018().englishLike.headlineMedium!.copyWith(
+          fontSize: 36, fontWeight: FontWeight.w500, color: AppColors.black);
+
+  TextStyle get headline6Green =>
+      Typography.material2018().englishLike.titleLarge!.copyWith(
+          fontSize: 22, fontWeight: FontWeight.w500, color: AppColors.green3);
+
+  TextStyle get headline7Green => headline7.copyWith(
+      fontSize: 22, fontWeight: FontWeight.w500, color: AppColors.green3);
+
+  TextStyle get subtitle1Green1 => titleMedium!.copyWith(
+      fontSize: 18,
+      fontWeight: FontWeight.w500,
+      letterSpacing: 2,
+      color: AppColors.green1);
+
+  TextStyle get subtitle1Red2 =>
+      subtitle1Green1.copyWith(color: AppColors.red1);
 }
 
 class SeedsInputDecorationTheme {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,7 @@ Future<void> main() async {
   // for details: https://docs.flutter.dev/testing/errors
   await runZonedGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
-    await dotenv.load(fileName: '.env');
+    await dotenv.load();
     await Firebase.initializeApp();
     await settingsStorage.initialise();
     await PushNotificationService().initialise();

--- a/lib/screens/app/app.dart
+++ b/lib/screens/app/app.dart
@@ -140,7 +140,7 @@ class _AppState extends State<App> with WidgetsBindingObserver {
         ),
         bottomNavigationBar: BlocBuilder<AppBloc, AppState>(
           builder: (context, state) {
-            return Container(
+            return DecoratedBox(
               decoration: const BoxDecoration(border: Border(top: BorderSide(color: AppColors.white, width: 0.2))),
               child: BottomNavigationBar(
                 currentIndex: state.index,
@@ -149,7 +149,7 @@ class _AppState extends State<App> with WidgetsBindingObserver {
                 unselectedLabelStyle: Theme.of(context).textTheme.subtitle3,
                 selectedItemColor: AppColors.white,
                 items: [
-                  for (var i in _appScreenItems)
+                  for (final i in _appScreenItems)
                     BottomNavigationBarItem(
                       activeIcon:
                           Padding(padding: const EdgeInsets.only(bottom: 4.0), child: SvgPicture.asset(i.iconSelected)),

--- a/lib/screens/app/components/account_under_recovery_screen.dart
+++ b/lib/screens/app/components/account_under_recovery_screen.dart
@@ -16,7 +16,8 @@ class AccountUnderRecoveryScreen extends StatelessWidget {
         child: CustomDialog(
           singleLargeButtonTitle: 'Cancel Recovery'.i18n,
           onSingleLargeButtonPressed: () {
-            BlocProvider.of<AppBloc>(context).add(const OnStopGuardianActiveRecoveryTapped());
+            BlocProvider.of<AppBloc>(context)
+                .add(const OnStopGuardianActiveRecoveryTapped());
           },
           children: [
             Container(
@@ -24,16 +25,19 @@ class AccountUnderRecoveryScreen extends StatelessWidget {
               width: 250,
               decoration: const BoxDecoration(
                 color: AppColors.white,
-                borderRadius: BorderRadius.all(Radius.circular(defaultCardBorderRadius)),
+                borderRadius:
+                    BorderRadius.all(Radius.circular(defaultCardBorderRadius)),
                 image: DecorationImage(
-                    image: AssetImage('assets/images/guardians/guardian_shield.png'), fit: BoxFit.fitWidth),
+                    image: AssetImage(
+                        'assets/images/guardians/guardian_shield.png'),
+                    fit: BoxFit.fitWidth),
               ),
             ),
             const SizedBox(height: 20),
             Text(
               'Recovery Mode Initiated'.i18n,
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.headline6,
+              style: Theme.of(context).textTheme.titleLarge,
             ),
             const SizedBox(height: 30),
             Padding(

--- a/lib/screens/app/components/guardian_approve_or_deny_recovery_screen.dart
+++ b/lib/screens/app/components/guardian_approve_or_deny_recovery_screen.dart
@@ -20,10 +20,12 @@ class GuardianApproveOrDenyScreen extends StatelessWidget {
           leftButtonTitle: 'Dismiss'.i18n,
           rightButtonTitle: 'Accept Request'.i18n,
           onLeftButtonPressed: () {
-            BlocProvider.of<AppBloc>(context).add(OnDismissGuardianRecoveryTapped());
+            BlocProvider.of<AppBloc>(context)
+                .add(OnDismissGuardianRecoveryTapped());
           },
           onRightButtonPressed: () {
-            BlocProvider.of<AppBloc>(context).add(OnApproveGuardianRecoveryTapped(data));
+            BlocProvider.of<AppBloc>(context)
+                .add(OnApproveGuardianRecoveryTapped(data));
           },
           children: [
             Container(
@@ -31,16 +33,19 @@ class GuardianApproveOrDenyScreen extends StatelessWidget {
               width: 250,
               decoration: const BoxDecoration(
                 color: AppColors.white,
-                borderRadius: BorderRadius.all(Radius.circular(defaultCardBorderRadius)),
+                borderRadius:
+                    BorderRadius.all(Radius.circular(defaultCardBorderRadius)),
                 image: DecorationImage(
-                    image: AssetImage('assets/images/guardians/guardian_shield.png'), fit: BoxFit.fitWidth),
+                    image: AssetImage(
+                        'assets/images/guardians/guardian_shield.png'),
+                    fit: BoxFit.fitWidth),
               ),
             ),
             const SizedBox(height: 20),
             Text(
               'Account Recovery Request'.i18n,
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.headline6,
+              style: Theme.of(context).textTheme.titleLarge,
             ),
             const SizedBox(height: 30),
             Padding(

--- a/lib/screens/app/interactor/viewmodels/connection_notifier.dart
+++ b/lib/screens/app/interactor/viewmodels/connection_notifier.dart
@@ -55,7 +55,7 @@ class ConnectionNotifier extends ChangeNotifier {
         return Endpoint(endpoint, infinitePing);
       }
     } catch (err) {
-      print('error pinging: ${err.toString()}');
+      print('error pinging: $err');
       return Endpoint(endpoint, doubleInfinitePing);
     }
   }

--- a/lib/screens/authentication/import_key/components/import_key_accounts_widget.dart
+++ b/lib/screens/authentication/import_key/components/import_key_accounts_widget.dart
@@ -19,8 +19,8 @@ class ImportKeyAccountsWidget extends StatelessWidget {
     return BlocConsumer<ImportKeyBloc, ImportKeyState>(
       listenWhen: (_, current) => current.accountSelected != null,
       listener: (context, state) {
-        BlocProvider.of<AuthenticationBloc>(context)
-            .add(OnImportAccount(account: state.accountSelected!, authData: state.authData!));
+        BlocProvider.of<AuthenticationBloc>(context).add(OnImportAccount(
+            account: state.accountSelected!, authData: state.authData!));
       },
       builder: (context, state) {
         switch (state.pageState) {
@@ -29,7 +29,8 @@ class ImportKeyAccountsWidget extends StatelessWidget {
           case PageState.failure:
             return Center(
                 child: Text(
-              state.error?.localizedDescription(context) ?? GlobalError.unknown.localizedDescription(context),
+              state.error?.localizedDescription(context) ??
+                  GlobalError.unknown.localizedDescription(context),
               style: Theme.of(context).textTheme.subtitle1Red2,
             ));
           case PageState.success:
@@ -38,13 +39,17 @@ class ImportKeyAccountsWidget extends StatelessWidget {
                 shrinkWrap: true,
                 children: state.accounts
                     .map((ProfileModel? profile) => Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 6, horizontal: horizontalEdgePadding),
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 6, horizontal: horizontalEdgePadding),
                           child: MaterialButton(
                             padding: EdgeInsets.zero,
                             color: AppColors.darkGreen2,
-                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(defaultCardBorderRadius)),
+                            shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(
+                                    defaultCardBorderRadius)),
                             onPressed: () {
-                              context.read<ImportKeyBloc>().add(AccountSelected(account: profile!.account));
+                              context.read<ImportKeyBloc>().add(
+                                  AccountSelected(account: profile!.account));
                             },
                             child: Padding(
                               padding: const EdgeInsets.only(top: 6, bottom: 6),
@@ -56,12 +61,16 @@ class ImportKeyAccountsWidget extends StatelessWidget {
                                   nickname: profile.nickname,
                                 ),
                                 title: Text(
-                                  profile.nickname.isNotEmpty ? profile.nickname : profile.account,
-                                  style: Theme.of(context).textTheme.button,
+                                  profile.nickname.isNotEmpty
+                                      ? profile.nickname
+                                      : profile.account,
+                                  style: Theme.of(context).textTheme.labelLarge,
                                 ),
                                 subtitle: Text(
                                   profile.account,
-                                  style: Theme.of(context).textTheme.subtitle3OpacityEmphasis,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .subtitle3OpacityEmphasis,
                                 ),
                                 trailing: const Icon(Icons.navigate_next),
                               ),

--- a/lib/screens/authentication/import_key/components/import_words_accounts_widget.dart
+++ b/lib/screens/authentication/import_key/components/import_words_accounts_widget.dart
@@ -19,8 +19,8 @@ class ImportWordsAccountsWidget extends StatelessWidget {
     return BlocConsumer<ImportKeyBloc, ImportKeyState>(
       listenWhen: (_, current) => current.accountSelected != null,
       listener: (context, state) {
-        BlocProvider.of<AuthenticationBloc>(context)
-            .add(OnImportAccount(account: state.accountSelected!, authData: state.authData!));
+        BlocProvider.of<AuthenticationBloc>(context).add(OnImportAccount(
+            account: state.accountSelected!, authData: state.authData!));
       },
       builder: (context, state) {
         switch (state.pageState) {
@@ -29,7 +29,8 @@ class ImportWordsAccountsWidget extends StatelessWidget {
           case PageState.failure:
             return Center(
                 child: Text(
-              state.error?.localizedDescription(context) ?? GlobalError.unknown.localizedDescription(context),
+              state.error?.localizedDescription(context) ??
+                  GlobalError.unknown.localizedDescription(context),
               style: Theme.of(context).textTheme.subtitle1Red2,
             ));
           case PageState.success:
@@ -41,9 +42,12 @@ class ImportWordsAccountsWidget extends StatelessWidget {
                         child: MaterialButton(
                           padding: EdgeInsets.zero,
                           color: AppColors.darkGreen2,
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(defaultCardBorderRadius)),
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(
+                                  defaultCardBorderRadius)),
                           onPressed: () {
-                            context.read<ImportKeyBloc>().add(AccountSelected(account: profile!.account));
+                            context.read<ImportKeyBloc>().add(
+                                AccountSelected(account: profile!.account));
                           },
                           child: Padding(
                             padding: const EdgeInsets.only(top: 6, bottom: 6),
@@ -55,12 +59,16 @@ class ImportWordsAccountsWidget extends StatelessWidget {
                                 nickname: profile.nickname,
                               ),
                               title: Text(
-                                profile.nickname.isNotEmpty ? profile.nickname : profile.account,
-                                style: Theme.of(context).textTheme.button,
+                                profile.nickname.isNotEmpty
+                                    ? profile.nickname
+                                    : profile.account,
+                                style: Theme.of(context).textTheme.labelLarge,
                               ),
                               subtitle: Text(
                                 profile.account,
-                                style: Theme.of(context).textTheme.subtitle3OpacityEmphasis,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .subtitle3OpacityEmphasis,
                               ),
                               trailing: const Icon(Icons.navigate_next),
                             ),

--- a/lib/screens/authentication/import_key/import_key_screen.dart
+++ b/lib/screens/authentication/import_key/import_key_screen.dart
@@ -40,7 +40,8 @@ class _ImportKeyScreenState extends State<ImportKeyScreen> {
   void _onSubmitted() {
     FocusScope.of(context).unfocus();
     if (_formImportKey.currentState!.validate()) {
-      _importKeyBloc.add(FindAccountByKey(privateKey: _keyController.text, words: []));
+      _importKeyBloc
+          .add(FindAccountByKey(privateKey: _keyController.text, words: []));
     }
   }
 
@@ -63,32 +64,40 @@ class _ImportKeyScreenState extends State<ImportKeyScreen> {
                         key: _formImportKey,
                         autovalidateMode: AutovalidateMode.disabled,
                         child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: horizontalEdgePadding),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: horizontalEdgePadding),
                           child: Column(
                             children: [
                               TextFormFieldCustom(
                                 autofocus: true,
-                                labelText: context.loc.importKeyPrivateKeyFieldPlaceholder,
+                                labelText: context
+                                    .loc.importKeyPrivateKeyFieldPlaceholder,
                                 suffixIcon: IconButton(
-                                  icon: const Icon(Icons.paste, color: AppColors.white),
+                                  icon: const Icon(Icons.paste,
+                                      color: AppColors.white),
                                   onPressed: () async {
-                                    final clipboardData = await Clipboard.getData('text/plain');
-                                    final clipboardText = clipboardData?.text ?? '';
+                                    final clipboardData =
+                                        await Clipboard.getData('text/plain');
+                                    final clipboardText =
+                                        clipboardData?.text ?? '';
                                     _keyController.text = clipboardText;
                                     // ignore: use_build_context_synchronously
-                                    BlocProvider.of<ImportKeyBloc>(context)
-                                        .add(OnPrivateKeyChange(privateKeyChanged: clipboardText));
+                                    BlocProvider.of<ImportKeyBloc>(context).add(
+                                        OnPrivateKeyChange(
+                                            privateKeyChanged: clipboardText));
                                     _onSubmitted();
                                   },
                                 ),
                                 onFieldSubmitted: (value) {
-                                  BlocProvider.of<ImportKeyBloc>(context)
-                                      .add(OnPrivateKeyChange(privateKeyChanged: value));
+                                  BlocProvider.of<ImportKeyBloc>(context).add(
+                                      OnPrivateKeyChange(
+                                          privateKeyChanged: value));
                                 },
                                 controller: _keyController,
                                 onChanged: (value) {
-                                  BlocProvider.of<ImportKeyBloc>(context)
-                                      .add(OnPrivateKeyChange(privateKeyChanged: value));
+                                  BlocProvider.of<ImportKeyBloc>(context).add(
+                                      OnPrivateKeyChange(
+                                          privateKeyChanged: value));
                                 },
                               ),
                             ],
@@ -100,18 +109,24 @@ class _ImportKeyScreenState extends State<ImportKeyScreen> {
                           padding: const EdgeInsets.all(16.0),
                           child: RichText(
                             text: TextSpan(
-                              style: Theme.of(context).textTheme.subtitle2,
+                              style: Theme.of(context).textTheme.titleSmall,
                               children: <TextSpan>[
                                 TextSpan(
-                                    text: context.loc.importKeyImportUsingRecoveryPhraseActionLink,
-                                    style: Theme.of(context).textTheme.subtitle2Green2,
+                                    text: context.loc
+                                        .importKeyImportUsingRecoveryPhraseActionLink,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .subtitle2Green2,
                                     recognizer: TapGestureRecognizer()
                                       ..onTap = () {
                                         Navigator.of(context).pop();
-                                        NavigationService.of(context).navigateTo(Routes.importWords);
+                                        NavigationService.of(context)
+                                            .navigateTo(Routes.importWords);
                                       }),
                                 const TextSpan(text: " "),
-                                TextSpan(text: context.loc.importKeyImportUsingRecoveryPhraseDescription),
+                                TextSpan(
+                                    text: context.loc
+                                        .importKeyImportUsingRecoveryPhraseDescription),
                               ],
                             ),
                           ),
@@ -122,7 +137,8 @@ class _ImportKeyScreenState extends State<ImportKeyScreen> {
                     ],
                   ),
                   Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: horizontalEdgePadding),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: horizontalEdgePadding),
                     child: Align(
                       alignment: Alignment.bottomCenter,
                       child: FlatButtonLong(

--- a/lib/screens/authentication/import_key/import_words_screen.dart
+++ b/lib/screens/authentication/import_key/import_words_screen.dart
@@ -30,7 +30,8 @@ class ImportWordsScreen extends StatelessWidget {
                 title: context.loc.importKeySearchButtonTitle,
                 onPressed: () {
                   FocusScope.of(context).unfocus();
-                  BlocProvider.of<ImportKeyBloc>(context).add(const FindAccountFromWords());
+                  BlocProvider.of<ImportKeyBloc>(context)
+                      .add(const FindAccountFromWords());
                 },
                 enabled: state.enableButton,
               ),
@@ -60,72 +61,92 @@ class ImportWordsScreen extends StatelessWidget {
                           return Padding(
                             padding: EdgeInsets.only(
                                 left: (index % _numberOfColumns == 0) ? 0 : 8,
-                                right: ((index + 1) % _numberOfColumns == 0) ? 0 : 8),
+                                right: ((index + 1) % _numberOfColumns == 0)
+                                    ? 0
+                                    : 8),
                             child: Autocomplete<String>(
-                              fieldViewBuilder: (context, textEditingController, focusNode, onFieldSubmitted) {
-                                textEditingController.text = state.userEnteredWords[index] ?? "";
+                              fieldViewBuilder: (context, textEditingController,
+                                  focusNode, onFieldSubmitted) {
+                                textEditingController.text =
+                                    state.userEnteredWords[index] ?? "";
                                 textEditingController.selection =
-                                    TextSelection.fromPosition(TextPosition(offset: textEditingController.text.length));
+                                    TextSelection.fromPosition(TextPosition(
+                                        offset:
+                                            textEditingController.text.length));
                                 return TextField(
                                   controller: textEditingController,
                                   focusNode: focusNode,
                                   autocorrect: false,
                                   enableSuggestions: false,
                                   enabled: true,
-                                  textInputAction: index < 11 ? TextInputAction.next : TextInputAction.done,
+                                  textInputAction: index < 11
+                                      ? TextInputAction.next
+                                      : TextInputAction.done,
                                   onChanged: (value) {
-                                    BlocProvider.of<ImportKeyBloc>(context)
-                                        .add(OnWordChange(word: value, wordIndex: index));
+                                    BlocProvider.of<ImportKeyBloc>(context).add(
+                                        OnWordChange(
+                                            word: value, wordIndex: index));
                                   },
                                   keyboardType: TextInputType.visiblePassword,
                                   decoration: InputDecoration(
-                                    floatingLabelBehavior: FloatingLabelBehavior.always,
+                                    floatingLabelBehavior:
+                                        FloatingLabelBehavior.always,
                                     labelText: (index + 1).toString(),
                                     border: const OutlineInputBorder(),
                                   ),
                                 );
                               },
-                              optionsBuilder: (TextEditingValue textEditingValue) {
+                              optionsBuilder:
+                                  (TextEditingValue textEditingValue) {
                                 if (textEditingValue.text == '') {
                                   return const Iterable<String>.empty();
                                 }
                                 return wordList.where((String option) {
-                                  return option.startsWith(textEditingValue.text.toLowerCase());
+                                  return option.startsWith(
+                                      textEditingValue.text.toLowerCase());
                                 });
                               },
                               onSelected: (String selection) {
                                 FocusScope.of(context).nextFocus();
-                                BlocProvider.of<ImportKeyBloc>(context)
-                                    .add(OnWordChange(word: selection, wordIndex: index));
+                                BlocProvider.of<ImportKeyBloc>(context).add(
+                                    OnWordChange(
+                                        word: selection, wordIndex: index));
                               },
                             ),
                           );
                         }),
                       ),
-                      if (state.pageState != PageState.loading && state.accounts.isEmpty)
+                      if (state.pageState != PageState.loading &&
+                          state.accounts.isEmpty)
                         TextButton(
                           child: Text(context.loc.importWordClipBoardTitle),
                           onPressed: () {
-                            BlocProvider.of<ImportKeyBloc>(context).add(const OnUserPastedWords());
+                            BlocProvider.of<ImportKeyBloc>(context)
+                                .add(const OnUserPastedWords());
                           },
                         ),
                       const SizedBox(height: 16),
                       if (state.userEnteredWords.isEmpty)
                         RichText(
                           text: TextSpan(
-                            style: Theme.of(context).textTheme.subtitle2,
+                            style: Theme.of(context).textTheme.titleSmall,
                             children: <TextSpan>[
                               TextSpan(
-                                text: context.loc.importKeyImportUsingPrivateKeyActionLink,
-                                style: Theme.of(context).textTheme.subtitle2Green2,
+                                text: context.loc
+                                    .importKeyImportUsingPrivateKeyActionLink,
+                                style:
+                                    Theme.of(context).textTheme.subtitle2Green2,
                                 recognizer: TapGestureRecognizer()
                                   ..onTap = () {
                                     Navigator.of(context).pop();
-                                    NavigationService.of(context).navigateTo(Routes.importKey);
+                                    NavigationService.of(context)
+                                        .navigateTo(Routes.importKey);
                                   },
                               ),
                               const TextSpan(text: " "),
-                              TextSpan(text: context.loc.importKeyImportUsingPrivateKeyDescription),
+                              TextSpan(
+                                  text: context.loc
+                                      .importKeyImportUsingPrivateKeyDescription),
                             ],
                           ),
                         ),

--- a/lib/screens/authentication/login_screen.dart
+++ b/lib/screens/authentication/login_screen.dart
@@ -22,21 +22,27 @@ class LoginScreen extends StatelessWidget {
         padding: const EdgeInsets.all(16),
         child: TextButton(
           style: TextButton.styleFrom(
-              shape: const BeveledRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10)))),
+              shape: const BeveledRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(10)))),
           onPressed: () {
             if (settingsStorage.inRecoveryMode) {
-              NavigationService.of(context).navigateTo(Routes.recoverAccountFound, settingsStorage.accountName);
+              NavigationService.of(context).navigateTo(
+                  Routes.recoverAccountFound, settingsStorage.accountName);
             } else {
-              NavigationService.of(context).navigateTo(Routes.recoverAccountSearch);
+              NavigationService.of(context)
+                  .navigateTo(Routes.recoverAccountSearch);
             }
           },
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Text(context.loc.loginRecoverAccountActionSegment1, style: Theme.of(context).textTheme.subtitle2),
+              Text(context.loc.loginRecoverAccountActionSegment1,
+                  style: Theme.of(context).textTheme.titleSmall),
               Text(context.loc.loginRecoverAccountActionLink,
-                  style: Theme.of(context).textTheme.subtitle2HighEmphasisGreen1),
-              Text(context.loc.loginRecoverAccountActionSegment2, style: Theme.of(context).textTheme.subtitle2),
+                  style:
+                      Theme.of(context).textTheme.subtitle2HighEmphasisGreen1),
+              Text(context.loc.loginRecoverAccountActionSegment2,
+                  style: Theme.of(context).textTheme.titleSmall),
             ],
           ),
         ),
@@ -49,33 +55,42 @@ class LoginScreen extends StatelessWidget {
               Container(
                 height: max(0, min(height * 0.4, height - _approxWidgetHeight)),
                 decoration: const BoxDecoration(
-                  image: DecorationImage(fit: BoxFit.fitWidth, image: AssetImage("assets/images/login/background.png")),
+                  image: DecorationImage(
+                      fit: BoxFit.fitWidth,
+                      image: AssetImage("assets/images/login/background.png")),
                 ),
               ),
-              SvgPicture.asset("assets/images/login/seeds_light_wallet_logo.svg"),
+              SvgPicture.asset(
+                  "assets/images/login/seeds_light_wallet_logo.svg"),
               const SizedBox(height: 80),
               Padding(
                 padding: const EdgeInsets.only(left: 20, right: 20),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(context.loc.loginFirstTimeHere, style: Theme.of(context).textTheme.subtitle2),
+                    Text(context.loc.loginFirstTimeHere,
+                        style: Theme.of(context).textTheme.titleSmall),
                     const SizedBox(height: 10),
                     FlatButtonLong(
-                      onPressed: () => NavigationService.of(context).navigateTo(Routes.signup),
+                      onPressed: () => NavigationService.of(context)
+                          .navigateTo(Routes.signup),
                       title: context.loc.loginClaimInviteCodeButtonTitle,
                     ),
                     const SizedBox(height: 40),
-                    Text(context.loc.loginAlreadyHaveAnAccount, style: Theme.of(context).textTheme.subtitle2),
+                    Text(context.loc.loginAlreadyHaveAnAccount,
+                        style: Theme.of(context).textTheme.titleSmall),
                     const SizedBox(height: 10),
                     FlatButtonLongOutlined(
                       onPressed: () {
                         /// We use remoteConfigurations directly here because this page doesnt have blocs.
                         /// !!!Please do not copy this pattern!!!
-                        if (remoteConfigurations.featureFlagExportRecoveryPhraseEnabled) {
-                          NavigationService.of(context).navigateTo(Routes.importWords);
+                        if (remoteConfigurations
+                            .featureFlagExportRecoveryPhraseEnabled) {
+                          NavigationService.of(context)
+                              .navigateTo(Routes.importWords);
                         } else {
-                          NavigationService.of(context).navigateTo(Routes.importKey);
+                          NavigationService.of(context)
+                              .navigateTo(Routes.importKey);
                         }
                       },
                       title: context.loc.loginImportAccountButtonTitle,

--- a/lib/screens/authentication/onboarding/components/onboarding_pages.dart
+++ b/lib/screens/authentication/onboarding/components/onboarding_pages.dart
@@ -31,11 +31,13 @@ class OnboardingPage extends StatelessWidget {
           height: MediaQuery.of(context).size.height / 2,
           decoration: const BoxDecoration(
             color: AppColors.lightGreen4,
-            borderRadius: BorderRadius.vertical(bottom: Radius.elliptical(300, 50)),
+            borderRadius:
+                BorderRadius.vertical(bottom: Radius.elliptical(300, 50)),
           ),
           child: Center(
             child: Container(
-              padding: const EdgeInsets.only(bottom: 20, top: 50, right: 40, left: 40),
+              padding: const EdgeInsets.only(
+                  bottom: 20, top: 50, right: 40, left: 40),
               child: Stack(
                 clipBehavior: Clip.none,
                 children: [
@@ -61,9 +63,11 @@ class OnboardingPage extends StatelessWidget {
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(title, style: Theme.of(context).textTheme.headline3),
+                        Text(title,
+                            style: Theme.of(context).textTheme.displaySmall),
                         const SizedBox(height: 30),
-                        Text(subTitle, style: Theme.of(context).textTheme.button),
+                        Text(subTitle,
+                            style: Theme.of(context).textTheme.labelLarge),
                       ],
                     ),
                   ],

--- a/lib/screens/authentication/onboarding/onboarding_screen.dart
+++ b/lib/screens/authentication/onboarding/onboarding_screen.dart
@@ -51,7 +51,8 @@ class OnboardingState extends State<OnboardingScreen> {
                 height: height * 0.91,
                 viewportFraction: 1,
                 enableInfiniteScroll: false,
-                onPageChanged: (index, _) => setState(() => _selectedIndex = index),
+                onPageChanged: (index, _) =>
+                    setState(() => _selectedIndex = index),
               ),
             ),
             Expanded(
@@ -65,19 +66,22 @@ class OnboardingState extends State<OnboardingScreen> {
                           )
                         : const SizedBox.shrink(),
                   ),
-                  Expanded(child: DotsIndicator(dotsCount: 3, position: _selectedIndex.toDouble())),
+                  Expanded(
+                      child: DotsIndicator(
+                          dotsCount: 3, position: _selectedIndex.toDouble())),
                   if (_selectedIndex == 2)
                     Expanded(
                       child: Row(
                         children: [
                           Flexible(
                             child: InkWell(
-                              onTap: () => NavigationService.of(context).navigateTo(Routes.login, null, true),
+                              onTap: () => NavigationService.of(context)
+                                  .navigateTo(Routes.login, null, true),
                               child: Text(
                                 context.loc.onboardingJoinButtonTitle,
                                 maxLines: 2,
                                 overflow: TextOverflow.ellipsis,
-                                style: Theme.of(context).textTheme.subtitle1,
+                                style: Theme.of(context).textTheme.titleMedium,
                               ),
                             ),
                           ),

--- a/lib/screens/authentication/recover/recover_account_found/components/guardian_row_widget.dart
+++ b/lib/screens/authentication/recover/recover_account_found/components/guardian_row_widget.dart
@@ -18,7 +18,9 @@ class GuardianRowWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-        trailing: showGuardianSigned ? const Icon(Icons.check_circle, color: AppColors.green) : const SizedBox.shrink(),
+        trailing: showGuardianSigned
+            ? const Icon(Icons.check_circle, color: AppColors.green)
+            : const SizedBox.shrink(),
         leading: ProfileAvatar(
           size: 60,
           image: guardianModel.image,
@@ -26,10 +28,13 @@ class GuardianRowWidget extends StatelessWidget {
           nickname: guardianModel.nickname,
         ),
         title: Text(
-          (!guardianModel.nickname.isNullOrEmpty) ? guardianModel.nickname : guardianModel.account,
-          style: Theme.of(context).textTheme.button,
+          (!guardianModel.nickname.isNullOrEmpty)
+              ? guardianModel.nickname
+              : guardianModel.account,
+          style: Theme.of(context).textTheme.labelLarge,
         ),
-        subtitle: Text(guardianModel.account, style: Theme.of(context).textTheme.subtitle2OpacityEmphasis),
+        subtitle: Text(guardianModel.account,
+            style: Theme.of(context).textTheme.subtitle2OpacityEmphasis),
         onTap: () {});
   }
 }

--- a/lib/screens/authentication/recover/recover_account_found/recover_account_found_screen.dart
+++ b/lib/screens/authentication/recover/recover_account_found/recover_account_found_screen.dart
@@ -27,23 +27,28 @@ class RecoverAccountFoundScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // ignore: cast_nullable_to_non_nullable
-    final String userAccount = ModalRoute.of(context)!.settings.arguments as String;
+    final String userAccount =
+        ModalRoute.of(context)!.settings.arguments! as String;
     return BlocProvider(
-      create: (_) => RecoverAccountFoundBloc(userAccount)..add(const FetchInitialData()),
+      create: (_) =>
+          RecoverAccountFoundBloc(userAccount)..add(const FetchInitialData()),
       child: BlocConsumer<RecoverAccountFoundBloc, RecoverAccountFoundState>(
         listenWhen: (_, current) => current.pageCommand != null,
         listener: (context, state) {
           final pageCommand = state.pageCommand;
-          BlocProvider.of<RecoverAccountFoundBloc>(context).add(const ClearRecoverPageCommand());
+          BlocProvider.of<RecoverAccountFoundBloc>(context)
+              .add(const ClearRecoverPageCommand());
 
           if (pageCommand is ShowLinkCopied) {
-            eventBus.fire(ShowSnackBar.success(context.loc.recoverAccountFoundShowLinkCopied));
+            eventBus.fire(ShowSnackBar.success(
+                context.loc.recoverAccountFoundShowLinkCopied));
           } else if (pageCommand is ShowErrorMessage) {
             eventBus.fire(ShowSnackBar(pageCommand.message));
           } else if (pageCommand is CancelRecoveryProcess) {
             Navigator.of(context).pop();
           } else if (pageCommand is OnRecoverAccountSuccess) {
-            BlocProvider.of<AuthenticationBloc>(context).add(const OnRecoverAccount());
+            BlocProvider.of<AuthenticationBloc>(context)
+                .add(const OnRecoverAccount());
           }
         },
         builder: (context, state) {
@@ -62,7 +67,9 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                       padding: const EdgeInsets.all(8.0),
                       child: IconButton(
                         icon: const Icon(Icons.refresh),
-                        onPressed: () => BlocProvider.of<RecoverAccountFoundBloc>(context).add(const OnRefreshTapped()),
+                        onPressed: () =>
+                            BlocProvider.of<RecoverAccountFoundBloc>(context)
+                                .add(const OnRefreshTapped()),
                       ),
                     )
                   ],
@@ -82,9 +89,13 @@ class RecoverAccountFoundScreen extends StatelessWidget {
         return const FullPageLoadingIndicator();
       case PageState.failure:
         return FullPageErrorIndicator(
-          errorMessage: state.error?.localizedDescription(context) ?? GlobalError.unknown.localizedDescription(context),
-          buttonTitle: context.loc.recoverAccountFoundFullPageErrorIndicatorTitle,
-          buttonOnPressed: () => BlocProvider.of<RecoverAccountFoundBloc>(context).add(const OnCancelProcessTapped()),
+          errorMessage: state.error?.localizedDescription(context) ??
+              GlobalError.unknown.localizedDescription(context),
+          buttonTitle:
+              context.loc.recoverAccountFoundFullPageErrorIndicatorTitle,
+          buttonOnPressed: () =>
+              BlocProvider.of<RecoverAccountFoundBloc>(context)
+                  .add(const OnCancelProcessTapped()),
         );
       case PageState.success:
         switch (state.recoveryStatus) {
@@ -98,12 +109,15 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                     Stack(
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(left: 8, right: 8, top: 8),
+                          padding:
+                              const EdgeInsets.only(left: 8, right: 8, top: 8),
                           child: TextFormFieldCustom(
                             enabled: false,
                             labelText: context.loc.recoverAccountFoundLinkTitle,
                             suffixIcon: const SizedBox.shrink(),
-                            controller: TextEditingController(text: state.linkToActivateGuardians?.toString()),
+                            controller: TextEditingController(
+                                text:
+                                    state.linkToActivateGuardians?.toString()),
                           ),
                         ),
                         Positioned(
@@ -112,10 +126,12 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                           child: Padding(
                             padding: const EdgeInsets.only(right: 8, top: 8),
                             child: IconButton(
-                              icon: const Icon(Icons.share, color: AppColors.white),
+                              icon: const Icon(Icons.share,
+                                  color: AppColors.white),
                               splashRadius: 30,
                               onPressed: () async {
-                                await Share.share(state.linkToActivateGuardians!.toString());
+                                await Share.share(
+                                    state.linkToActivateGuardians!.toString());
                               },
                             ),
                           ),
@@ -128,44 +144,57 @@ class RecoverAccountFoundScreen extends StatelessWidget {
                         children: [
                           Text(state.confirmedGuardianSignatures.toString(),
                               style: Theme.of(context).textTheme.button1),
-                          Text("/${state.userGuardiansData.length}", style: Theme.of(context).textTheme.button1),
+                          Text("/${state.userGuardiansData.length}",
+                              style: Theme.of(context).textTheme.button1),
                           const SizedBox(width: 24),
                           Flexible(
                             child: Text(
-                              context.loc.recoverAccountFoundGuardiansAcceptedTitle,
-                              style: Theme.of(context).textTheme.buttonLowEmphasis,
+                              context.loc
+                                  .recoverAccountFoundGuardiansAcceptedTitle,
+                              style:
+                                  Theme.of(context).textTheme.buttonLowEmphasis,
                             ),
                           ),
                         ],
                       ),
                     ),
-                    const Padding(padding: EdgeInsets.fromLTRB(16.0, 8.0, 16.0, 16.0), child: DividerJungle()),
+                    const Padding(
+                        padding: EdgeInsets.fromLTRB(16.0, 8.0, 16.0, 16.0),
+                        child: DividerJungle()),
                     const SizedBox(height: 16),
                     Expanded(
                       child: ListView(
                         children: state.userGuardiansData
                             .map((e) => GuardianRowWidget(
                                   guardianModel: e,
-                                  showGuardianSigned: state.alreadySignedGuardians
-                                      .where((String element) => element == e.account)
+                                  showGuardianSigned: state
+                                      .alreadySignedGuardians
+                                      .where((String element) =>
+                                          element == e.account)
                                       .isNotEmpty,
                                 ))
                             .toList(),
                       ),
                     ),
                     Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: horizontalEdgePadding, vertical: 16),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: horizontalEdgePadding, vertical: 16),
                       child: FlatButtonLong(
                         title: context.loc.recoverAccountFoundReloadTitle,
-                        onPressed: () => BlocProvider.of<RecoverAccountFoundBloc>(context).add(const OnRefreshTapped()),
+                        onPressed: () =>
+                            BlocProvider.of<RecoverAccountFoundBloc>(context)
+                                .add(const OnRefreshTapped()),
                       ),
                     ),
                     Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: horizontalEdgePadding),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: horizontalEdgePadding),
                       child: FlatButtonLongOutlined(
-                        title: context.loc.recoverAccountFoundFullPageErrorIndicatorTitle,
+                        title: context
+                            .loc.recoverAccountFoundFullPageErrorIndicatorTitle,
                         onPressed: () =>
-                            BlocProvider.of<RecoverAccountFoundBloc>(context).add(const OnCancelProcessTapped()),
+                            BlocProvider.of<RecoverAccountFoundBloc>(context)
+                                .add(const OnCancelProcessTapped()),
                       ),
                     ),
                   ],
@@ -177,70 +206,104 @@ class RecoverAccountFoundScreen extends StatelessWidget {
               bottomSheet: Padding(
                 padding: const EdgeInsets.all(horizontalEdgePadding),
                 child: FlatButtonLong(
-                  enabled: state.recoveryStatus == RecoveryStatus.readyToClaimAccount,
+                  enabled: state.recoveryStatus ==
+                      RecoveryStatus.readyToClaimAccount,
                   title: context.loc.recoverAccountFoundClaimButtonTitle,
-                  onPressed: () => BlocProvider.of<RecoverAccountFoundBloc>(context).add(const OnClaimAccountTapped()),
+                  onPressed: () =>
+                      BlocProvider.of<RecoverAccountFoundBloc>(context)
+                          .add(const OnClaimAccountTapped()),
                 ),
               ),
               body: SafeArea(
                 child: SingleChildScrollView(
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: horizontalEdgePadding),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: horizontalEdgePadding),
                     child: Column(
                       children: [
                         const SizedBox(height: 10),
                         Padding(
                           padding: const EdgeInsets.all(16.0),
                           child: Text(
-                            context.loc.recoverAccountFoundAllGuardiansAcceptedTitle,
-                            style: Theme.of(context).textTheme.subtitle2LowEmphasis,
+                            context.loc
+                                .recoverAccountFoundAllGuardiansAcceptedTitle,
+                            style: Theme.of(context)
+                                .textTheme
+                                .subtitle2LowEmphasis,
                             textAlign: TextAlign.center,
                           ),
                         ),
                         const SizedBox(height: 40),
-                        const Image(image: AssetImage('assets/images/guardians/check_circle.png')),
+                        const Image(
+                            image: AssetImage(
+                                'assets/images/guardians/check_circle.png')),
                         const SizedBox(height: 100),
                         Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             Row(
                               children: [
-                                Text(state.currentRemainingTime?.hoursFormatted ?? '00',
-                                    style: Theme.of(context).textTheme.headline4),
+                                Text(
+                                    state.currentRemainingTime
+                                            ?.hoursFormatted ??
+                                        '00',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .headlineMedium),
                                 Padding(
                                   padding: const EdgeInsets.only(bottom: 6),
-                                  child: Text(':', style: Theme.of(context).textTheme.headline4),
+                                  child: Text(':',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .headlineMedium),
                                 )
                               ],
                             ),
                             Row(
                               children: [
-                                Text(state.currentRemainingTime?.minFormatted ?? '00',
-                                    style: Theme.of(context).textTheme.headline4),
+                                Text(
+                                    state.currentRemainingTime?.minFormatted ??
+                                        '00',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .headlineMedium),
                                 Padding(
                                   padding: const EdgeInsets.only(bottom: 6),
-                                  child: Text(':', style: Theme.of(context).textTheme.headline4),
+                                  child: Text(':',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .headlineMedium),
                                 )
                               ],
                             ),
                             Row(
                               children: [
-                                Text('${state.currentRemainingTime?.secFormatted ?? '00'} ',
-                                    style: Theme.of(context).textTheme.headline4),
+                                Text(
+                                    '${state.currentRemainingTime?.secFormatted ?? '00'} ',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .headlineMedium),
                               ],
                             ),
                             Padding(
                               padding: const EdgeInsets.only(top: 14),
-                              child: Text(context.loc.recoverAccountFoundHoursLeft,
-                                  style: Theme.of(context).textTheme.subtitle2),
+                              child: Text(
+                                  context.loc.recoverAccountFoundHoursLeft,
+                                  style:
+                                      Theme.of(context).textTheme.titleSmall),
                             )
                           ],
                         ),
                         const SizedBox(height: 20),
-                        if (state.recoveryStatus == RecoveryStatus.readyToClaimAccount)
+                        if (state.recoveryStatus ==
+                            RecoveryStatus.readyToClaimAccount)
                           Row(
                             mainAxisAlignment: MainAxisAlignment.center,
-                            children: [Text(context.loc.recoverAccountFoundRecoveredTitle), Text(state.userAccount)],
+                            children: [
+                              Text(context
+                                  .loc.recoverAccountFoundRecoveredTitle),
+                              Text(state.userAccount)
+                            ],
                           ),
                         const SizedBox(height: 150),
                       ],

--- a/lib/screens/authentication/recover/recover_account_search/recover_account_search_screen.dart
+++ b/lib/screens/authentication/recover/recover_account_search/recover_account_search_screen.dart
@@ -78,7 +78,7 @@ class _RecoverAccountSearchScreenState extends State<RecoverAccountSearchScreen>
                           },
                         ),
                         if (state.accountFound)
-                          Container(
+                          DecoratedBox(
                             decoration: BoxDecoration(
                               color: AppColors.darkGreen2,
                               borderRadius: BorderRadius.circular(defaultCardBorderRadius),

--- a/lib/screens/authentication/sign_up/components/invite_link_fail_dialog.dart
+++ b/lib/screens/authentication/sign_up/components/invite_link_fail_dialog.dart
@@ -12,12 +12,13 @@ class InviteLinkFailDialog extends StatelessWidget {
       icon: const Icon(Icons.cancel_outlined, size: 60, color: AppColors.red),
       singleLargeButtonTitle: context.loc.genericCloseButtonTitle,
       children: [
-        Text(context.loc.signUpInviteCodeErrorTitle, style: Theme.of(context).textTheme.headline6),
+        Text(context.loc.signUpInviteCodeErrorTitle,
+            style: Theme.of(context).textTheme.titleLarge),
         const SizedBox(height: 24.0),
         Text(
           context.loc.signUpInviteCodeErrorDescription,
           textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.subtitle2,
+          style: Theme.of(context).textTheme.titleSmall,
         ),
         const SizedBox(height: 16.0),
       ],

--- a/lib/screens/authentication/verification/components/keyboard.dart
+++ b/lib/screens/authentication/verification/components/keyboard.dart
@@ -27,13 +27,13 @@ class Keyboard extends StatelessWidget {
                   child: InkWell(
                     splashColor: Colors.white.withOpacity(0.4),
                     onTap: () => onDigitTapped(i),
-                    child: Container(
+                    child: DecoratedBox(
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
                         color: Colors.transparent,
                         border: Border.all(color: Colors.white),
                       ),
-                      child: Container(
+                      child: DecoratedBox(
                         decoration: const BoxDecoration(shape: BoxShape.circle, color: Colors.transparent),
                         child: Center(
                           child: Text(i, style: const TextStyle(fontSize: 30, color: Colors.white), semanticsLabel: i),

--- a/lib/screens/authentication/verification/components/passcode_created_dialog.dart
+++ b/lib/screens/authentication/verification/components/passcode_created_dialog.dart
@@ -8,21 +8,24 @@ class PasscodeCreatedDialog extends StatelessWidget {
   const PasscodeCreatedDialog({super.key});
 
   Future<void> show(BuildContext context) async {
-    return showDialog<void>(context: context, barrierDismissible: false, builder: (_) => this);
+    return showDialog<void>(
+        context: context, barrierDismissible: false, builder: (_) => this);
   }
 
   @override
   Widget build(BuildContext context) {
     return CustomDialog(
-      icon: SvgPicture.asset('assets/images/security/success_outlined_icon.svg'),
+      icon:
+          SvgPicture.asset('assets/images/security/success_outlined_icon.svg'),
       singleLargeButtonTitle: context.loc.genericCloseButtonTitle,
       children: [
-        Text(context.loc.verificationPasscodeDialogTitle, style: Theme.of(context).textTheme.button1),
+        Text(context.loc.verificationPasscodeDialogTitle,
+            style: Theme.of(context).textTheme.button1),
         const SizedBox(height: 30.0),
         Text(
           context.loc.verificationPasscodeDialogSubTitle,
           textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.subtitle2,
+          style: Theme.of(context).textTheme.titleSmall,
         ),
         const SizedBox(height: 30.0),
       ],

--- a/lib/screens/authentication/verification/components/passcode_screen.dart
+++ b/lib/screens/authentication/verification/components/passcode_screen.dart
@@ -18,13 +18,18 @@ class PasscodeScreen extends StatefulWidget {
   final ValueSetter<String> onPasscodeCompleted;
   final Widget? bottomWidget;
 
-  const PasscodeScreen({super.key, required this.title, required this.onPasscodeCompleted, this.bottomWidget});
+  const PasscodeScreen(
+      {super.key,
+      required this.title,
+      required this.onPasscodeCompleted,
+      this.bottomWidget});
 
   @override
   State<StatefulWidget> createState() => _PasscodeScreenState();
 }
 
-class _PasscodeScreenState extends State<PasscodeScreen> with SingleTickerProviderStateMixin {
+class _PasscodeScreenState extends State<PasscodeScreen>
+    with SingleTickerProviderStateMixin {
   late AnimationController controller;
   late Animation<double> animation;
   String enteredPasscode = '';
@@ -32,8 +37,10 @@ class _PasscodeScreenState extends State<PasscodeScreen> with SingleTickerProvid
   @override
   void initState() {
     super.initState();
-    controller = AnimationController(duration: const Duration(milliseconds: 300), vsync: this);
-    final Animation curve = CurvedAnimation(parent: controller, curve: _ShakeCurve());
+    controller = AnimationController(
+        duration: const Duration(milliseconds: 300), vsync: this);
+    final Animation curve =
+        CurvedAnimation(parent: controller, curve: _ShakeCurve());
     animation = Tween(begin: 0.0, end: 10.0).animate(curve as Animation<double>)
       ..addStatusListener((status) {
         if (status == AnimationStatus.completed) {
@@ -96,7 +103,9 @@ class _PasscodeScreenState extends State<PasscodeScreen> with SingleTickerProvid
                         for (int i = 0; i < _passwordDigits; i++)
                           Container(
                             margin: const EdgeInsets.all(8),
-                            child: Circle(filled: i < enteredPasscode.length, extraSize: animation.value),
+                            child: Circle(
+                                filled: i < enteredPasscode.length,
+                                extraSize: animation.value),
                           ),
                       ],
                     ),
@@ -111,7 +120,8 @@ class _PasscodeScreenState extends State<PasscodeScreen> with SingleTickerProvid
               child: CupertinoButton(
                 onPressed: () {
                   if (enteredPasscode.isNotEmpty) {
-                    setState(() => enteredPasscode = enteredPasscode.substring(0, enteredPasscode.length - 1));
+                    setState(() => enteredPasscode = enteredPasscode.substring(
+                        0, enteredPasscode.length - 1));
                   }
                 },
                 child: Container(
@@ -119,7 +129,7 @@ class _PasscodeScreenState extends State<PasscodeScreen> with SingleTickerProvid
                   child: enteredPasscode.isEmpty
                       ? const SizedBox.shrink()
                       : Text(context.loc.verificationPasscodeScreenButtonTitle,
-                          style: Theme.of(context).textTheme.subtitle2),
+                          style: Theme.of(context).textTheme.titleSmall),
                 ),
               ),
             ),

--- a/lib/screens/authentication/verification/verification_screen.dart
+++ b/lib/screens/authentication/verification/verification_screen.dart
@@ -32,20 +32,25 @@ class VerificationScreen extends StatelessWidget {
               listenWhen: (_, current) => current.pageCommand != null,
               listener: (context, state) {
                 final pageCommand = state.pageCommand;
-                BlocProvider.of<VerificationBloc>(context).add(const ClearVerificationPageCommand());
+                BlocProvider.of<VerificationBloc>(context)
+                    .add(const ClearVerificationPageCommand());
                 if (pageCommand is PasscodeNotMatch) {
-                  eventBus.fire(ShowSnackBar.success(context.loc.verificationScreenSnackBarError));
+                  eventBus.fire(ShowSnackBar.success(
+                      context.loc.verificationScreenSnackBarError));
                 } else if (pageCommand is BiometricAuthorized) {
                   if (_isUnpoppable) {
                     // Onboarding or timeout authentication: just unlock
-                    BlocProvider.of<AuthenticationBloc>(context).add(const UnlockWallet());
+                    BlocProvider.of<AuthenticationBloc>(context)
+                        .add(const UnlockWallet());
                   }
                   Navigator.of(context).pop(true);
                 } else if (pageCommand is PasscodeValid) {
-                  final authenticationBloc = BlocProvider.of<AuthenticationBloc>(context);
+                  final authenticationBloc =
+                      BlocProvider.of<AuthenticationBloc>(context);
                   if (state.isCreateMode) {
                     // Enable and save new passcode
-                    authenticationBloc.add(EnablePasscode(newPasscode: state.newPasscode!));
+                    authenticationBloc
+                        .add(EnablePasscode(newPasscode: state.newPasscode!));
                     if (_isUnpoppable) {
                       authenticationBloc.add(const UnlockWallet());
                     }
@@ -66,28 +71,38 @@ class VerificationScreen extends StatelessWidget {
                   case PageState.failure:
                   case PageState.success:
                     return PasscodeScreen(
-                      title: Text(state.passcodeTitle.localizedDescription(context),
+                      title: Text(
+                          state.passcodeTitle.localizedDescription(context),
                           style: Theme.of(context).textTheme.titleSmall),
                       onPasscodeCompleted: (passcode) {
                         if (state.isCreateMode && state.newPasscode == null) {
-                          BlocProvider.of<VerificationBloc>(context).add(OnPasscodeCreated(passcode));
+                          BlocProvider.of<VerificationBloc>(context)
+                              .add(OnPasscodeCreated(passcode));
                         } else {
-                          BlocProvider.of<VerificationBloc>(context).add(OnVerifyPasscode(passcode));
+                          BlocProvider.of<VerificationBloc>(context)
+                              .add(OnVerifyPasscode(passcode));
                         }
                       },
                       bottomWidget: state.showTryAgainBiometric
                           ? Padding(
                               padding: const EdgeInsets.only(top: 30),
                               child: InkWell(
-                                onTap: () => BlocProvider.of<VerificationBloc>(context).add(const InitBiometricAuth()),
+                                onTap: () =>
+                                    BlocProvider.of<VerificationBloc>(context)
+                                        .add(const InitBiometricAuth()),
                                 borderRadius: BorderRadius.circular(16.0),
                                 child: Container(
-                                  padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                                  padding: const EdgeInsets.symmetric(
+                                      vertical: 8.0, horizontal: 16.0),
                                   decoration: BoxDecoration(
                                       borderRadius: BorderRadius.circular(16.0),
-                                      border: Border.all(color: AppColors.white)),
-                                  child: Text(context.loc.verificationScreenButtonTitle,
-                                      style: Theme.of(context).textTheme.subtitle2),
+                                      border:
+                                          Border.all(color: AppColors.white)),
+                                  child: Text(
+                                      context.loc.verificationScreenButtonTitle,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleSmall),
                                 ),
                               ),
                             )

--- a/lib/screens/explore_screens/explore/components/flag_user_info_dialog.dart
+++ b/lib/screens/explore_screens/explore/components/flag_user_info_dialog.dart
@@ -11,9 +11,11 @@ class FlagUserInfoDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CustomDialog(
-      icon: const CustomPaint(size: Size(60, 60), painter: RedExclamationCircle()),
+      icon: const CustomPaint(
+          size: Size(60, 60), painter: RedExclamationCircle()),
       children: [
-        Text(context.loc.explorerFlagInfoDialogTitle, style: Theme.of(context).textTheme.button1),
+        Text(context.loc.explorerFlagInfoDialogTitle,
+            style: Theme.of(context).textTheme.button1),
         const SizedBox(height: 30.0),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8.0),
@@ -22,13 +24,13 @@ class FlagUserInfoDialog extends StatelessWidget {
               Text(
                 context.loc.explorerFlagInfoDialogSubTitle,
                 textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.subtitle2,
+                style: Theme.of(context).textTheme.titleSmall,
               ),
               const SizedBox(height: 36.0),
               Text(
                 context.loc.explorerFlagInfoDialogSubTitlePartTwo,
                 textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.subtitle2,
+                style: Theme.of(context).textTheme.titleSmall,
               ),
               const SizedBox(height: 36.0),
               FlatButtonLong(

--- a/lib/screens/explore_screens/flag/flag_user/components/flag_user_confirmation_dialog.dart
+++ b/lib/screens/explore_screens/flag/flag_user/components/flag_user_confirmation_dialog.dart
@@ -19,19 +19,22 @@ class FlagUserConfirmationDialog extends StatelessWidget {
             return true;
           },
           child: CustomDialog(
-            icon: const CustomPaint(size: Size(60, 60), painter: RedExclamationCircle()),
+            icon: const CustomPaint(
+                size: Size(60, 60), painter: RedExclamationCircle()),
             leftButtonTitle: 'Back',
             rightButtonTitle: "Yes I'm sure",
             onRightButtonPressed: () {
-              BlocProvider.of<FlagUserBloc>(context).add(OnConfirmFlagUserTap());
+              BlocProvider.of<FlagUserBloc>(context)
+                  .add(OnConfirmFlagUserTap());
               Navigator.of(context).pop();
             },
             children: [
-              Text('Are you sure?', style: Theme.of(context).textTheme.headline6),
+              Text('Are you sure?',
+                  style: Theme.of(context).textTheme.titleLarge),
               const SizedBox(height: 10.0),
               Text(
                 'Flagging has strong negative consequences so please make sure you are flagging the right person!',
-                style: Theme.of(context).textTheme.subtitle2,
+                style: Theme.of(context).textTheme.titleSmall,
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 20.0),
@@ -39,12 +42,17 @@ class FlagUserConfirmationDialog extends StatelessWidget {
                 textAlign: TextAlign.center,
                 text: TextSpan(
                     text: 'Are you sure you would like to flag ',
-                    style: Theme.of(context).textTheme.subtitle2,
+                    style: Theme.of(context).textTheme.titleSmall,
                     children: <TextSpan>[
                       TextSpan(
-                          text: '${state.selectedProfile?.nickname} (${state.selectedProfile?.account})',
-                          style: Theme.of(context).textTheme.subtitle2Green3LowEmphasis),
-                      TextSpan(text: '?', style: Theme.of(context).textTheme.subtitle2),
+                          text:
+                              '${state.selectedProfile?.nickname} (${state.selectedProfile?.account})',
+                          style: Theme.of(context)
+                              .textTheme
+                              .subtitle2Green3LowEmphasis),
+                      TextSpan(
+                          text: '?',
+                          style: Theme.of(context).textTheme.titleSmall),
                     ]),
               ),
             ],

--- a/lib/screens/explore_screens/flag/flags/components/remove_flag_info_dialog.dart
+++ b/lib/screens/explore_screens/flag/flags/components/remove_flag_info_dialog.dart
@@ -16,10 +16,12 @@ class RemoveFlagInfoDialog extends StatelessWidget {
       leftButtonTitle: 'Back',
       rightButtonTitle: "Yes I'm sure",
       onRightButtonPressed: () {
-        BlocProvider.of<FlagBloc>(context).add(OnRemoveUserFlagTapped(userAccount));
+        BlocProvider.of<FlagBloc>(context)
+            .add(OnRemoveUserFlagTapped(userAccount));
         Navigator.of(context).pop();
       },
-      icon: const CustomPaint(size: Size(60, 60), painter: RedExclamationCircle()),
+      icon: const CustomPaint(
+          size: Size(60, 60), painter: RedExclamationCircle()),
       children: [
         Text('Are you sure?', style: Theme.of(context).textTheme.button1),
         const SizedBox(height: 30.0),
@@ -30,7 +32,7 @@ class RemoveFlagInfoDialog extends StatelessWidget {
               Text(
                 'Removing the Flag means you believe the member is now acting in good faith. Penalties will be removed from the member. ',
                 textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.subtitle2,
+                style: Theme.of(context).textTheme.titleSmall,
               ),
               const SizedBox(height: 20.0),
             ],

--- a/lib/screens/explore_screens/invite/components/invite_link_dialog.dart
+++ b/lib/screens/explore_screens/invite/components/invite_link_dialog.dart
@@ -32,9 +32,12 @@ class _InviteLinkDialogState extends State<InviteLinkDialog> {
           child: Center(
             child: SingleChildScrollView(
               child: CustomDialog(
-                icon: SvgPicture.asset('assets/images/security/success_outlined_icon.svg'),
+                icon: SvgPicture.asset(
+                    'assets/images/security/success_outlined_icon.svg'),
                 rightButtonTitle: context.loc.inviteLinkDialogRightButtonTitle,
-                leftButtonTitle: _showCloseDialogButton ? context.loc.genericCloseButtonTitle : '',
+                leftButtonTitle: _showCloseDialogButton
+                    ? context.loc.genericCloseButtonTitle
+                    : '',
                 onRightButtonPressed: () async {
                   setState(() => _showCloseDialogButton = true);
                   await Share.share(state.dynamicSecretLink!);
@@ -43,22 +46,26 @@ class _InviteLinkDialogState extends State<InviteLinkDialog> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      Text(state.tokenAmount.amountString(), style: Theme.of(context).textTheme.headline4),
+                      Text(state.tokenAmount.amountString(),
+                          style: Theme.of(context).textTheme.headlineMedium),
                       Padding(
                         padding: const EdgeInsets.only(top: 12, left: 4),
-                        child: Text(state.tokenAmount.symbol, style: Theme.of(context).textTheme.subtitle2),
+                        child: Text(state.tokenAmount.symbol,
+                            style: Theme.of(context).textTheme.titleSmall),
                       ),
                     ],
                   ),
                   const SizedBox(height: 4.0),
-                  Text(state.fiatAmount.asFormattedString(), style: Theme.of(context).textTheme.subtitle2),
+                  Text(state.fiatAmount.asFormattedString(),
+                      style: Theme.of(context).textTheme.titleSmall),
                   const SizedBox(height: 20.0),
-                  QrCodeGeneratorWidget(data: state.dynamicSecretLink!, size: 254),
+                  QrCodeGeneratorWidget(
+                      data: state.dynamicSecretLink!, size: 254),
                   const SizedBox(height: 20.0),
                   Text(
                     context.loc.inviteLinkDialogMessage,
                     textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.button,
+                    style: Theme.of(context).textTheme.labelLarge,
                   ),
                 ],
               ),

--- a/lib/screens/explore_screens/invite/invite_screen.dart
+++ b/lib/screens/explore_screens/invite/invite_screen.dart
@@ -26,13 +26,15 @@ class InviteScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => InviteBloc(BlocProvider.of<RatesBloc>(context).state)..add(const LoadUserBalance()),
+      create: (context) => InviteBloc(BlocProvider.of<RatesBloc>(context).state)
+        ..add(const LoadUserBalance()),
       child: Scaffold(
         appBar: AppBar(
           title: Text(context.loc.inviteScreenAppBarTitle),
           actions: [
             TextButton(
-              onPressed: () => NavigationService.of(context).navigateTo(Routes.manageInvites),
+              onPressed: () => NavigationService.of(context)
+                  .navigateTo(Routes.manageInvites),
               child: Text(
                 context.loc.inviteScreenManageInvitesTitle,
                 style: Theme.of(context).textTheme.subtitle2Green3LowEmphasis,
@@ -59,7 +61,8 @@ class InviteScreen extends StatelessWidget {
               );
             }
             if (pageCommand is ShowErrorMessage) {
-              eventBus.fire(ShowSnackBar(pageCommand.message.localizedDescription(context)));
+              eventBus.fire(ShowSnackBar(
+                  pageCommand.message.localizedDescription(context)));
             }
           },
           builder: (context, state) {
@@ -77,24 +80,29 @@ class InviteScreen extends StatelessWidget {
                     children: [
                       SingleChildScrollView(
                         child: Container(
-                          height: MediaQuery.of(context).size.height - Scaffold.of(context).appBarMaxHeight!,
+                          height: MediaQuery.of(context).size.height -
+                              Scaffold.of(context).appBarMaxHeight!,
                           child: Column(
                             children: [
                               const SizedBox(height: 16),
                               Text(context.loc.inviteScreenInputAmountTitle,
-                                  style: Theme.of(context).textTheme.headline6),
+                                  style:
+                                      Theme.of(context).textTheme.titleLarge),
                               const SizedBox(height: 16),
                               AmountEntryWidget(
                                 tokenDataModel: TokenDataModel(0),
                                 onValueChange: (value) {
-                                  BlocProvider.of<InviteBloc>(context).add(OnAmountChange(amountChanged: value));
+                                  BlocProvider.of<InviteBloc>(context).add(
+                                      OnAmountChange(amountChanged: value));
                                 },
                                 autoFocus: state.isAutoFocus,
                               ),
                               const SizedBox(height: 24),
                               AlertInputValue(
-                                  state.errorMessage?.localizedDescription(context) ??
-                                      GlobalError.unknown.localizedDescription(context),
+                                  state.errorMessage
+                                          ?.localizedDescription(context) ??
+                                      GlobalError.unknown
+                                          .localizedDescription(context),
                                   isVisible: state.alertMessage != null),
                               const SizedBox(height: 24),
                               BalanceRow(
@@ -111,7 +119,8 @@ class InviteScreen extends StatelessWidget {
                         child: FlatButtonLong(
                           title: context.loc.inviteScreenButtonTitle,
                           enabled: state.isCreateInviteButtonEnabled,
-                          onPressed: () => BlocProvider.of<InviteBloc>(context).add(const OnCreateInviteButtonTapped()),
+                          onPressed: () => BlocProvider.of<InviteBloc>(context)
+                              .add(const OnCreateInviteButtonTapped()),
                         ),
                       ),
                     ],

--- a/lib/screens/explore_screens/manage_invites/components/claimed_invite_row.dart
+++ b/lib/screens/explore_screens/manage_invites/components/claimed_invite_row.dart
@@ -40,12 +40,17 @@ class ClaimedInviteRow extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      (name != null && name?.isNotEmpty == true) ? name! : account,
+                      (name != null && name?.isNotEmpty == true)
+                          ? name!
+                          : account,
                       textAlign: TextAlign.start,
-                      style: Theme.of(context).textTheme.button,
+                      style: Theme.of(context).textTheme.labelLarge,
                     ),
                     const SizedBox(height: 8),
-                    Text(account, style: Theme.of(context).textTheme.subtitle2OpacityEmphasis)
+                    Text(account,
+                        style: Theme.of(context)
+                            .textTheme
+                            .subtitle2OpacityEmphasis)
                   ],
                 ),
               ),

--- a/lib/screens/explore_screens/plant_seeds/components/plant_seeds_success_dialog.dart
+++ b/lib/screens/explore_screens/plant_seeds/components/plant_seeds_success_dialog.dart
@@ -25,7 +25,8 @@ class PlantSeedsSuccessDialog extends StatelessWidget {
         return true;
       },
       child: CustomDialog(
-        icon: SvgPicture.asset('assets/images/security/success_outlined_icon.svg'),
+        icon: SvgPicture.asset(
+            'assets/images/security/success_outlined_icon.svg'),
         singleLargeButtonTitle: context.loc.genericCloseButtonTitle,
         onSingleLargeButtonPressed: () {
           Navigator.of(context).pop();
@@ -36,26 +37,36 @@ class PlantSeedsSuccessDialog extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Text(
-                BlocProvider.of<PlantSeedsBloc>(context).state.tokenAmount.amountString(),
-                style: Theme.of(context).textTheme.headline4,
+                BlocProvider.of<PlantSeedsBloc>(context)
+                    .state
+                    .tokenAmount
+                    .amountString(),
+                style: Theme.of(context).textTheme.headlineMedium,
               ),
               Padding(
                 padding: const EdgeInsets.only(top: 12, left: 4),
-                child: Text(BlocProvider.of<PlantSeedsBloc>(context).state.tokenAmount.symbol,
-                    style: Theme.of(context).textTheme.subtitle2),
+                child: Text(
+                    BlocProvider.of<PlantSeedsBloc>(context)
+                        .state
+                        .tokenAmount
+                        .symbol,
+                    style: Theme.of(context).textTheme.titleSmall),
               ),
             ],
           ),
           const SizedBox(height: 4.0),
           Text(
-            BlocProvider.of<PlantSeedsBloc>(context).state.fiatAmount.asFormattedString(),
-            style: Theme.of(context).textTheme.subtitle2,
+            BlocProvider.of<PlantSeedsBloc>(context)
+                .state
+                .fiatAmount
+                .asFormattedString(),
+            style: Theme.of(context).textTheme.titleSmall,
           ),
           const SizedBox(height: 30.0),
           Text(
             context.loc.plantSeedsPlantSuccessMessage,
             textAlign: TextAlign.center,
-            style: Theme.of(context).textTheme.button,
+            style: Theme.of(context).textTheme.labelLarge,
           ),
         ],
       ),

--- a/lib/screens/explore_screens/plant_seeds/plant_seeds_screen.dart
+++ b/lib/screens/explore_screens/plant_seeds/plant_seeds_screen.dart
@@ -24,7 +24,9 @@ class PlantSeedsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => PlantSeedsBloc(BlocProvider.of<RatesBloc>(context).state)..add(const LoadUserBalance()),
+      create: (context) =>
+          PlantSeedsBloc(BlocProvider.of<RatesBloc>(context).state)
+            ..add(const LoadUserBalance()),
       child: Scaffold(
         appBar: AppBar(title: Text(context.loc.plantSeedsAppBarTitle)),
         body: BlocConsumer<PlantSeedsBloc, PlantSeedsState>(
@@ -32,19 +34,23 @@ class PlantSeedsScreen extends StatelessWidget {
           listener: (context, state) {
             final pageCommand = state.pageCommand;
             if (pageCommand is ShowPlantSeedsSuccess) {
-              const PlantSeedsSuccessDialog().show(context, BlocProvider.of<PlantSeedsBloc>(context));
+              const PlantSeedsSuccessDialog()
+                  .show(context, BlocProvider.of<PlantSeedsBloc>(context));
             }
             if (pageCommand is ShowError) {
-              eventBus.fire(ShowSnackBar(pageCommand.error.localizedDescription(context)));
+              eventBus.fire(ShowSnackBar(
+                  pageCommand.error.localizedDescription(context)));
             }
           },
-          buildWhen: (previous, current) => previous.pageState != current.pageState,
+          buildWhen: (previous, current) =>
+              previous.pageState != current.pageState,
           builder: (context, state) {
             switch (state.pageState) {
               case PageState.loading:
                 return const FullPageLoadingIndicator();
               case PageState.failure:
-                return FullPageErrorIndicator(errorMessage: state.error?.localizedDescription(context));
+                return FullPageErrorIndicator(
+                    errorMessage: state.error?.localizedDescription(context));
               case PageState.success:
                 return SafeArea(
                   minimum: const EdgeInsets.all(horizontalEdgePadding),
@@ -52,21 +58,27 @@ class PlantSeedsScreen extends StatelessWidget {
                     children: [
                       SingleChildScrollView(
                         child: Container(
-                          height: MediaQuery.of(context).size.height - Scaffold.of(context).appBarMaxHeight!,
+                          height: MediaQuery.of(context).size.height -
+                              Scaffold.of(context).appBarMaxHeight!,
                           child: Column(
                             children: [
                               const SizedBox(height: 16),
-                              Text(context.loc.plantSeedsPlantAmount, style: Theme.of(context).textTheme.headline6),
+                              Text(context.loc.plantSeedsPlantAmount,
+                                  style:
+                                      Theme.of(context).textTheme.titleLarge),
                               const SizedBox(height: 16),
                               AmountEntryWidget(
                                 tokenDataModel: TokenDataModel(0),
                                 onValueChange: (value) {
-                                  BlocProvider.of<PlantSeedsBloc>(context).add(OnAmountChange(amountChanged: value));
+                                  BlocProvider.of<PlantSeedsBloc>(context).add(
+                                      OnAmountChange(amountChanged: value));
                                 },
                                 autoFocus: state.isAutoFocus,
                               ),
                               const SizedBox(height: 24),
-                              AlertInputValue(context.loc.plantSeedsNotEnoughBalanceAlert, isVisible: state.showAlert),
+                              AlertInputValue(
+                                  context.loc.plantSeedsNotEnoughBalanceAlert,
+                                  isVisible: state.showAlert),
                               const SizedBox(height: 24),
                               BalanceRow(
                                 label: context.loc.plantSeedsAvailableBalance,
@@ -85,7 +97,8 @@ class PlantSeedsScreen extends StatelessWidget {
                       ),
                       BlocBuilder<PlantSeedsBloc, PlantSeedsState>(
                         buildWhen: (previous, current) {
-                          return previous.isPlantSeedsButtonEnabled != current.isPlantSeedsButtonEnabled;
+                          return previous.isPlantSeedsButtonEnabled !=
+                              current.isPlantSeedsButtonEnabled;
                         },
                         builder: (context, state) {
                           return Align(
@@ -94,7 +107,8 @@ class PlantSeedsScreen extends StatelessWidget {
                               title: context.loc.plantSeedsPlantButtonTitle,
                               enabled: state.isPlantSeedsButtonEnabled,
                               onPressed: () =>
-                                  BlocProvider.of<PlantSeedsBloc>(context).add(const OnPlantSeedsButtonTapped()),
+                                  BlocProvider.of<PlantSeedsBloc>(context)
+                                      .add(const OnPlantSeedsButtonTapped()),
                             ),
                           );
                         },

--- a/lib/screens/explore_screens/regions_screens/create_region_event_screens/components/review_and_publish_region_event_bottom.dart
+++ b/lib/screens/explore_screens/regions_screens/create_region_event_screens/components/review_and_publish_region_event_bottom.dart
@@ -14,7 +14,7 @@ class ReviewAndPublishRegionEventBottom extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text("Details", style: Theme.of(context).textTheme.headline6),
+              Text("Details", style: Theme.of(context).textTheme.titleLarge),
               const SizedBox(height: 16),
               Row(
                 children: [
@@ -23,7 +23,7 @@ class ReviewAndPublishRegionEventBottom extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 16),
-              Text(state.eventDescription, style: Theme.of(context).textTheme.subtitle2)
+              Text(state.eventDescription, style: Theme.of(context).textTheme.titleSmall)
             ],
           ),
         );

--- a/lib/screens/explore_screens/regions_screens/create_region_event_screens/review_and_publish_region_event.dart
+++ b/lib/screens/explore_screens/regions_screens/create_region_event_screens/review_and_publish_region_event.dart
@@ -26,14 +26,14 @@ class ReviewAndPublishRegionEvent extends StatelessWidget {
               minimum: const EdgeInsets.only(bottom: 16),
               child: Stack(
                 children: [
-                  SingleChildScrollView(
+                  const SingleChildScrollView(
                     child: Column(
                       children: [
-                        const ReviewAndPublishRegionEventHeader(),
-                        const ReviewAndPublishRegionEventMiddle(),
-                        const DividerJungle(),
-                        const ReviewAndPublishRegionEventBottom(),
-                        const SizedBox(height: 60)
+                        ReviewAndPublishRegionEventHeader(),
+                        ReviewAndPublishRegionEventMiddle(),
+                        DividerJungle(),
+                        ReviewAndPublishRegionEventBottom(),
+                        SizedBox(height: 60)
                       ],
                     ),
                   ),

--- a/lib/screens/explore_screens/regions_screens/create_region_screens/components/create_region_confirmation_dialog.dart
+++ b/lib/screens/explore_screens/regions_screens/create_region_screens/components/create_region_confirmation_dialog.dart
@@ -25,20 +25,20 @@ class CreateRegionConfirmationDialog extends StatelessWidget {
         },
         children: [
           const SizedBox(height: 10.0),
-          Text("Create Region Confirmation", style: Theme.of(context).textTheme.headline6),
+          Text("Create Region Confirmation", style: Theme.of(context).textTheme.titleLarge),
           const SizedBox(height: 30.0),
           RichText(
               textAlign: TextAlign.center,
               text: TextSpan(children: <TextSpan>[
-                TextSpan(text: "By selecting “Yes I’m sure”,", style: Theme.of(context).textTheme.subtitle2),
+                TextSpan(text: "By selecting “Yes I’m sure”,", style: Theme.of(context).textTheme.titleSmall),
                 TextSpan(text: " 1,000 Seeds", style: Theme.of(context).textTheme.subtitle2Green3LowEmphasis),
                 TextSpan(
                     text: " will be staked and your region will be created for others to see and join.",
-                    style: Theme.of(context).textTheme.subtitle2)
+                    style: Theme.of(context).textTheme.titleSmall)
               ])),
           const SizedBox(height: 16.0),
           Text("Please make sure that everything is in order and that you are ready to create your region!",
-              style: Theme.of(context).textTheme.subtitle2, textAlign: TextAlign.center),
+              style: Theme.of(context).textTheme.titleSmall, textAlign: TextAlign.center),
           const SizedBox(height: 20.0),
         ],
       ),

--- a/lib/screens/explore_screens/regions_screens/join_region/components/create_new_region_dialog.dart
+++ b/lib/screens/explore_screens/regions_screens/join_region/components/create_new_region_dialog.dart
@@ -31,13 +31,13 @@ class CreateNewRegionDialog extends StatelessWidget {
           BlocProvider.of<JoinRegionBloc>(context).add(const OnCreateRegionNextTapped());
         },
         children: [
-          Text(context.loc.createRegionDialogTitle, style: Theme.of(context).textTheme.headline6),
+          Text(context.loc.createRegionDialogTitle, style: Theme.of(context).textTheme.titleLarge),
           const SizedBox(height: 30.0),
           Container(width: iconSize, height: iconSize, child: const CustomPaint(painter: Regions())),
           const SizedBox(height: 30.0),
           Text(
             context.loc.createRegionDialogSubtitle,
-            style: Theme.of(context).textTheme.subtitle2,
+            style: Theme.of(context).textTheme.titleSmall,
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 20.0),

--- a/lib/screens/explore_screens/regions_screens/join_region/components/introducing_regions_dialog.dart
+++ b/lib/screens/explore_screens/regions_screens/join_region/components/introducing_regions_dialog.dart
@@ -24,7 +24,7 @@ class IntroducingRegionsDialog extends StatelessWidget {
             Navigator.of(context).pop(true);
           },
           children: [
-            Text(context.loc.introducingRegionsDialogTitle, style: Theme.of(context).textTheme.headline6),
+            Text(context.loc.introducingRegionsDialogTitle, style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 30.0),
             const CustomPaint(size: Size(103, 106), painter: Regions()),
             const SizedBox(height: 40.0),
@@ -33,31 +33,31 @@ class IntroducingRegionsDialog extends StatelessWidget {
                 children: [
                   TextSpan(
                       text: context.loc.introducingRegionsDialogDescription1,
-                      style: Theme.of(context).textTheme.subtitle2),
+                      style: Theme.of(context).textTheme.titleSmall),
                   TextSpan(
                       text: context.loc.introducingRegionsDialogDescription2,
                       style: Theme.of(context).textTheme.subtitle2HighEmphasis),
                   TextSpan(
                       text: context.loc.introducingRegionsDialogDescription3,
-                      style: Theme.of(context).textTheme.subtitle2),
+                      style: Theme.of(context).textTheme.titleSmall),
                   TextSpan(
                       text: context.loc.introducingRegionsDialogDescription4,
-                      style: Theme.of(context).textTheme.subtitle2),
+                      style: Theme.of(context).textTheme.titleSmall),
                   TextSpan(
                       text: context.loc.introducingRegionsDialogDescription5,
                       style: Theme.of(context).textTheme.subtitle2Green2),
                   TextSpan(
                       text: context.loc.introducingRegionsDialogDescription6,
-                      style: Theme.of(context).textTheme.subtitle2),
+                      style: Theme.of(context).textTheme.titleSmall),
                   TextSpan(
                       text: context.loc.introducingRegionsDialogDescription7,
-                      style: Theme.of(context).textTheme.subtitle2),
+                      style: Theme.of(context).textTheme.titleSmall),
                   TextSpan(
                       text: ' ${context.loc.genericNextButtonTitle} ',
                       style: Theme.of(context).textTheme.subtitle2Green2),
                   TextSpan(
                       text: context.loc.introducingRegionsDialogDescription8,
-                      style: Theme.of(context).textTheme.subtitle2),
+                      style: Theme.of(context).textTheme.titleSmall),
                 ],
               ),
             ),

--- a/lib/screens/explore_screens/regions_screens/join_region/components/not_enough_seeds_dialog.dart
+++ b/lib/screens/explore_screens/regions_screens/join_region/components/not_enough_seeds_dialog.dart
@@ -27,11 +27,11 @@ class NotEnoughSeedsDialog extends StatelessWidget {
         onRightButtonPressed: () => launchUrl(Uri.parse('$urlBuySeeds${settingsStorage.accountName}')),
         children: [
           const SizedBox(height: 10.0),
-          Text(context.loc.createRegionNotEnoughSeedsDialogTitle, style: Theme.of(context).textTheme.headline6),
+          Text(context.loc.createRegionNotEnoughSeedsDialogTitle, style: Theme.of(context).textTheme.titleLarge),
           const SizedBox(height: 30.0),
           Text(
             context.loc.createRegionNotEnoughSeedsDialogSubtitle,
-            style: Theme.of(context).textTheme.subtitle2,
+            style: Theme.of(context).textTheme.titleSmall,
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 20.0),

--- a/lib/screens/explore_screens/regions_screens/region_event_details/region_event_details_screen.dart
+++ b/lib/screens/explore_screens/regions_screens/region_event_details/region_event_details_screen.dart
@@ -148,7 +148,7 @@ class RegionEventDetailsScreen extends StatelessWidget {
                         children: [
                           Text('Details', style: Theme.of(context).textTheme.headline7),
                           const SizedBox(height: 10.0),
-                          Text(event.eventAddress, style: Theme.of(context).textTheme.subtitle2),
+                          Text(event.eventAddress, style: Theme.of(context).textTheme.titleSmall),
                           const SizedBox(height: 16.0),
                           Row(
                             children: [

--- a/lib/screens/explore_screens/regions_screens/regions_main/components/generic_region_dialog.dart
+++ b/lib/screens/explore_screens/regions_screens/regions_main/components/generic_region_dialog.dart
@@ -21,9 +21,9 @@ class GenericRegionDialog extends StatelessWidget {
       rightButtonTitle: context.loc.genericRegionConfirmImSureButton,
       onRightButtonPressed: () => Navigator.of(context).pop(true),
       children: [
-        Text(title, style: Theme.of(context).textTheme.headline6),
+        Text(title, style: Theme.of(context).textTheme.titleLarge),
         const SizedBox(height: 40.0),
-        Text(description, style: Theme.of(context).textTheme.subtitle2),
+        Text(description, style: Theme.of(context).textTheme.titleSmall),
         const SizedBox(height: 20.0),
       ],
     );

--- a/lib/screens/explore_screens/regions_screens/regions_main/components/region_event_card/region_event_card.dart
+++ b/lib/screens/explore_screens/regions_screens/regions_main/components/region_event_card/region_event_card.dart
@@ -27,7 +27,7 @@ class RegionEventCard extends StatelessWidget {
             child: InkWell(
               onTap: () => NavigationService.of(context).navigateTo(Routes.regionEventDetails, event),
               borderRadius: BorderRadius.circular(16.0),
-              child: Container(
+              child: DecoratedBox(
                 decoration: state.isEventExpired
                     ? BoxDecoration(
                         borderRadius: BorderRadius.circular(16.0),
@@ -65,7 +65,7 @@ class RegionEventCard extends StatelessWidget {
                                   padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 6),
                                   child: Text(
                                     "The event has passed",
-                                    style: Theme.of(context).textTheme.subtitle2,
+                                    style: Theme.of(context).textTheme.titleSmall,
                                   ),
                                 ),
                               ),

--- a/lib/screens/explore_screens/unplant_seeds/components/claim_seeds_succes_dialog.dart
+++ b/lib/screens/explore_screens/unplant_seeds/components/claim_seeds_succes_dialog.dart
@@ -33,22 +33,22 @@ class ClaimSeedsSuccessDialog extends StatelessWidget {
             children: [
               Text(
                 claimSeedsAmount.amountString(),
-                style: Theme.of(context).textTheme.headline4,
+                style: Theme.of(context).textTheme.headlineMedium,
               ),
               Padding(
                 padding: const EdgeInsets.only(top: 12, left: 4),
-                child: Text(claimSeedsAmount.symbol, style: Theme.of(context).textTheme.subtitle2),
+                child: Text(claimSeedsAmount.symbol, style: Theme.of(context).textTheme.titleSmall),
               ),
             ],
           ),
           const SizedBox(height: 4.0),
           Text(
             claimSeedsAmountFiat.asFormattedString(),
-            style: Theme.of(context).textTheme.subtitle2,
+            style: Theme.of(context).textTheme.titleSmall,
           ),
           const SizedBox(height: 20.0),
           Text(context.loc.plantSeedsClaimSuccessMessage,
-              textAlign: TextAlign.center, style: Theme.of(context).textTheme.headline6),
+              textAlign: TextAlign.center, style: Theme.of(context).textTheme.titleLarge),
           const SizedBox(height: 20.0),
         ],
       ),

--- a/lib/screens/explore_screens/unplant_seeds/components/unplant_seeds_amount_entry.dart
+++ b/lib/screens/explore_screens/unplant_seeds/components/unplant_seeds_amount_entry.dart
@@ -33,7 +33,7 @@ class UnplantSeedsAmountEntry extends StatelessWidget {
               child: TextFormField(
                 controller: controller,
                 textAlign: TextAlign.end,
-                style: Theme.of(context).textTheme.headline4,
+                style: Theme.of(context).textTheme.headlineMedium,
                 keyboardType: const TextInputType.numberWithOptions(decimal: true),
                 decoration: const InputDecoration(
                   hintText: "0.0",

--- a/lib/screens/explore_screens/unplant_seeds/components/unplant_seeds_success_dialog.dart
+++ b/lib/screens/explore_screens/unplant_seeds/components/unplant_seeds_success_dialog.dart
@@ -36,27 +36,27 @@ class UnplantSeedsSuccessDialog extends StatelessWidget {
             children: [
               Text(
                 unplantedInputAmount.amountString(),
-                style: Theme.of(context).textTheme.headline4,
+                style: Theme.of(context).textTheme.headlineMedium,
               ),
               Padding(
                 padding: const EdgeInsets.only(top: 12, left: 4),
-                child: Text(unplantedInputAmount.symbol, style: Theme.of(context).textTheme.subtitle2),
+                child: Text(unplantedInputAmount.symbol, style: Theme.of(context).textTheme.titleSmall),
               ),
             ],
           ),
           const SizedBox(height: 4.0),
           Text(
             unplantedInputAmountFiat.asFormattedString(),
-            style: Theme.of(context).textTheme.subtitle2,
+            style: Theme.of(context).textTheme.titleSmall,
           ),
           const SizedBox(height: 20.0),
           Text(context.loc.plantSeedsUnplantSuccessMessage,
-              textAlign: TextAlign.center, style: Theme.of(context).textTheme.headline6),
+              textAlign: TextAlign.center, style: Theme.of(context).textTheme.titleLarge),
           const SizedBox(height: 20.0),
           Text(
             context.loc.plantSeedsUnplantExplanationMessage,
             textAlign: TextAlign.center,
-            style: Theme.of(context).textTheme.button,
+            style: Theme.of(context).textTheme.labelLarge,
           ),
         ],
       ),

--- a/lib/screens/explore_screens/unplant_seeds/unplant_seeds_screen.dart
+++ b/lib/screens/explore_screens/unplant_seeds/unplant_seeds_screen.dart
@@ -96,7 +96,7 @@ class _UnplantSeedsScreenState extends State<UnplantSeedsScreen> {
                           child: Column(
                             children: [
                               const SizedBox(height: 26),
-                              Text('Unplant amount', style: Theme.of(context).textTheme.headline6),
+                              Text('Unplant amount', style: Theme.of(context).textTheme.titleLarge),
                               const SizedBox(height: 16),
                               UnplantSeedsAmountEntry(
                                 controller: _amountController,

--- a/lib/screens/explore_screens/vote_screens/delegate/delegates_tab/components/delegate_card.dart
+++ b/lib/screens/explore_screens/vote_screens/delegate/delegates_tab/components/delegate_card.dart
@@ -40,7 +40,7 @@ class DelegateCard extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 6),
               child: Text(
                 'Delegate',
-                style: Theme.of(context).textTheme.subtitle2,
+                style: Theme.of(context).textTheme.titleSmall,
               ),
             ),
           ),

--- a/lib/screens/explore_screens/vote_screens/delegate/delegates_tab/components/introducing_delegates_dialog.dart
+++ b/lib/screens/explore_screens/vote_screens/delegate/delegates_tab/components/introducing_delegates_dialog.dart
@@ -15,7 +15,7 @@ class IntroducingDelegatesDialog extends StatelessWidget {
         singleLargeButtonTitle: "Dismiss",
         onSingleLargeButtonPressed: () => Navigator.of(context).pop(),
         children: [
-          Text('Introducing Delegates!', style: Theme.of(context).textTheme.headline6),
+          Text('Introducing Delegates!', style: Theme.of(context).textTheme.titleLarge),
           const SizedBox(height: 30.0),
           Image.asset('assets/images/explore/introducing_delegate.png'),
           const SizedBox(height: 30.0),

--- a/lib/screens/explore_screens/vote_screens/delegate/delegates_tab/components/remove_delegate_confirmation_dialog.dart
+++ b/lib/screens/explore_screens/vote_screens/delegate/delegates_tab/components/remove_delegate_confirmation_dialog.dart
@@ -25,10 +25,10 @@ class RemoveDelegateConfirmationDialog extends StatelessWidget {
         },
         children: [
           const SizedBox(height: 10.0),
-          Text('Remove Delegate?', style: Theme.of(context).textTheme.headline6),
+          Text('Remove Delegate?', style: Theme.of(context).textTheme.titleLarge),
           const SizedBox(height: 30.0),
           Text('Are you sure you would like to remove this person as your Delegate?',
-              style: Theme.of(context).textTheme.subtitle2),
+              style: Theme.of(context).textTheme.titleSmall),
           const SizedBox(height: 20.0),
         ],
       ),

--- a/lib/screens/explore_screens/vote_screens/delegate/delegates_tab/delegates_tab.dart
+++ b/lib/screens/explore_screens/vote_screens/delegate/delegates_tab/delegates_tab.dart
@@ -68,7 +68,7 @@ class DelegatesTab extends StatelessWidget {
                         padding: const EdgeInsets.symmetric(horizontal: 10),
                         child: Text(
                             'Delegating your vote means to entrust the power of your vote to another Citizen.  Please choose your delegate carefully!',
-                            style: Theme.of(context).textTheme.subtitle2),
+                            style: Theme.of(context).textTheme.titleSmall),
                       ),
                       const SizedBox(height: 30),
                       DelegateCard(

--- a/lib/screens/explore_screens/vote_screens/delegate/delegators_tab/components/delegator_row.dart
+++ b/lib/screens/explore_screens/vote_screens/delegate/delegators_tab/components/delegator_row.dart
@@ -20,7 +20,7 @@ class DelegatorRow extends StatelessWidget {
       ),
       title: Text(
         (!delegator.nickname.isNullOrEmpty) ? delegator.nickname : delegator.nickname,
-        style: Theme.of(context).textTheme.button,
+        style: Theme.of(context).textTheme.labelLarge,
       ),
       subtitle: Text(delegator.account, style: Theme.of(context).textTheme.subtitle2OpacityEmphasis),
     );

--- a/lib/screens/explore_screens/vote_screens/delegate/delegators_tab/delegators_tab.dart
+++ b/lib/screens/explore_screens/vote_screens/delegate/delegators_tab/delegators_tab.dart
@@ -31,7 +31,7 @@ class DelegatorsTab extends StatelessWidget {
                         padding: const EdgeInsets.symmetric(horizontal: 10),
                         child: Text(
                             'Delegators are Citizens that have chosen you to vote on their behalf. All votes already cast this cycle will not change.',
-                            style: Theme.of(context).textTheme.subtitle2),
+                            style: Theme.of(context).textTheme.titleSmall),
                       ),
                       Expanded(
                         child: state.delegators.isEmpty

--- a/lib/screens/explore_screens/vote_screens/delegate_a_user/component/delegate_a_user_confirmation_dialog.dart
+++ b/lib/screens/explore_screens/vote_screens/delegate_a_user/component/delegate_a_user_confirmation_dialog.dart
@@ -30,22 +30,22 @@ class DelegateAUserConfirmationDialog extends StatelessWidget {
               Navigator.of(context).pop();
             },
             children: [
-              Text('Delegate Confirmation', style: Theme.of(context).textTheme.headline6),
+              Text('Delegate Confirmation', style: Theme.of(context).textTheme.titleLarge),
               const SizedBox(height: 30.0),
               Text(
                   'By selecting this Citizen as your delegate you are entrusting your Trust Tokens to them to vote with.',
-                  style: Theme.of(context).textTheme.subtitle2),
+                  style: Theme.of(context).textTheme.titleSmall),
               const SizedBox(height: 20.0),
               RichText(
                 textAlign: TextAlign.center,
                 text: TextSpan(
                     text: 'Are you sure you would like ',
-                    style: Theme.of(context).textTheme.subtitle2,
+                    style: Theme.of(context).textTheme.titleSmall,
                     children: <TextSpan>[
                       TextSpan(
                           text: '${selectedDelegate.nickname} (${selectedDelegate.account})',
                           style: Theme.of(context).textTheme.subtitle2Green3LowEmphasis),
-                      TextSpan(text: ' to be your delegate?', style: Theme.of(context).textTheme.subtitle2)
+                      TextSpan(text: ' to be your delegate?', style: Theme.of(context).textTheme.titleSmall)
                     ]),
               ),
             ],

--- a/lib/screens/explore_screens/vote_screens/delegate_a_user/component/delegate_a_user_success_dialog.dart
+++ b/lib/screens/explore_screens/vote_screens/delegate_a_user/component/delegate_a_user_success_dialog.dart
@@ -27,10 +27,10 @@ class DelegateAUserSuccessDialog extends StatelessWidget {
               NavigationService.of(context).navigateTo(Routes.delegate);
             },
             children: [
-              Text('Delegate Chosen!', style: Theme.of(context).textTheme.headline6),
+              Text('Delegate Chosen!', style: Theme.of(context).textTheme.titleLarge),
               const SizedBox(height: 30.0),
               Text('You have successfully chosen your delegate. They will now vote with the power of your vote.',
-                  style: Theme.of(context).textTheme.subtitle2),
+                  style: Theme.of(context).textTheme.titleSmall),
             ],
           ),
         );

--- a/lib/screens/explore_screens/vote_screens/proposal_details/components/confirm_vote_dialog.dart
+++ b/lib/screens/explore_screens/vote_screens/proposal_details/components/confirm_vote_dialog.dart
@@ -20,7 +20,7 @@ class ConfirmVoteDialog extends StatelessWidget {
         Text(
           'Your trust tokens cannot be reallocated afterwards so please be sure of your vote!'.i18n,
           textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.subtitle2,
+          style: Theme.of(context).textTheme.titleSmall,
         ),
         const SizedBox(height: 16.0),
       ],

--- a/lib/screens/explore_screens/vote_screens/proposal_details/components/current_vote_choice_label.dart
+++ b/lib/screens/explore_screens/vote_screens/proposal_details/components/current_vote_choice_label.dart
@@ -20,9 +20,9 @@ class CurrentVoteChoiceLabel extends StatelessWidget {
                 RichText(
                   text: TextSpan(
                     children: [
-                      TextSpan(text: "I'm".i18n, style: Theme.of(context).textTheme.subtitle2),
+                      TextSpan(text: "I'm".i18n, style: Theme.of(context).textTheme.titleSmall),
                       TextSpan(text: ' in favor '.i18n, style: Theme.of(context).textTheme.subtitle2Green2),
-                      TextSpan(text: 'of this proposal'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                      TextSpan(text: 'of this proposal'.i18n, style: Theme.of(context).textTheme.titleSmall),
                     ],
                   ),
                 ),
@@ -37,9 +37,9 @@ class CurrentVoteChoiceLabel extends StatelessWidget {
                 RichText(
                   text: TextSpan(
                     children: [
-                      TextSpan(text: 'I'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                      TextSpan(text: 'I'.i18n, style: Theme.of(context).textTheme.titleSmall),
                       TextSpan(text: ' refrain '.i18n, style: Theme.of(context).textTheme.subtitle2Green2),
-                      TextSpan(text: 'from voting'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                      TextSpan(text: 'from voting'.i18n, style: Theme.of(context).textTheme.titleSmall),
                     ],
                   ),
                 ),
@@ -54,9 +54,9 @@ class CurrentVoteChoiceLabel extends StatelessWidget {
                 RichText(
                   text: TextSpan(
                     children: [
-                      TextSpan(text: "I'm".i18n, style: Theme.of(context).textTheme.subtitle2),
+                      TextSpan(text: "I'm".i18n, style: Theme.of(context).textTheme.titleSmall),
                       TextSpan(text: ' against '.i18n, style: Theme.of(context).textTheme.subtitle2Green2),
-                      TextSpan(text: 'this proposal'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                      TextSpan(text: 'this proposal'.i18n, style: Theme.of(context).textTheme.titleSmall),
                     ],
                   ),
                 ),

--- a/lib/screens/explore_screens/vote_screens/proposal_details/components/proposal_details_header.dart
+++ b/lib/screens/explore_screens/vote_screens/proposal_details/components/proposal_details_header.dart
@@ -62,7 +62,7 @@ class ProposalDetailsHeader extends StatelessWidget {
                     padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 6),
                     child: Text(
                       state.proposals[state.currentIndex].proposalCategory.localizedDescription(context).inCaps,
-                      style: Theme.of(context).textTheme.subtitle2,
+                      style: Theme.of(context).textTheme.titleSmall,
                     ),
                   ),
                 ),

--- a/lib/screens/explore_screens/vote_screens/proposal_details/components/proposal_details_middle.dart
+++ b/lib/screens/explore_screens/vote_screens/proposal_details/components/proposal_details_middle.dart
@@ -47,7 +47,7 @@ class ProposalDetailsMiddle extends StatelessWidget {
                         const SizedBox(height: 30.0),
                       ],
                     ),
-                  Text('Created by'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                  Text('Created by'.i18n, style: Theme.of(context).textTheme.titleSmall),
                   const SizedBox(height: 10.0),
                   Row(
                     children: [
@@ -67,7 +67,7 @@ class ProposalDetailsMiddle extends StatelessWidget {
                                   Expanded(
                                     child: Text(
                                       state.proposals[state.currentIndex].creator,
-                                      style: Theme.of(context).textTheme.button,
+                                      style: Theme.of(context).textTheme.labelLarge,
                                     ),
                                   ),
                                   Text(
@@ -78,7 +78,7 @@ class ProposalDetailsMiddle extends StatelessWidget {
                               ),
                               const SizedBox(height: 10.0),
                               Row(
-                                children: [Text(state.creator!.nickname, style: Theme.of(context).textTheme.subtitle2)],
+                                children: [Text(state.creator!.nickname, style: Theme.of(context).textTheme.titleSmall)],
                               ),
                             ],
                           ),
@@ -100,12 +100,12 @@ class ProposalDetailsMiddle extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          'Setting: %s '.i18n.fill([(state.proposals[state.currentIndex].settingName)]),
+                          'Setting: %s '.i18n.fill([state.proposals[state.currentIndex].settingName]),
                           style: Theme.of(context).textTheme.subtitle3OpacityEmphasis,
                         ),
                         const SizedBox(height: 8),
                         Text(
-                          'New Value: %s'.i18n.fill([(state.proposals[state.currentIndex].settingValue)]),
+                          'New Value: %s'.i18n.fill([state.proposals[state.currentIndex].settingValue]),
                           style: Theme.of(context).textTheme.subtitle3OpacityEmphasis,
                         ),
                       ],
@@ -115,12 +115,12 @@ class ProposalDetailsMiddle extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          'Recipient: %s '.i18n.fill([(state.proposals[state.currentIndex].recipient)]),
+                          'Recipient: %s '.i18n.fill([state.proposals[state.currentIndex].recipient]),
                           style: Theme.of(context).textTheme.subtitle3OpacityEmphasis,
                         ),
                         const SizedBox(height: 8),
                         Text(
-                          'Requested: %s '.i18n.fill([(state.proposals[state.currentIndex].quantity)]),
+                          'Requested: %s '.i18n.fill([state.proposals[state.currentIndex].quantity]),
                           style: Theme.of(context).textTheme.subtitle3OpacityEmphasis,
                         ),
                         const SizedBox(height: 8),
@@ -130,12 +130,12 @@ class ProposalDetailsMiddle extends StatelessWidget {
                         ),
                         const SizedBox(height: 8),
                         Text(
-                          'Status: %s '.i18n.fill([(state.proposals[state.currentIndex].status.inCaps)]),
+                          'Status: %s '.i18n.fill([state.proposals[state.currentIndex].status.inCaps]),
                           style: Theme.of(context).textTheme.subtitle3OpacityEmphasis,
                         ),
                         const SizedBox(height: 8),
                         Text(
-                          'Stage: %s '.i18n.fill([(state.proposals[state.currentIndex].stage.inCaps)]),
+                          'Stage: %s '.i18n.fill([state.proposals[state.currentIndex].stage.inCaps]),
                           style: Theme.of(context).textTheme.subtitle3OpacityEmphasis,
                         ),
                       ],

--- a/lib/screens/explore_screens/vote_screens/proposal_details/components/vote_status_label.dart
+++ b/lib/screens/explore_screens/vote_screens/proposal_details/components/vote_status_label.dart
@@ -23,9 +23,9 @@ class VoteStatusLabel extends StatelessWidget {
                     RichText(
                       text: TextSpan(
                         children: [
-                          TextSpan(text: 'You must be a'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                          TextSpan(text: 'You must be a'.i18n, style: Theme.of(context).textTheme.titleSmall),
                           TextSpan(text: ' Citizen '.i18n, style: Theme.of(context).textTheme.subtitle2Green2),
-                          TextSpan(text: 'to vote on proposals.'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                          TextSpan(text: 'to vote on proposals.'.i18n, style: Theme.of(context).textTheme.titleSmall),
                         ],
                       ),
                     ),
@@ -40,13 +40,13 @@ class VoteStatusLabel extends StatelessWidget {
                     RichText(
                       text: TextSpan(
                         children: [
-                          TextSpan(text: 'You have already'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                          TextSpan(text: 'You have already'.i18n, style: Theme.of(context).textTheme.titleSmall),
                           TextSpan(text: ' Voted with '.i18n, style: Theme.of(context).textTheme.subtitle2Green2),
                           TextSpan(
                               text: state.vote!.amount == 1
                                   ? '${state.vote!.amount} ' 'vote '.i18n
                                   : '${state.vote!.amount} ' 'votes'.i18n,
-                              style: Theme.of(context).textTheme.subtitle2),
+                              style: Theme.of(context).textTheme.titleSmall),
                         ],
                       ),
                     ),
@@ -65,12 +65,12 @@ class VoteStatusLabel extends StatelessWidget {
                           children: [
                             TextSpan(
                                 text: 'You have delegated your vote to'.i18n,
-                                style: Theme.of(context).textTheme.subtitle2),
+                                style: Theme.of(context).textTheme.titleSmall),
                             TextSpan(
                                 text: ' ${state.proposalDelegate}. ',
                                 style: Theme.of(context).textTheme.subtitle2Green2),
                             TextSpan(
-                                text: 'They are voting for you.'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                                text: 'They are voting for you.'.i18n, style: Theme.of(context).textTheme.titleSmall),
                           ],
                         ),
                       ),
@@ -86,7 +86,7 @@ class VoteStatusLabel extends StatelessWidget {
                     RichText(
                       text: TextSpan(
                         children: [
-                          TextSpan(text: 'Voting'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                          TextSpan(text: 'Voting'.i18n, style: Theme.of(context).textTheme.titleSmall),
                           TextSpan(
                               text: ' - ${state.proposals[state.currentIndex].proposalCategory.name}: ',
                               style: Theme.of(context).textTheme.subtitle2Green2),
@@ -94,7 +94,7 @@ class VoteStatusLabel extends StatelessWidget {
                               text: state.voteAmount == 1
                                   ? '${state.voteAmount} ' 'vote '.i18n
                                   : '${state.voteAmount} ' 'votes'.i18n,
-                              style: Theme.of(context).textTheme.subtitle2),
+                              style: Theme.of(context).textTheme.titleSmall),
                         ],
                       ),
                     ),
@@ -109,7 +109,7 @@ class VoteStatusLabel extends StatelessWidget {
             padding: const EdgeInsets.only(top: horizontalEdgePadding, left: horizontalEdgePadding),
             child: Row(
               children: [
-                Text('Voting for this proposal is not open yet.'.i18n, style: Theme.of(context).textTheme.subtitle2),
+                Text('Voting for this proposal is not open yet.'.i18n, style: Theme.of(context).textTheme.titleSmall),
               ],
             ),
           );

--- a/lib/screens/explore_screens/vote_screens/proposal_details/components/vote_success_dialog.dart
+++ b/lib/screens/explore_screens/vote_screens/proposal_details/components/vote_success_dialog.dart
@@ -19,7 +19,7 @@ class VoteSuccessDialog extends StatelessWidget {
           'Thank you for coming and contributing your voice to the collective decision making process. Please make sure to come back at the start of the next Voting Cycle to empower more people!'
               .i18n,
           textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.subtitle2,
+          style: Theme.of(context).textTheme.titleSmall,
         ),
         const SizedBox(height: 16.0),
       ],

--- a/lib/screens/explore_screens/vote_screens/proposal_details/interactor/usecases/vote_proposal_use_case.dart
+++ b/lib/screens/explore_screens/vote_screens/proposal_details/interactor/usecases/vote_proposal_use_case.dart
@@ -5,12 +5,12 @@ import 'package:seeds/screens/explore_screens/vote_screens/proposals/viewmodels/
 
 class VoteProposalUseCase {
   Future<Result> run({required ProposalViewModel proposal, required int amount}) {
-    final ProposalsRepository _proposalsRepository = ProposalsRepository();
+    final ProposalsRepository proposalsRepository = ProposalsRepository();
     final String accountName = settingsStorage.accountName;
     if (proposal.proposalCategory == ProposalCategory.referendum) {
-      return _proposalsRepository.voteReferendum(id: proposal.id, amount: amount, accountName: accountName);
+      return proposalsRepository.voteReferendum(id: proposal.id, amount: amount, accountName: accountName);
     } else {
-      return _proposalsRepository.voteProposal(id: proposal.id, amount: amount, accountName: accountName);
+      return proposalsRepository.voteProposal(id: proposal.id, amount: amount, accountName: accountName);
     }
   }
 }

--- a/lib/screens/explore_screens/vote_screens/proposals/components/proposal_card.dart
+++ b/lib/screens/explore_screens/vote_screens/proposals/components/proposal_card.dart
@@ -217,7 +217,7 @@ class _ProposalCardState extends State<ProposalCard> with AutomaticKeepAliveClie
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 6),
                     child: Text(widget.proposal.proposalCategory.localizedDescription(context).inCaps,
-                        style: Theme.of(context).textTheme.subtitle2),
+                        style: Theme.of(context).textTheme.titleSmall),
                   ),
                 ),
               ],
@@ -229,7 +229,7 @@ class _ProposalCardState extends State<ProposalCard> with AutomaticKeepAliveClie
             Positioned(
               top: 10.0,
               left: 26.0,
-              child: Container(
+              child: DecoratedBox(
                 decoration: BoxDecoration(color: AppColors.darkGreen2, borderRadius: BorderRadius.circular(6.0)),
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),

--- a/lib/screens/explore_screens/vote_screens/proposals/components/vote_amount_label/vote_amount_label.dart
+++ b/lib/screens/explore_screens/vote_screens/proposals/components/vote_amount_label/vote_amount_label.dart
@@ -31,7 +31,7 @@ class VoteAmountLabel extends StatelessWidget {
                     child: SizedBox(width: 14.0, height: 14.0, child: CircularProgressIndicator(strokeWidth: 2))),
               );
             case PageState.success:
-              return Container(
+              return DecoratedBox(
                 decoration: BoxDecoration(color: AppColors.darkGreen3, borderRadius: BorderRadius.circular(6.0)),
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),

--- a/lib/screens/explore_screens/vote_screens/proposals/components/voting_end_cycle_card.dart
+++ b/lib/screens/explore_screens/vote_screens/proposals/components/voting_end_cycle_card.dart
@@ -20,7 +20,7 @@ class VotingCycleEndCard implements SliverPersistentHeaderDelegate {
           Container(color: AppColors.primary),
           Padding(
             padding: const EdgeInsets.all(16.0),
-            child: Container(
+            child: DecoratedBox(
               decoration: BoxDecoration(color: AppColors.darkGreen2, borderRadius: BorderRadius.circular(12)),
               child: SingleChildScrollView(
                 padding: const EdgeInsets.only(top: 16, bottom: 16, right: 14, left: 14),
@@ -39,21 +39,21 @@ class VotingCycleEndCard implements SliverPersistentHeaderDelegate {
                           case PageState.initial:
                             return const SizedBox.shrink();
                           case PageState.loading:
-                            return Row(
+                            return const Row(
                               mainAxisAlignment: MainAxisAlignment.center,
-                              children: [const SizedBox(height: 20, width: 20, child: CircularProgressIndicator())],
+                              children: [SizedBox(height: 20, width: 20, child: CircularProgressIndicator())],
                             );
                           case PageState.failure:
                             return Row(
                               mainAxisAlignment: MainAxisAlignment.center,
-                              children: [Text(state.errorMessage!, style: Theme.of(context).textTheme.headline5)],
+                              children: [Text(state.errorMessage!, style: Theme.of(context).textTheme.headlineSmall)],
                             );
                           case PageState.success:
                             return voteCycleEnded
                                 ? Row(
                                     children: [
                                       Text(context.loc.proposalVoteCycleEndedTimeRemaining,
-                                          style: Theme.of(context).textTheme.headline5)
+                                          style: Theme.of(context).textTheme.headlineSmall)
                                     ],
                                   )
                                 : Row(
@@ -62,7 +62,7 @@ class VotingCycleEndCard implements SliverPersistentHeaderDelegate {
                                       Row(
                                         children: [
                                           Text('${state.currentRemainingTime?.days ?? 0} ',
-                                              style: Theme.of(context).textTheme.headline5),
+                                              style: Theme.of(context).textTheme.headlineSmall),
                                           Column(
                                             children: [
                                               const SizedBox(height: 12),
@@ -75,7 +75,7 @@ class VotingCycleEndCard implements SliverPersistentHeaderDelegate {
                                       Row(
                                         children: [
                                           Text('${state.currentRemainingTime?.hours ?? 0} ',
-                                              style: Theme.of(context).textTheme.headline5),
+                                              style: Theme.of(context).textTheme.headlineSmall),
                                           Column(
                                             children: [
                                               const SizedBox(height: 12),
@@ -88,7 +88,7 @@ class VotingCycleEndCard implements SliverPersistentHeaderDelegate {
                                       Row(
                                         children: [
                                           Text('${state.currentRemainingTime?.min ?? 0} ',
-                                              style: Theme.of(context).textTheme.headline5),
+                                              style: Theme.of(context).textTheme.headlineSmall),
                                           Column(
                                             children: [
                                               const SizedBox(height: 12),
@@ -103,7 +103,7 @@ class VotingCycleEndCard implements SliverPersistentHeaderDelegate {
                                       Row(
                                         children: [
                                           Text('${state.currentRemainingTime?.sec ?? 0} ',
-                                              style: Theme.of(context).textTheme.headline5),
+                                              style: Theme.of(context).textTheme.headlineSmall),
                                           Column(
                                             children: [
                                               const SizedBox(height: 12),

--- a/lib/screens/explore_screens/vote_screens/proposals/proposals_list.dart
+++ b/lib/screens/explore_screens/vote_screens/proposals/proposals_list.dart
@@ -94,7 +94,7 @@ class _ProposalsListState extends State<ProposalsList> with AutomaticKeepAliveCl
                     if (state.proposals.isEmpty)
                       SliverFillRemaining(
                         child: Center(
-                          child: Text('No proposals to show, yet', style: Theme.of(context).textTheme.button),
+                          child: Text('No proposals to show, yet', style: Theme.of(context).textTheme.labelLarge),
                         ),
                       )
                     else

--- a/lib/screens/explore_screens/vote_screens/vote/vote_screen.dart
+++ b/lib/screens/explore_screens/vote_screens/vote/vote_screen.dart
@@ -51,11 +51,11 @@ class VoteScreen extends StatelessWidget {
                     indicatorSize: TabBarIndicatorSize.label,
                     unselectedLabelStyle: Theme.of(context).textTheme.buttonOpacityEmphasis,
                     labelStyle: Theme.of(context).textTheme.buttonLowEmphasis,
-                    tabs: [for (var i in proposalTypes) Tab(child: FittedBox(child: Text(i.type.i18n)))],
+                    tabs: [for (final i in proposalTypes) Tab(child: FittedBox(child: Text(i.type.i18n)))],
                   ),
                 ),
               ),
-              body: SafeArea(child: TabBarView(children: [for (var i in proposalTypes) ProposalsList(i)])),
+              body: SafeArea(child: TabBarView(children: [for (final i in proposalTypes) ProposalsList(i)])),
             );
           },
         ),

--- a/lib/screens/explore_screens/vouch/vouch_for_a_member/components/vouch_for_member_confirmation_dialog.dart
+++ b/lib/screens/explore_screens/vouch/vouch_for_a_member/components/vouch_for_member_confirmation_dialog.dart
@@ -19,19 +19,22 @@ class VouchForMemberConfirmationDialog extends StatelessWidget {
             return true;
           },
           child: CustomDialog(
-            icon: const CustomPaint(size: Size(60, 60), painter: VouchWhiteBackground()),
+            icon: const CustomPaint(
+                size: Size(60, 60), painter: VouchWhiteBackground()),
             leftButtonTitle: "Cancel",
             rightButtonTitle: "Yes I'm sure",
             onRightButtonPressed: () {
-              BlocProvider.of<VouchForAMemberBloc>(context).add(OnConfirmVouchForMemberTap());
+              BlocProvider.of<VouchForAMemberBloc>(context)
+                  .add(OnConfirmVouchForMemberTap());
               Navigator.of(context).pop();
             },
             children: [
-              Text('Please read carefully', style: Theme.of(context).textTheme.headline6),
+              Text('Please read carefully',
+                  style: Theme.of(context).textTheme.titleLarge),
               const SizedBox(height: 10.0),
               Text(
                 'Vouching for someone means you are taking responsibility for their actions. If they are flagged, you will also lose reputation points. On the other hand, if they continue progressing to become citizens, you will gain reputation points! Choose carefully!',
-                style: Theme.of(context).textTheme.subtitle2,
+                style: Theme.of(context).textTheme.titleSmall,
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 20.0),
@@ -39,12 +42,17 @@ class VouchForMemberConfirmationDialog extends StatelessWidget {
                 textAlign: TextAlign.center,
                 text: TextSpan(
                     text: 'Are you sure you would like to vouch for ',
-                    style: Theme.of(context).textTheme.subtitle2,
+                    style: Theme.of(context).textTheme.titleSmall,
                     children: <TextSpan>[
                       TextSpan(
-                          text: '${state.selectedMember?.nickname} (${state.selectedMember?.account})',
-                          style: Theme.of(context).textTheme.subtitle2Green3LowEmphasis),
-                      TextSpan(text: '?', style: Theme.of(context).textTheme.subtitle2),
+                          text:
+                              '${state.selectedMember?.nickname} (${state.selectedMember?.account})',
+                          style: Theme.of(context)
+                              .textTheme
+                              .subtitle2Green3LowEmphasis),
+                      TextSpan(
+                          text: '?',
+                          style: Theme.of(context).textTheme.titleSmall),
                     ]),
               ),
             ],

--- a/lib/screens/explore_screens/vouch/vouched_tab/components/not_qualified_to_vouch_dialog.dart
+++ b/lib/screens/explore_screens/vouch/vouched_tab/components/not_qualified_to_vouch_dialog.dart
@@ -8,14 +8,16 @@ class NotQualifiedToVouchDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CustomDialog(
-      icon: const CustomPaint(size: Size(60, 60), painter: VouchWhiteBackground()),
+      icon: const CustomPaint(
+          size: Size(60, 60), painter: VouchWhiteBackground()),
       singleLargeButtonTitle: "Ok, Thank you!",
       children: [
-        Text('Not qualified to Vouch!', style: Theme.of(context).textTheme.headline6),
+        Text('Not qualified to Vouch!',
+            style: Theme.of(context).textTheme.titleLarge),
         const SizedBox(height: 16.0),
         Text(
           'As a visitor you do not have permission to vouch for another member just yet. Please go through the steps to become a Resident or Citizen to vouch for others members!',
-          style: Theme.of(context).textTheme.subtitle2,
+          style: Theme.of(context).textTheme.titleSmall,
           textAlign: TextAlign.center,
         ),
       ],

--- a/lib/screens/explore_screens/vouch/vouched_tab/components/vouch_success_dialog.dart
+++ b/lib/screens/explore_screens/vouch/vouched_tab/components/vouch_success_dialog.dart
@@ -12,7 +12,7 @@ class VouchSuccessDialog extends StatelessWidget {
       singleLargeButtonTitle: "Close",
       children: [
         const SizedBox(height: 10.0),
-        Text('Successfully Vouched!', style: Theme.of(context).textTheme.headline6),
+        Text('Successfully Vouched!', style: Theme.of(context).textTheme.titleLarge),
         const SizedBox(height: 10.0),
       ],
     );

--- a/lib/screens/profile_screens/citizenship/components/resident_view.dart
+++ b/lib/screens/profile_screens/citizenship/components/resident_view.dart
@@ -20,7 +20,8 @@ class ResidentView extends StatefulWidget {
   _ResidentViewState createState() => _ResidentViewState();
 }
 
-class _ResidentViewState extends State<ResidentView> with TickerProviderStateMixin {
+class _ResidentViewState extends State<ResidentView>
+    with TickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<double> _timeLineAnimation;
   late Animation<double> _reputationAnimation;
@@ -37,7 +38,8 @@ class _ResidentViewState extends State<ResidentView> with TickerProviderStateMix
 
   @override
   void initState() {
-    _controller = AnimationController(duration: const Duration(seconds: 1), vsync: this);
+    _controller =
+        AnimationController(duration: const Duration(seconds: 1), vsync: this);
     super.initState();
   }
 
@@ -51,33 +53,46 @@ class _ResidentViewState extends State<ResidentView> with TickerProviderStateMix
   Widget build(BuildContext context) {
     return BlocConsumer<CitizenshipBloc, CitizenshipState>(
       listenWhen: (previous, current) =>
-          previous.pageState != PageState.success && current.pageState == PageState.success,
+          previous.pageState != PageState.success &&
+          current.pageState == PageState.success,
       listener: (context, state) {
-        _timeLineAnimation = Tween<double>(begin: 0, end: state.progressTimeline).animate(_controller)
-          ..addListener(() {
-            setState(() => _timeLine = _timeLineAnimation.value.toInt());
-          });
-        _reputationAnimation = Tween<double>(begin: 0, end: state.reputationScore?.toDouble() ?? 0).animate(_controller)
+        _timeLineAnimation =
+            Tween<double>(begin: 0, end: state.progressTimeline)
+                .animate(_controller)
+              ..addListener(() {
+                setState(() => _timeLine = _timeLineAnimation.value.toInt());
+              });
+        _reputationAnimation = Tween<double>(
+                begin: 0, end: state.reputationScore?.toDouble() ?? 0)
+            .animate(_controller)
           ..addListener(() {
             setState(() => _reputation = _reputationAnimation.value.toInt());
           });
-        _citizenCeremonyAnimation = Tween<double>(begin: 0, end: state.citizenCeremony!.toDouble()).animate(_controller)
-          ..addListener(() {
-            setState(() => _citizenCeremony = _citizenCeremonyAnimation.value.toInt() * 100);
-          });
-        _ageAnimation = Tween<double>(begin: 0, end: state.profile!.accountAge.toDouble()).animate(_controller)
-          ..addListener(() {
-            setState(() => _age = _ageAnimation.value.toInt());
-          });
-        _seedsAnimation = Tween<double>(begin: 0, end: state.plantedSeeds).animate(_controller)
+        _citizenCeremonyAnimation =
+            Tween<double>(begin: 0, end: state.citizenCeremony!.toDouble())
+                .animate(_controller)
+              ..addListener(() {
+                setState(() => _citizenCeremony =
+                    _citizenCeremonyAnimation.value.toInt() * 100);
+              });
+        _ageAnimation =
+            Tween<double>(begin: 0, end: state.profile!.accountAge.toDouble())
+                .animate(_controller)
+              ..addListener(() {
+                setState(() => _age = _ageAnimation.value.toInt());
+              });
+        _seedsAnimation = Tween<double>(begin: 0, end: state.plantedSeeds)
+            .animate(_controller)
           ..addListener(() {
             setState(() => _seeds = _seedsAnimation.value.toInt());
           });
-        _transactionsAnimation =
-            Tween<double>(begin: 0, end: state.seedsTransactionsCount?.toDouble()).animate(_controller)
-              ..addListener(() {
-                setState(() => _transactions = _transactionsAnimation.value.toInt());
-              });
+        _transactionsAnimation = Tween<double>(
+                begin: 0, end: state.seedsTransactionsCount?.toDouble())
+            .animate(_controller)
+          ..addListener(() {
+            setState(
+                () => _transactions = _transactionsAnimation.value.toInt());
+          });
         _controller.forward();
       },
       builder: (context, state) {
@@ -106,22 +121,24 @@ class _ResidentViewState extends State<ResidentView> with TickerProviderStateMix
                         const SizedBox(height: 8.0),
                         Text(
                           state.profile!.nickname,
-                          style: Theme.of(context).textTheme.headline6,
+                          style: Theme.of(context).textTheme.titleLarge,
                         ),
                         const SizedBox(height: 8.0),
                         Text(
                           state.profile!.statusString.i18n,
-                          style: Theme.of(context).textTheme.headline7LowEmphasis,
+                          style:
+                              Theme.of(context).textTheme.headline7LowEmphasis,
                         ),
                       ],
                     ),
                   ],
                 ),
                 const SizedBox(height: 16.0),
-                Container(
+                DecoratedBox(
                   decoration: const BoxDecoration(
                     color: AppColors.lightGreen2,
-                    borderRadius: BorderRadius.all(Radius.circular(defaultCardBorderRadius)),
+                    borderRadius: BorderRadius.all(
+                        Radius.circular(defaultCardBorderRadius)),
                   ),
                   child: Padding(
                     padding: const EdgeInsets.all(16.0),
@@ -130,8 +147,12 @@ class _ResidentViewState extends State<ResidentView> with TickerProviderStateMix
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            Text('Progress Timeline'.i18n, style: Theme.of(context).textTheme.button),
-                            Text('$_timeLine%', style: Theme.of(context).textTheme.subtitle2LowEmphasis),
+                            Text('Progress Timeline'.i18n,
+                                style: Theme.of(context).textTheme.labelLarge),
+                            Text('$_timeLine%',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .subtitle2LowEmphasis),
                           ],
                         ),
                         const SizedBox(height: 16.0),
@@ -157,54 +178,61 @@ class _ResidentViewState extends State<ResidentView> with TickerProviderStateMix
                   childAspectRatio: 0.8,
                   children: <Widget>[
                     CircularProgressItem(
-                      icon: SvgPicture.asset('assets/images/citizenship/community.svg'),
+                      icon: SvgPicture.asset(
+                          'assets/images/citizenship/community.svg'),
                       totalStep: citizenRequiredCitizenVouched * 100,
                       currentStep: _citizenCeremony,
                       circleRadius: 30,
                       title: 'Citizen Ceremony'.i18n,
                       titleStyle: Theme.of(context).textTheme.subtitle3,
-                      rate: _citizenCeremony == citizenRequiredCitizenVouched ? 'Passed' : 'Waiting',
-                      rateStyle: Theme.of(context).textTheme.subtitle1!,
+                      rate: _citizenCeremony == citizenRequiredCitizenVouched
+                          ? 'Passed'
+                          : 'Waiting',
+                      rateStyle: Theme.of(context).textTheme.titleMedium!,
                     ),
                     CircularProgressItem(
-                      icon: SvgPicture.asset('assets/images/citizenship/reputation.svg'),
+                      icon: SvgPicture.asset(
+                          'assets/images/citizenship/reputation.svg'),
                       totalStep: citizenRequiredReputation,
                       currentStep: _reputation,
                       circleRadius: 30,
                       title: 'Reputation Score'.i18n,
                       titleStyle: Theme.of(context).textTheme.subtitle3,
                       rate: '$_reputation/$citizenRequiredReputation',
-                      rateStyle: Theme.of(context).textTheme.subtitle1!,
+                      rateStyle: Theme.of(context).textTheme.titleMedium!,
                     ),
                     CircularProgressItem(
-                      icon: SvgPicture.asset('assets/images/citizenship/age.svg'),
+                      icon:
+                          SvgPicture.asset('assets/images/citizenship/age.svg'),
                       totalStep: citizenRequiredAccountAge,
                       currentStep: _age,
                       circleRadius: 30,
                       title: 'Account Age'.i18n,
                       titleStyle: Theme.of(context).textTheme.subtitle3,
                       rate: '$_age/$citizenRequiredAccountAge',
-                      rateStyle: Theme.of(context).textTheme.subtitle1!,
+                      rateStyle: Theme.of(context).textTheme.titleMedium!,
                     ),
                     CircularProgressItem(
-                      icon: SvgPicture.asset('assets/images/citizenship/planted.svg'),
+                      icon: SvgPicture.asset(
+                          'assets/images/citizenship/planted.svg'),
                       totalStep: citizenRequiredPlantedSeeds,
                       currentStep: _seeds,
                       circleRadius: 30,
                       title: 'Planted Seeds'.i18n,
                       titleStyle: Theme.of(context).textTheme.subtitle3,
                       rate: '$_seeds/$citizenRequiredPlantedSeeds',
-                      rateStyle: Theme.of(context).textTheme.subtitle1!,
+                      rateStyle: Theme.of(context).textTheme.titleMedium!,
                     ),
                     CircularProgressItem(
-                      icon: SvgPicture.asset('assets/images/citizenship/transaction.svg'),
+                      icon: SvgPicture.asset(
+                          'assets/images/citizenship/transaction.svg'),
                       totalStep: citizenRequiredSeedsTransactions,
                       currentStep: _transactions,
                       circleRadius: 30,
                       title: 'Transactions with Seeds'.i18n,
                       titleStyle: Theme.of(context).textTheme.subtitle3,
                       rate: '$_transactions/$citizenRequiredSeedsTransactions',
-                      rateStyle: Theme.of(context).textTheme.subtitle1!,
+                      rateStyle: Theme.of(context).textTheme.titleMedium!,
                     ),
                   ],
                 ),

--- a/lib/screens/profile_screens/citizenship/components/visitor_view.dart
+++ b/lib/screens/profile_screens/citizenship/components/visitor_view.dart
@@ -100,7 +100,7 @@ class _VisitorViewState extends State<VisitorView> with TickerProviderStateMixin
                         const SizedBox(height: 8.0),
                         Text(
                           state.profile!.nickname,
-                          style: Theme.of(context).textTheme.headline6,
+                          style: Theme.of(context).textTheme.titleLarge,
                         ),
                         const SizedBox(height: 8.0),
                         Text(
@@ -112,7 +112,7 @@ class _VisitorViewState extends State<VisitorView> with TickerProviderStateMixin
                   ],
                 ),
                 const SizedBox(height: 16.0),
-                Container(
+                DecoratedBox(
                   decoration: const BoxDecoration(
                     color: AppColors.lightGreen2,
                     borderRadius: BorderRadius.all(Radius.circular(defaultCardBorderRadius)),
@@ -124,7 +124,7 @@ class _VisitorViewState extends State<VisitorView> with TickerProviderStateMixin
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            Text('Progress Timeline'.i18n, style: Theme.of(context).textTheme.button),
+                            Text('Progress Timeline'.i18n, style: Theme.of(context).textTheme.labelLarge),
                             Text('$_timeLine%', style: Theme.of(context).textTheme.subtitle2LowEmphasis),
                           ],
                         ),
@@ -158,7 +158,7 @@ class _VisitorViewState extends State<VisitorView> with TickerProviderStateMixin
                       title: 'Reputation Points'.i18n,
                       titleStyle: Theme.of(context).textTheme.subtitle3,
                       rate: '$_reputation/$residentRequiredReputation',
-                      rateStyle: Theme.of(context).textTheme.subtitle1!,
+                      rateStyle: Theme.of(context).textTheme.titleMedium!,
                     ),
                     CircularProgressItem(
                       icon: SvgPicture.asset('assets/images/citizenship/community.svg'),
@@ -168,7 +168,7 @@ class _VisitorViewState extends State<VisitorView> with TickerProviderStateMixin
                       title: 'Visitors Invited'.i18n,
                       titleStyle: Theme.of(context).textTheme.subtitle3,
                       rate: '${_visitors ~/ 100}/$residentRequiredVisitorsInvited',
-                      rateStyle: Theme.of(context).textTheme.subtitle1!,
+                      rateStyle: Theme.of(context).textTheme.titleMedium!,
                     ),
                     CircularProgressItem(
                       icon: SvgPicture.asset('assets/images/citizenship/planted.svg'),
@@ -178,7 +178,7 @@ class _VisitorViewState extends State<VisitorView> with TickerProviderStateMixin
                       title: 'Planted Seeds'.i18n,
                       titleStyle: Theme.of(context).textTheme.subtitle3,
                       rate: '$_seeds/$residentRequiredPlantedSeeds',
-                      rateStyle: Theme.of(context).textTheme.subtitle1!,
+                      rateStyle: Theme.of(context).textTheme.titleMedium!,
                     ),
                     CircularProgressItem(
                       icon: SvgPicture.asset('assets/images/citizenship/transaction.svg'),
@@ -188,7 +188,7 @@ class _VisitorViewState extends State<VisitorView> with TickerProviderStateMixin
                       title: 'Transactions with Seeds'.i18n,
                       titleStyle: Theme.of(context).textTheme.subtitle3,
                       rate: '$_transactions/$residentRequiredSeedsTransactions',
-                      rateStyle: Theme.of(context).textTheme.subtitle1!,
+                      rateStyle: Theme.of(context).textTheme.titleMedium!,
                     ),
                   ],
                 ),

--- a/lib/screens/profile_screens/citizenship/interactor/usecases/get_referred_accounts_use_case.dart
+++ b/lib/screens/profile_screens/citizenship/interactor/usecases/get_referred_accounts_use_case.dart
@@ -13,7 +13,7 @@ class GetReferredAccountsUseCase {
     } else {
       final ReferredAccounts referredAccounts = result.asValue!.value;
       //This is an expensive approach we need change it
-      return Future.wait([for (var i in referredAccounts.accounts) _profileRepository.getProfile(i)]);
+      return Future.wait([for (final i in referredAccounts.accounts) _profileRepository.getProfile(i)]);
     }
   }
 }

--- a/lib/screens/profile_screens/contribution/contribution_detail/components/contribution_detail_subtitle.dart
+++ b/lib/screens/profile_screens/contribution/contribution_detail/components/contribution_detail_subtitle.dart
@@ -13,7 +13,7 @@ class ContributionDetailSubtitle extends StatelessWidget {
       margin: const EdgeInsets.symmetric(horizontal: horizontalEdgePadding),
       padding: const EdgeInsets.all(horizontalEdgePadding),
       decoration: BoxDecoration(color: AppColors.darkGreen2, borderRadius: BorderRadius.circular(8.0)),
-      child: Text(title, textAlign: TextAlign.center, style: Theme.of(context).textTheme.button),
+      child: Text(title, textAlign: TextAlign.center, style: Theme.of(context).textTheme.labelLarge),
     );
   }
 }

--- a/lib/screens/profile_screens/contribution/contribution_detail/contribution_detail_screen.dart
+++ b/lib/screens/profile_screens/contribution/contribution_detail/contribution_detail_screen.dart
@@ -58,7 +58,7 @@ class ContributionDetailScreen extends StatelessWidget {
                     Text(scoreDetails.scoreType,
                         textAlign: TextAlign.center, maxLines: 2, style: Theme.of(context).textTheme.headline7),
                     const SizedBox(height: 8.0),
-                    Text(scoreDetails.score.toString(), style: Theme.of(context).textTheme.headline3),
+                    Text(scoreDetails.score.toString(), style: Theme.of(context).textTheme.displaySmall),
                   ],
                 ),
               ),

--- a/lib/screens/profile_screens/contribution/contribution_screen.dart
+++ b/lib/screens/profile_screens/contribution/contribution_screen.dart
@@ -133,7 +133,7 @@ class _ContributionScreenState extends State<ContributionScreen> with TickerProv
                                         maxLines: 2,
                                         style: Theme.of(context).textTheme.headline7),
                                     const SizedBox(height: 8.0),
-                                    Text('$_contribution/99', style: Theme.of(context).textTheme.headline3),
+                                    Text('$_contribution/99', style: Theme.of(context).textTheme.displaySmall),
                                   ],
                                 ),
                               ),
@@ -157,7 +157,7 @@ class _ContributionScreenState extends State<ContributionScreen> with TickerProv
                             title: 'Community'.i18n,
                             titleStyle: Theme.of(context).textTheme.buttonLowEmphasis,
                             rate: '$_community',
-                            rateStyle: Theme.of(context).textTheme.headline4!,
+                            rateStyle: Theme.of(context).textTheme.headlineMedium!,
                             onPressed: () => BlocProvider.of<ContributionBloc>(context)
                                 .add(const ShowScoreDetails(ScoreType.communityScore)),
                           ),
@@ -169,7 +169,7 @@ class _ContributionScreenState extends State<ContributionScreen> with TickerProv
                             title: 'Reputation'.i18n,
                             titleStyle: Theme.of(context).textTheme.buttonLowEmphasis,
                             rate: '$_reputation',
-                            rateStyle: Theme.of(context).textTheme.headline4!,
+                            rateStyle: Theme.of(context).textTheme.headlineMedium!,
                             onPressed: () => BlocProvider.of<ContributionBloc>(context)
                                 .add(const ShowScoreDetails(ScoreType.reputationScore)),
                           ),
@@ -181,7 +181,7 @@ class _ContributionScreenState extends State<ContributionScreen> with TickerProv
                             title: 'Planted'.i18n,
                             titleStyle: Theme.of(context).textTheme.buttonLowEmphasis,
                             rate: '$_seeds',
-                            rateStyle: Theme.of(context).textTheme.headline4!,
+                            rateStyle: Theme.of(context).textTheme.headlineMedium!,
                             onPressed: () => BlocProvider.of<ContributionBloc>(context)
                                 .add(const ShowScoreDetails(ScoreType.plantedScore)),
                           ),
@@ -193,7 +193,7 @@ class _ContributionScreenState extends State<ContributionScreen> with TickerProv
                             title: 'Transactions'.i18n,
                             titleStyle: Theme.of(context).textTheme.buttonLowEmphasis,
                             rate: '$_transactions',
-                            rateStyle: Theme.of(context).textTheme.headline4!,
+                            rateStyle: Theme.of(context).textTheme.headlineMedium!,
                             onPressed: () => BlocProvider.of<ContributionBloc>(context)
                                 .add(const ShowScoreDetails(ScoreType.transactionScore)),
                           ),

--- a/lib/screens/profile_screens/edit_name/edit_name_screen.dart
+++ b/lib/screens/profile_screens/edit_name/edit_name_screen.dart
@@ -17,12 +17,12 @@ class EditNameScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final _profileModel = ModalRoute.of(context)!.settings.arguments as ProfileModel?;
-    assert(_profileModel != null);
+    final profileModel = ModalRoute.of(context)!.settings.arguments as ProfileModel?;
+    assert(profileModel != null);
     return Scaffold(
       appBar: AppBar(title: Text(context.loc.editNameTitle)),
       body: BlocProvider(
-        create: (_) => EditNameBloc(_profileModel!),
+        create: (_) => EditNameBloc(profileModel!),
         child: BlocConsumer<EditNameBloc, EditNameState>(
           listenWhen: (_, current) => current.pageCommand != null,
           listener: (context, state) {

--- a/lib/screens/profile_screens/guardians/guardians_tabs/components/guardian_dialog_single_action.dart
+++ b/lib/screens/profile_screens/guardians/guardians_tabs/components/guardian_dialog_single_action.dart
@@ -38,7 +38,7 @@ class GuardianDialogSingleAction extends StatelessWidget {
             Text(
               title,
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.headline6,
+              style: Theme.of(context).textTheme.titleLarge,
             ),
             const SizedBox(height: 30),
             Padding(

--- a/lib/screens/profile_screens/guardians/guardians_tabs/components/guardian_row_widget.dart
+++ b/lib/screens/profile_screens/guardians/guardians_tabs/components/guardian_row_widget.dart
@@ -24,7 +24,7 @@ class GuardianRowWidget extends StatelessWidget {
       ),
       title: Text(
         (!guardianModel.nickname.isNullOrEmpty) ? guardianModel.nickname! : guardianModel.uid,
-        style: Theme.of(context).textTheme.button,
+        style: Theme.of(context).textTheme.labelLarge,
       ),
       subtitle: Text(guardianModel.uid, style: Theme.of(context).textTheme.subtitle2OpacityEmphasis),
       onTap: () {

--- a/lib/screens/profile_screens/guardians/guardians_tabs/components/my_guardians_tab.dart
+++ b/lib/screens/profile_screens/guardians/guardians_tabs/components/my_guardians_tab.dart
@@ -45,9 +45,9 @@ class MyGuardiansTab extends StatelessWidget {
                           onPressed: () {
                             BlocProvider.of<GuardiansBloc>(context).add(OnGuardianReadyForActivation(myGuardians));
                           },
-                          child: Row(
+                          child: const Row(
                             mainAxisSize: MainAxisSize.min,
-                            children: [const Text("Activate "), const Icon(Icons.shield), const Text(" Guardians")],
+                            children: [Text("Activate "), Icon(Icons.shield), Text(" Guardians")],
                           ),
                         ),
                       ));

--- a/lib/screens/profile_screens/guardians/guardians_tabs/components/remove_guardian_confirmation_dialog.dart
+++ b/lib/screens/profile_screens/guardians/guardians_tabs/components/remove_guardian_confirmation_dialog.dart
@@ -37,7 +37,7 @@ class RemoveGuardianConfirmationDialog extends StatelessWidget {
       onLeftButtonPressed: onDismiss,
       children: [
         const SizedBox(height: 20),
-        Text("Remove Guardian?".i18n, style: Theme.of(context).textTheme.headline6),
+        Text("Remove Guardian?".i18n, style: Theme.of(context).textTheme.titleLarge),
         const SizedBox(height: 30),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 30),
@@ -45,10 +45,10 @@ class RemoveGuardianConfirmationDialog extends StatelessWidget {
             textAlign: TextAlign.center,
             text: TextSpan(
                 text: 'Are you sure you want to remove '.i18n,
-                style: Theme.of(context).textTheme.subtitle2,
+                style: Theme.of(context).textTheme.titleSmall,
                 children: <TextSpan>[
-                  TextSpan(text: guardian.nickname, style: Theme.of(context).textTheme.subtitle2),
-                  TextSpan(text: ' as your Guardian?'.i18n, style: Theme.of(context).textTheme.subtitle2)
+                  TextSpan(text: guardian.nickname, style: Theme.of(context).textTheme.titleSmall),
+                  TextSpan(text: ' as your Guardian?'.i18n, style: Theme.of(context).textTheme.titleSmall)
                 ]),
           ),
         ),

--- a/lib/screens/profile_screens/guardians/guardians_tabs/guardians_screen.dart
+++ b/lib/screens/profile_screens/guardians/guardians_tabs/guardians_screen.dart
@@ -115,9 +115,9 @@ void _showRecoveryStartedBottomSheet(BuildContext context, GuardianModel guardia
                 child: RichText(
                   text: TextSpan(
                       text: 'A motion to Recover your Key has been initiated by '.i18n,
-                      style: Theme.of(context).textTheme.button,
+                      style: Theme.of(context).textTheme.labelLarge,
                       children: <TextSpan>[
-                        TextSpan(text: guardian.nickname, style: Theme.of(context).textTheme.button)
+                        TextSpan(text: guardian.nickname, style: Theme.of(context).textTheme.labelLarge)
                       ]),
                 ),
               ),

--- a/lib/screens/profile_screens/guardians/invite_guardians_sent/invite_guardians_sent_screen.dart
+++ b/lib/screens/profile_screens/guardians/invite_guardians_sent/invite_guardians_sent_screen.dart
@@ -27,7 +27,7 @@ class InviteGuardiansSentScreen extends StatelessWidget {
                 padding: const EdgeInsets.all(24.0),
                 child: Text(
                   "Invites Sent!".i18n,
-                  style: Theme.of(context).textTheme.headline4,
+                  style: Theme.of(context).textTheme.headlineMedium,
                   textAlign: TextAlign.center,
                 ),
               ),

--- a/lib/screens/profile_screens/profile/components/citizenship_card.dart
+++ b/lib/screens/profile_screens/profile/components/citizenship_card.dart
@@ -26,7 +26,7 @@ class CitizenshipCard extends StatelessWidget {
             case PageState.loading:
               return const ShimmerRectangle(size: Size(328, 145), radius: defaultCardBorderRadius);
             case PageState.success:
-              return Container(
+              return DecoratedBox(
                 decoration: const BoxDecoration(
                   color: AppColors.lightGreen2,
                   borderRadius: BorderRadius.all(Radius.circular(defaultCardBorderRadius)),
@@ -64,7 +64,7 @@ class CitizenshipCard extends StatelessWidget {
                                   children: [
                                     Text(
                                       'You are on the way from'.i18n,
-                                      style: Theme.of(context).textTheme.subtitle2,
+                                      style: Theme.of(context).textTheme.titleSmall,
                                     ),
                                   ],
                                 ),

--- a/lib/screens/profile_screens/profile/components/citizenship_upgrade_success_dialog.dart
+++ b/lib/screens/profile_screens/profile/components/citizenship_upgrade_success_dialog.dart
@@ -28,7 +28,7 @@ class CitizenshipUpgradeSuccessDialog extends StatelessWidget {
                     text: TextSpan(
                         text: 'You have have fulfilled all the requirements and are now officially upgraded to be a '
                             .i18n,
-                        style: Theme.of(context).textTheme.subtitle2,
+                        style: Theme.of(context).textTheme.titleSmall,
                         children: <TextSpan>[
                           TextSpan(
                             text: "Citizen".i18n,
@@ -38,7 +38,7 @@ class CitizenshipUpgradeSuccessDialog extends StatelessWidget {
                             text:
                                 ' You now have the ability to vote on proposals! Go to the Explore section to see more.'
                                     .i18n,
-                            style: Theme.of(context).textTheme.subtitle2,
+                            style: Theme.of(context).textTheme.titleSmall,
                           )
                         ]),
                     textAlign: TextAlign.center,
@@ -51,7 +51,7 @@ class CitizenshipUpgradeSuccessDialog extends StatelessWidget {
                     text: TextSpan(
                         text: 'You have have fulfilled all the requirements and are now officially upgraded to be a '
                             .i18n,
-                        style: Theme.of(context).textTheme.subtitle2,
+                        style: Theme.of(context).textTheme.titleSmall,
                         children: <TextSpan>[
                           TextSpan(
                             text: "Resident",
@@ -59,7 +59,7 @@ class CitizenshipUpgradeSuccessDialog extends StatelessWidget {
                           ),
                           TextSpan(
                             text: 'Just one more level until you are a full-fledged Citizen.!'.i18n,
-                            style: Theme.of(context).textTheme.subtitle2,
+                            style: Theme.of(context).textTheme.titleSmall,
                           )
                         ]),
                     textAlign: TextAlign.center,

--- a/lib/screens/profile_screens/profile/components/logout_dialog.dart
+++ b/lib/screens/profile_screens/profile/components/logout_dialog.dart
@@ -28,7 +28,7 @@ class LogoutDialog extends StatelessWidget {
                   Text(
                     'Save private key in secure place - to be able to restore access to your wallet later'.i18n,
                     textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.subtitle2,
+                    style: Theme.of(context).textTheme.titleSmall,
                   ),
                   const SizedBox(height: 36.0),
                   FlatButtonLong(

--- a/lib/screens/profile_screens/profile/components/logout_recovery_phrase_dialog.dart
+++ b/lib/screens/profile_screens/profile/components/logout_recovery_phrase_dialog.dart
@@ -29,7 +29,7 @@ class LogoutRecoveryPhraseDialog extends StatelessWidget {
                     'Save private Recovery Phrase in secure place - to be able to restore access to your wallet later'
                         .i18n,
                     textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.subtitle2,
+                    style: Theme.of(context).textTheme.titleSmall,
                   ),
                   const SizedBox(height: 36.0),
                   FlatButtonLong(

--- a/lib/screens/profile_screens/profile/components/profile_list_tile.dart
+++ b/lib/screens/profile_screens/profile/components/profile_list_tile.dart
@@ -22,7 +22,7 @@ class ProfileListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Text titleText = Text(title, style: Theme.of(context).textTheme.button);
+    final Text titleText = Text(title, style: Theme.of(context).textTheme.labelLarge);
     final Text trailingText = Text(trailing, style: Theme.of(context).textTheme.headline7LowEmphasis);
     return SizedBox(
       height: 60,

--- a/lib/screens/profile_screens/recovery_phrase/recovery_phrase_screen.dart
+++ b/lib/screens/profile_screens/recovery_phrase/recovery_phrase_screen.dart
@@ -35,7 +35,7 @@ class RecoveryPhraseScreen extends StatelessWidget {
                     children: [
                       RichText(
                         text: TextSpan(
-                          style: Theme.of(context).textTheme.subtitle2,
+                          style: Theme.of(context).textTheme.titleSmall,
                           children: <TextSpan>[
                             const TextSpan(text: 'Get a pen and paper before you start. \nWrite down or '),
                             TextSpan(

--- a/lib/screens/profile_screens/security/components/biometric_enabled_dialog.dart
+++ b/lib/screens/profile_screens/security/components/biometric_enabled_dialog.dart
@@ -18,7 +18,7 @@ class BiometricEnabledDialog extends StatelessWidget {
         Text(
           context.loc.securityBiometricEnabledDescription,
           textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.subtitle2,
+          style: Theme.of(context).textTheme.titleSmall,
         ),
         const SizedBox(height: 16.0),
       ],

--- a/lib/screens/profile_screens/security/components/guardian_security_card.dart
+++ b/lib/screens/profile_screens/security/components/guardian_security_card.dart
@@ -73,7 +73,7 @@ class GuardianSecurityCard extends StatelessWidget {
                                   Flexible(
                                     child: Text(
                                       context.loc.securityGuardiansHeader,
-                                      style: Theme.of(context).textTheme.button,
+                                      style: Theme.of(context).textTheme.labelLarge,
                                     ),
                                   ),
                                   const SizedBox(width: 10),

--- a/lib/screens/profile_screens/security/components/security_card.dart
+++ b/lib/screens/profile_screens/security/components/security_card.dart
@@ -72,7 +72,7 @@ class SecurityCard extends StatelessWidget {
                                   Flexible(
                                     child: Text(
                                       title,
-                                      style: Theme.of(context).textTheme.button,
+                                      style: Theme.of(context).textTheme.labelLarge,
                                     ),
                                   ),
                                   const SizedBox(width: 10),

--- a/lib/screens/profile_screens/set_currency/set_currency_screen.dart
+++ b/lib/screens/profile_screens/set_currency/set_currency_screen.dart
@@ -65,10 +65,10 @@ class _SetCurrencyScreenState extends State<SetCurrencyScreen> {
                           itemBuilder: (_, index) => ListTile(
                             key: Key(state.queryCurrenciesResults![index].code),
                             leading: Text(state.queryCurrenciesResults![index].flagEmoji,
-                                style: Theme.of(context).textTheme.headline4),
+                                style: Theme.of(context).textTheme.headlineMedium),
                             title: Text(
                               state.queryCurrenciesResults![index].code,
-                              style: Theme.of(context).textTheme.button,
+                              style: Theme.of(context).textTheme.labelLarge,
                             ),
                             subtitle: Text(state.queryCurrenciesResults![index].name,
                                 style: Theme.of(context).textTheme.subtitle4),

--- a/lib/screens/transfer/receive/receive_detail_qr_code/components/receive_paid_success_dialog.dart
+++ b/lib/screens/transfer/receive/receive_detail_qr_code/components/receive_paid_success_dialog.dart
@@ -35,21 +35,21 @@ class ReceivePaidSuccessDialog extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Text(context.loc.transferReceivePaidSuccessHeader, style: Theme.of(context).textTheme.headline6)
+                Text(context.loc.transferReceivePaidSuccessHeader, style: Theme.of(context).textTheme.titleLarge)
               ],
             ),
             const SizedBox(height: 20),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Text(args.transaction.doubleQuantity.seedsFormatted, style: Theme.of(context).textTheme.headline4),
+                Text(args.transaction.doubleQuantity.seedsFormatted, style: Theme.of(context).textTheme.headlineMedium),
                 Padding(
                   padding: const EdgeInsets.only(top: 14, left: 4),
-                  child: Text(args.transaction.symbol, style: Theme.of(context).textTheme.subtitle2),
+                  child: Text(args.transaction.symbol, style: Theme.of(context).textTheme.titleSmall),
                 ),
               ],
             ),
-            Text(args.fiatData?.asFormattedString() ?? '', style: Theme.of(context).textTheme.subtitle2),
+            Text(args.fiatData?.asFormattedString() ?? '', style: Theme.of(context).textTheme.titleSmall),
             const SizedBox(height: 30.0),
             Row(
               children: [
@@ -65,20 +65,20 @@ class ReceivePaidSuccessDialog extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(args.from.nickname, textAlign: TextAlign.start, style: Theme.of(context).textTheme.button),
+                        Text(args.from.nickname, textAlign: TextAlign.start, style: Theme.of(context).textTheme.labelLarge),
                         const SizedBox(height: 8),
                         Text(args.transaction.from, style: Theme.of(context).textTheme.subtitle2LowEmphasis)
                       ],
                     ),
                   ),
                 ),
-                Container(
+                DecoratedBox(
                   decoration: const BoxDecoration(
                       borderRadius: BorderRadius.all(Radius.elliptical(4, 4)), color: AppColors.lightGreen6),
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
                     child:
-                        Text(context.loc.transferReceivePaidSuccessFrom, style: Theme.of(context).textTheme.subtitle2),
+                        Text(context.loc.transferReceivePaidSuccessFrom, style: Theme.of(context).textTheme.titleSmall),
                   ),
                 ),
               ],
@@ -86,20 +86,20 @@ class ReceivePaidSuccessDialog extends StatelessWidget {
             const SizedBox(height: 30.0),
             Row(
               children: [
-                Text(context.loc.transferReceivePaidSuccessDate, style: Theme.of(context).textTheme.subtitle2),
+                Text(context.loc.transferReceivePaidSuccessDate, style: Theme.of(context).textTheme.titleSmall),
                 const SizedBox(width: 16),
                 Text(
                   DateFormat('dd MMMM yyyy').format(DateTime.now()),
-                  style: Theme.of(context).textTheme.subtitle2,
+                  style: Theme.of(context).textTheme.titleSmall,
                 ),
               ],
             ),
             const SizedBox(height: 20.0),
             Row(
               children: [
-                Text(context.loc.transferReceivePaidSuccessStatus, style: Theme.of(context).textTheme.subtitle2),
+                Text(context.loc.transferReceivePaidSuccessStatus, style: Theme.of(context).textTheme.titleSmall),
                 const SizedBox(width: 16),
-                Container(
+                DecoratedBox(
                   decoration: const BoxDecoration(
                       borderRadius: BorderRadius.all(Radius.circular(20)), color: AppColors.lightGreen6),
                   child: Padding(
@@ -107,7 +107,7 @@ class ReceivePaidSuccessDialog extends StatelessWidget {
                     child: Text(
                       context.loc.transferReceivePaidSuccessButtonTitle,
                       overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.subtitle2,
+                      style: Theme.of(context).textTheme.titleSmall,
                     ),
                   ),
                 ),

--- a/lib/screens/transfer/receive/receive_detail_qr_code/receive_detail_qr_code.dart
+++ b/lib/screens/transfer/receive/receive_detail_qr_code/receive_detail_qr_code.dart
@@ -74,7 +74,7 @@ class ReceiveDetailQrCodeScreen extends StatelessWidget {
                               ),
                             ),
                           const SizedBox(height: 40),
-                          Text(context.loc.transferReceiveWaiting, style: Theme.of(context).textTheme.headline6),
+                          Text(context.loc.transferReceiveWaiting, style: Theme.of(context).textTheme.titleLarge),
                           Padding(
                             padding: const EdgeInsets.fromLTRB(60.0, 40, 60.0, 0),
                             child: FlatButtonLong(

--- a/lib/screens/transfer/receive/receive_enter_data/interactor/usecases/receive_seeds_invoice_use_case.dart
+++ b/lib/screens/transfer/receive/receive_enter_data/interactor/usecases/receive_seeds_invoice_use_case.dart
@@ -1,15 +1,16 @@
 import 'package:seeds/datasource/local/models/token_data_model.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/datasource/remote/api/invoice_repository.dart';
-import 'package:seeds/datasource/remote/model/token_model.dart';
 import 'package:seeds/domain-shared/app_constants.dart';
 import 'package:seeds/domain-shared/base_use_case.dart';
 import 'package:seeds/domain-shared/shared_use_cases/cerate_firebase_dynamic_link_use_case.dart';
 import 'package:seeds/utils/result_extension.dart';
 
-class ReceiveSeedsInvoiceUseCase extends InputUseCase<ReceiveInvoiceResponse, _Input> {
+class ReceiveSeedsInvoiceUseCase
+    extends InputUseCase<ReceiveInvoiceResponse, _Input> {
   final InvoiceRepository _invoiceRepository = InvoiceRepository();
-  final CreateFirebaseDynamicLinkUseCase _firebaseDynamicLinkUseCase = CreateFirebaseDynamicLinkUseCase();
+  final CreateFirebaseDynamicLinkUseCase _firebaseDynamicLinkUseCase =
+      CreateFirebaseDynamicLinkUseCase();
 
   static _Input input({required TokenDataModel tokenAmount, String? memo}) =>
       _Input(tokenAmount: tokenAmount, memo: memo);
@@ -26,10 +27,11 @@ class ReceiveSeedsInvoiceUseCase extends InputUseCase<ReceiveInvoiceResponse, _I
     if (invoice.isError) {
       return Result.error(invoice.asError!.error);
     } else {
-      final Result<Uri> decodedInvoice =
-          await _firebaseDynamicLinkUseCase.createDynamicLink(invoiceTargetLink, invoice.valueOrCrash);
+      final Result<Uri> decodedInvoice = await _firebaseDynamicLinkUseCase
+          .createDynamicLink(invoiceTargetLink, invoice.valueOrCrash);
 
-      return Result.value(ReceiveInvoiceResponse(invoice.valueOrCrash, decodedInvoice.valueOrNull));
+      return Result.value(ReceiveInvoiceResponse(
+          invoice.valueOrCrash, decodedInvoice.valueOrNull));
     }
   }
 }

--- a/lib/screens/transfer/receive/receive_selection/components/receive_selection_card.dart
+++ b/lib/screens/transfer/receive/receive_selection/components/receive_selection_card.dart
@@ -33,7 +33,7 @@ class ReceiveSelectionCard extends StatelessWidget {
             ),
             Text(
               title,
-              style: Theme.of(context).textTheme.button,
+              style: Theme.of(context).textTheme.labelLarge,
               textAlign: TextAlign.center,
             ),
           ],

--- a/lib/screens/transfer/send/send_confirmation/components/generic_transaction_success_dialog.dart
+++ b/lib/screens/transfer/send/send_confirmation/components/generic_transaction_success_dialog.dart
@@ -31,29 +31,29 @@ class GenericTransactionSuccessDialog extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Text(context.loc.transferTransactionSuccessHeader, style: Theme.of(context).textTheme.headline4)
+                Text(context.loc.transferTransactionSuccessHeader, style: Theme.of(context).textTheme.headlineMedium)
               ],
             ),
             const SizedBox(height: 30.0),
             Row(
               children: [
-                Text(context.loc.transferTransactionSuccessDate, style: Theme.of(context).textTheme.subtitle2),
+                Text(context.loc.transferTransactionSuccessDate, style: Theme.of(context).textTheme.titleSmall),
                 const SizedBox(width: 16),
                 Text(
                   DateFormat('dd MMMM yyyy HH:mm').format(transactionModel.timestamp?.toLocal() ?? DateTime.now()),
-                  style: Theme.of(context).textTheme.subtitle2,
+                  style: Theme.of(context).textTheme.titleSmall,
                 ),
               ],
             ),
             Row(
               children: [
-                Text(context.loc.transferTransactionSuccessID, style: Theme.of(context).textTheme.subtitle2),
+                Text(context.loc.transferTransactionSuccessID, style: Theme.of(context).textTheme.titleSmall),
                 const SizedBox(width: 16),
                 Expanded(
                   child: Text(
                     transactionModel.transactionId ?? "",
                     overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context).textTheme.subtitle2,
+                    style: Theme.of(context).textTheme.titleSmall,
                   ),
                 ),
                 IconButton(
@@ -69,9 +69,9 @@ class GenericTransactionSuccessDialog extends StatelessWidget {
             ),
             Row(
               children: [
-                Text(context.loc.transferTransactionSuccessStatus, style: Theme.of(context).textTheme.subtitle2),
+                Text(context.loc.transferTransactionSuccessStatus, style: Theme.of(context).textTheme.titleSmall),
                 const SizedBox(width: 16),
-                Container(
+                DecoratedBox(
                   decoration: const BoxDecoration(
                       borderRadius: BorderRadius.all(Radius.circular(20)), color: AppColors.lightGreen6),
                   child: Padding(
@@ -79,7 +79,7 @@ class GenericTransactionSuccessDialog extends StatelessWidget {
                     child: Text(
                       context.loc.transferTransactionSuccessSuccessful,
                       overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.subtitle2,
+                      style: Theme.of(context).textTheme.titleSmall,
                     ),
                   ),
                 ),

--- a/lib/screens/transfer/send/send_confirmation/components/send_transaction_success_dialog.dart
+++ b/lib/screens/transfer/send/send_confirmation/components/send_transaction_success_dialog.dart
@@ -70,14 +70,14 @@ class SendTransactionSuccessDialog extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Text(amount, style: Theme.of(context).textTheme.headline4),
+                Text(amount, style: Theme.of(context).textTheme.headlineMedium),
                 Padding(
                   padding: const EdgeInsets.only(top: 14, left: 4),
-                  child: Text(tokenSymbol, style: Theme.of(context).textTheme.subtitle2),
+                  child: Text(tokenSymbol, style: Theme.of(context).textTheme.titleSmall),
                 ),
               ],
             ),
-            Text(fiatAmount?.asFormattedString() ?? "", style: Theme.of(context).textTheme.subtitle2),
+            Text(fiatAmount?.asFormattedString() ?? "", style: Theme.of(context).textTheme.titleSmall),
             const SizedBox(height: 30.0),
             DialogRow(
                 imageUrl: toImage,
@@ -93,23 +93,23 @@ class SendTransactionSuccessDialog extends StatelessWidget {
             const SizedBox(height: 30.0),
             Row(
               children: [
-                Text(context.loc.transferTransactionSuccessDate, style: Theme.of(context).textTheme.subtitle2),
+                Text(context.loc.transferTransactionSuccessDate, style: Theme.of(context).textTheme.titleSmall),
                 const SizedBox(width: 16),
                 Text(
                   DateFormat('dd MMMM yyyy').format(DateTime.now()),
-                  style: Theme.of(context).textTheme.subtitle2,
+                  style: Theme.of(context).textTheme.titleSmall,
                 ),
               ],
             ),
             Row(
               children: [
-                Text(context.loc.transferTransactionSuccessID, style: Theme.of(context).textTheme.subtitle2),
+                Text(context.loc.transferTransactionSuccessID, style: Theme.of(context).textTheme.titleSmall),
                 const SizedBox(width: 16),
                 Expanded(
                   child: Text(
                     transactionID,
                     overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context).textTheme.subtitle2,
+                    style: Theme.of(context).textTheme.titleSmall,
                   ),
                 ),
                 IconButton(
@@ -124,9 +124,9 @@ class SendTransactionSuccessDialog extends StatelessWidget {
             ),
             Row(
               children: [
-                Text(context.loc.transferTransactionSuccessStatus, style: Theme.of(context).textTheme.subtitle2),
+                Text(context.loc.transferTransactionSuccessStatus, style: Theme.of(context).textTheme.titleSmall),
                 const SizedBox(width: 16),
-                Container(
+                DecoratedBox(
                   decoration: const BoxDecoration(
                       borderRadius: BorderRadius.all(Radius.circular(20)), color: AppColors.lightGreen6),
                   child: Padding(
@@ -134,7 +134,7 @@ class SendTransactionSuccessDialog extends StatelessWidget {
                     child: Text(
                       context.loc.transferTransactionSuccessSuccessful,
                       overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.subtitle2,
+                      style: Theme.of(context).textTheme.titleSmall,
                     ),
                   ),
                 ),
@@ -166,19 +166,19 @@ class DialogRow extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(name ?? account, textAlign: TextAlign.start, style: Theme.of(context).textTheme.button),
+                Text(name ?? account, textAlign: TextAlign.start, style: Theme.of(context).textTheme.labelLarge),
                 const SizedBox(height: 8),
                 Text(account, style: Theme.of(context).textTheme.subtitle2LowEmphasis)
               ],
             ),
           ),
         ),
-        Container(
+        DecoratedBox(
           decoration: const BoxDecoration(
               borderRadius: BorderRadius.all(Radius.elliptical(4, 4)), color: AppColors.lightGreen6),
           child: Padding(
             padding: const EdgeInsets.only(top: 4, bottom: 4, right: 8, left: 8),
-            child: Text(toOrFromText!, style: Theme.of(context).textTheme.subtitle2),
+            child: Text(toOrFromText!, style: Theme.of(context).textTheme.titleSmall),
           ),
         ),
       ],

--- a/lib/screens/transfer/send/send_confirmation/components/transaction_action_card.dart
+++ b/lib/screens/transfer/send/send_confirmation/components/transaction_action_card.dart
@@ -13,7 +13,7 @@ class TransactionActionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 6.0),
-      child: Container(
+      child: DecoratedBox(
         decoration: BoxDecoration(
           border: Border.all(color: AppColors.grey1),
           borderRadius: const BorderRadius.all(Radius.circular(12)),
@@ -26,7 +26,7 @@ class TransactionActionCard extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   Text(action.name?.inCaps ?? "", style: Theme.of(context).textTheme.headline7),
-                  Text(action.account ?? "", style: Theme.of(context).textTheme.subtitle2),
+                  Text(action.account ?? "", style: Theme.of(context).textTheme.titleSmall),
                 ],
               ),
               const Divider(color: AppColors.grey1),
@@ -41,7 +41,7 @@ class TransactionActionCard extends StatelessWidget {
                           children: [
                             Text(i.key.inCaps, style: Theme.of(context).textTheme.subtitle2OpacityEmphasis),
                             const SizedBox(width: 4),
-                            Flexible(child: Text('${i.value}', style: Theme.of(context).textTheme.subtitle2)),
+                            Flexible(child: Text('${i.value}', style: Theme.of(context).textTheme.titleSmall)),
                           ],
                         ),
                       ),

--- a/lib/screens/transfer/send/send_enter_data/components/send_confirmation_dialog.dart
+++ b/lib/screens/transfer/send/send_enter_data/components/send_confirmation_dialog.dart
@@ -53,14 +53,14 @@ class SendConfirmationDialog extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text(tokenAmount.amountString(), style: Theme.of(context).textTheme.headline4),
+            Text(tokenAmount.amountString(), style: Theme.of(context).textTheme.headlineMedium),
             Padding(
               padding: const EdgeInsets.only(top: 14, left: 4),
-              child: Text(tokenAmount.symbol, style: Theme.of(context).textTheme.subtitle2),
+              child: Text(tokenAmount.symbol, style: Theme.of(context).textTheme.titleSmall),
             ),
           ],
         ),
-        Text(fiatAmount?.asFormattedString() ?? "", style: Theme.of(context).textTheme.subtitle2),
+        Text(fiatAmount?.asFormattedString() ?? "", style: Theme.of(context).textTheme.titleSmall),
         const SizedBox(height: 30.0),
         DialogRow(imageUrl: toImage, account: toAccount, name: toName, toOrFromText: context.loc.transferSendTo),
         const SizedBox(height: 24.0),
@@ -68,9 +68,9 @@ class SendConfirmationDialog extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(context.loc.transferSendNetworkFee,
-                textAlign: TextAlign.left, style: Theme.of(context).textTheme.subtitle2),
+                textAlign: TextAlign.left, style: Theme.of(context).textTheme.titleSmall),
             Text(context.loc.transferSendFreeAndInstant,
-                textAlign: TextAlign.right, style: Theme.of(context).textTheme.subtitle2),
+                textAlign: TextAlign.right, style: Theme.of(context).textTheme.titleSmall),
           ],
         ),
         const SizedBox(height: 40.0),
@@ -79,14 +79,14 @@ class SendConfirmationDialog extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(context.loc.transferSendMemo,
-                  textAlign: TextAlign.right, style: Theme.of(context).textTheme.subtitle2),
+                  textAlign: TextAlign.right, style: Theme.of(context).textTheme.titleSmall),
               const SizedBox(width: 16.0),
               Flexible(
                 child: Text(memo!,
                     maxLines: 5,
                     overflow: TextOverflow.ellipsis,
                     textAlign: TextAlign.right,
-                    style: Theme.of(context).textTheme.subtitle2),
+                    style: Theme.of(context).textTheme.titleSmall),
               ),
             ],
           )
@@ -116,19 +116,19 @@ class DialogRow extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(name ?? account, textAlign: TextAlign.start, style: Theme.of(context).textTheme.button),
+                Text(name ?? account, textAlign: TextAlign.start, style: Theme.of(context).textTheme.labelLarge),
                 const SizedBox(height: 8),
                 Text(account, style: Theme.of(context).textTheme.subtitle2LowEmphasis)
               ],
             ),
           ),
         ),
-        Container(
+        DecoratedBox(
           decoration: const BoxDecoration(
               borderRadius: BorderRadius.all(Radius.elliptical(4, 4)), color: AppColors.lightGreen6),
           child: Padding(
             padding: const EdgeInsets.only(top: 4, bottom: 4, right: 8, left: 8),
-            child: Text(toOrFromText!, style: Theme.of(context).textTheme.subtitle2),
+            child: Text(toOrFromText!, style: Theme.of(context).textTheme.titleSmall),
           ),
         ),
       ],

--- a/lib/screens/transfer/send/send_enter_data/interactor/mappers/send_amount_change_mapper.dart
+++ b/lib/screens/transfer/send/send_enter_data/interactor/mappers/send_amount_change_mapper.dart
@@ -1,16 +1,17 @@
 import 'package:seeds/blocs/rates/viewmodels/rates_bloc.dart';
 import 'package:seeds/datasource/local/models/token_data_model.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
-import 'package:seeds/datasource/remote/model/token_model.dart';
 import 'package:seeds/domain-shared/result_to_state_mapper.dart';
 import 'package:seeds/screens/transfer/send/send_enter_data/interactor/viewmodels/send_enter_data_bloc.dart';
 import 'package:seeds/utils/rate_states_extensions.dart';
 
 class SendAmountChangeMapper extends StateMapper {
-  SendEnterDataState mapResultToState(SendEnterDataState currentState, RatesState rateState, String quantity) {
+  SendEnterDataState mapResultToState(
+      SendEnterDataState currentState, RatesState rateState, String quantity) {
     final double parsedQuantity = double.tryParse(quantity) ?? 0;
 
-    final tokenAmount = TokenDataModel(parsedQuantity, token: settingsStorage.selectedToken);
+    final tokenAmount =
+        TokenDataModel(parsedQuantity, token: settingsStorage.selectedToken);
     final selectedFiat = settingsStorage.selectedFiatCurrency;
     final fiatAmount = rateState.tokenToFiat(tokenAmount, selectedFiat);
     final toAccount = currentState.sendTo.account;
@@ -18,14 +19,20 @@ class SendAmountChangeMapper extends StateMapper {
     final double currentAvailable = currentState.availableBalance?.amount ?? 0;
 
     final double insufficiency =
-        currentState.availableBalance?.asFormattedString() == tokenAmount.asFormattedString() ? 0.0 :
-        parsedQuantity - currentAvailable;
+        currentState.availableBalance?.asFormattedString() ==
+                tokenAmount.asFormattedString()
+            ? 0.0
+            : parsedQuantity - currentAvailable;
 
     return currentState.copyWith(
       fiatAmount: fiatAmount,
-      isNextButtonEnabled: parsedQuantity > 0 && !settingsStorage.selectedToken.blockTransfer(insufficiency, toAccount),
+      isNextButtonEnabled: parsedQuantity > 0 &&
+          !settingsStorage.selectedToken
+              .blockTransfer(insufficiency, toAccount),
       tokenAmount: tokenAmount,
-      showAlert: settingsStorage.selectedToken.warnTransfer(insufficiency, toAccount) != null,
+      showAlert: settingsStorage.selectedToken
+              .warnTransfer(insufficiency, toAccount) !=
+          null,
     );
   }
 }

--- a/lib/screens/transfer/send/send_enter_data/send_enter_data_screen.dart
+++ b/lib/screens/transfer/send/send_enter_data/send_enter_data_screen.dart
@@ -101,7 +101,7 @@ class SendEnterDataScreen extends StatelessWidget {
                                 padding: const EdgeInsets.only(top: 10),
                                 child: Text(
                                   context.loc.transferSendSendTo,
-                                  style: Theme.of(context).textTheme.subtitle1,
+                                  style: Theme.of(context).textTheme.titleMedium,
                                 ),
                               ),
                               const SizedBox(height: 8),

--- a/lib/screens/transfer/send/send_scanner/send_scanner_screen.dart
+++ b/lib/screens/transfer/send/send_scanner/send_scanner_screen.dart
@@ -46,7 +46,7 @@ class _SendScannerScreenState extends State<SendScannerScreen> {
           child: Column(
             children: [
               const SizedBox(height: 32),
-              Text(context.loc.transferSendScanQRCodePrompt, style: Theme.of(context).textTheme.button),
+              Text(context.loc.transferSendScanQRCodePrompt, style: Theme.of(context).textTheme.labelLarge),
               const SizedBox(height: 82),
               _scannerWidget,
               BlocBuilder<SendScannerBloc, SendScannerState>(
@@ -69,7 +69,7 @@ class _SendScannerScreenState extends State<SendScannerScreen> {
                             padding: const EdgeInsets.all(8.0),
                             child: Text(
                               state.errorMessage!,
-                              style: Theme.of(context).textTheme.subtitle2!.copyWith(color: AppColors.orangeYellow),
+                              style: Theme.of(context).textTheme.titleSmall!.copyWith(color: AppColors.orangeYellow),
                               textAlign: TextAlign.center,
                             ),
                           ),

--- a/lib/screens/wallet/components/receive_send_buttons.dart
+++ b/lib/screens/wallet/components/receive_send_buttons.dart
@@ -39,7 +39,7 @@ class ReceiveSendButtons extends StatelessWidget {
                         const Icon(Icons.arrow_upward, color: AppColors.white),
                         Container(
                           padding: const EdgeInsets.only(left: 4, top: 4),
-                          child: Text(context.loc.walletSendButtonTitle, style: Theme.of(context).textTheme.button),
+                          child: Text(context.loc.walletSendButtonTitle, style: Theme.of(context).textTheme.labelLarge),
                         ),
                       ],
                     ),
@@ -67,7 +67,7 @@ class ReceiveSendButtons extends StatelessWidget {
                         const Icon(Icons.arrow_downward, color: AppColors.white),
                         Container(
                           padding: const EdgeInsets.only(left: 4, top: 4),
-                          child: Text(context.loc.walletReceiveButtonTitle, style: Theme.of(context).textTheme.button),
+                          child: Text(context.loc.walletReceiveButtonTitle, style: Theme.of(context).textTheme.labelLarge),
                         ),
                       ],
                     ),

--- a/lib/screens/wallet/components/tokens_cards/components/currency_info_card.dart
+++ b/lib/screens/wallet/components/tokens_cards/components/currency_info_card.dart
@@ -34,7 +34,7 @@ class CurrencyInfoCard extends StatelessWidget {
       ),
       child: Stack(
         children: [
-          if ((tokenBalance.token.usecases?.contains('experimental')) ?? false)
+          if (tokenBalance.token.usecases?.contains('experimental') ?? false)
             Container(
               width: 128,
               height: 128,
@@ -68,10 +68,10 @@ class CurrencyInfoCard extends StatelessWidget {
                 ),
                 const SizedBox(height: 50),
                 Text(context.loc.walletCurrencyCardBalance,
-                    style: Theme.of(context).textTheme.subtitle2!.copyWith(color: textColor)),
+                    style: Theme.of(context).textTheme.titleSmall!.copyWith(color: textColor)),
                 const SizedBox(height: 6),
                 Text(tokenBalance.displayQuantity,
-                    style: Theme.of(context).textTheme.headline5!.copyWith(color: textColor)),
+                    style: Theme.of(context).textTheme.headlineSmall!.copyWith(color: textColor)),
                 const SizedBox(height: 6),
                 Text(fiatBalance, style: Theme.of(context).textTheme.subtitle3.copyWith(color: textColor))
               ],

--- a/lib/screens/wallet/components/tokens_cards/tokens_cards.dart
+++ b/lib/screens/wallet/components/tokens_cards/tokens_cards.dart
@@ -39,7 +39,7 @@ class _TokenCardsState extends State<TokenCards> with AutomaticKeepAliveClientMi
                 SingleChildScrollView(
                   child: CarouselSlider(
                     items: [
-                      for (var tokenBalanceViewModel in state.availableTokens)
+                      for (final tokenBalanceViewModel in state.availableTokens)
                         Container(
                           margin: EdgeInsets.only(
                               left: tokenBalanceViewModel.token == state.availableTokens.first.token ? 0 : 10.0,

--- a/lib/screens/wallet/components/transaction_details_bottom_sheet.dart
+++ b/lib/screens/wallet/components/transaction_details_bottom_sheet.dart
@@ -90,7 +90,7 @@ class TransactionDetailsBottomSheet extends StatelessWidget {
                             else
                               Text('-', style: Theme.of(context).textTheme.subtitle1Red2),
                             const SizedBox(width: 4),
-                            Text(transaction.quantity.seedsFormatted, style: Theme.of(context).textTheme.headline5)
+                            Text(transaction.quantity.seedsFormatted, style: Theme.of(context).textTheme.headlineSmall)
                           ],
                         ),
                         Padding(

--- a/lib/screens/wallet/components/transactions_list/components/transaction_info_row.dart
+++ b/lib/screens/wallet/components/transactions_list/components/transaction_info_row.dart
@@ -55,7 +55,7 @@ class TransactionInfoRow extends StatelessWidget {
                                 Expanded(
                                   child: Text(
                                     state.localizedDisplayName(context),
-                                    style: Theme.of(context).textTheme.button,
+                                    style: Theme.of(context).textTheme.labelLarge,
                                     overflow: TextOverflow.ellipsis,
                                     maxLines: 1,
                                   ),
@@ -66,7 +66,7 @@ class TransactionInfoRow extends StatelessWidget {
                                 else
                                   Text('-', style: Theme.of(context).textTheme.subtitle1Red2),
                                 const SizedBox(width: 4),
-                                Text(amount.seedsFormatted, style: Theme.of(context).textTheme.button),
+                                Text(amount.seedsFormatted, style: Theme.of(context).textTheme.labelLarge),
                               ],
                             ),
                             const SizedBox(height: 10),

--- a/lib/screens/wallet/components/transactions_list/components/transaction_loading_row.dart
+++ b/lib/screens/wallet/components/transactions_list/components/transaction_loading_row.dart
@@ -7,29 +7,29 @@ class TransactionLoadingRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 10, bottom: 10, right: 20, left: 20),
+    return const Padding(
+      padding: EdgeInsets.only(top: 10, bottom: 10, right: 20, left: 20),
       child: Row(
         children: [
-          const ShimmerCircle(60),
+          ShimmerCircle(60),
           Expanded(
             child: Padding(
-              padding: const EdgeInsets.only(left: 10),
+              padding: EdgeInsets.only(left: 10),
               child: Column(
                 children: [
                   Row(
                     children: [
-                      const ShimmerRectangle(size: Size(110, 21)),
-                      const Spacer(),
-                      const ShimmerRectangle(size: Size(64, 21)),
+                      ShimmerRectangle(size: Size(110, 21)),
+                      Spacer(),
+                      ShimmerRectangle(size: Size(64, 21)),
                     ],
                   ),
-                  const SizedBox(height: 10),
+                  SizedBox(height: 10),
                   Row(
                     children: [
-                      const ShimmerRectangle(size: Size(70, 16)),
-                      const Spacer(),
-                      const ShimmerRectangle(size: Size(44, 16)),
+                      ShimmerRectangle(size: Size(70, 16)),
+                      Spacer(),
+                      ShimmerRectangle(size: Size(44, 16)),
                     ],
                   )
                 ],

--- a/lib/seeds_app.dart
+++ b/lib/seeds_app.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:i18n_extension/i18n_widget.dart';
+import 'package:i18n_extension/i18n_extension.dart';
 import 'package:seeds/blocs/authentication/viewmodels/authentication_bloc.dart';
 import 'package:seeds/blocs/deeplink/viewmodels/deeplink_bloc.dart';
 import 'package:seeds/blocs/rates/viewmodels/rates_bloc.dart';
@@ -22,7 +22,8 @@ class SeedsApp extends StatelessWidget {
       child: MultiBlocProvider(
         providers: [
           BlocProvider<RootBloc>(create: (_) => RootBloc()),
-          BlocProvider<AuthenticationBloc>(create: (_) => AuthenticationBloc()..add(const InitAuthStatus())),
+          BlocProvider<AuthenticationBloc>(
+              create: (_) => AuthenticationBloc()..add(const InitAuthStatus())),
           BlocProvider<RatesBloc>(create: (_) => RatesBloc()),
           BlocProvider<DeeplinkBloc>(create: (_) => DeeplinkBloc()),
         ],
@@ -32,27 +33,38 @@ class SeedsApp extends StatelessWidget {
               listenWhen: (_, current) => current.busEvent != null,
               listener: (context, state) {
                 final BusEvent busEvent = state.busEvent!;
-                BlocProvider.of<RootBloc>(context).add(const ClearRootBusEvent());
+                BlocProvider.of<RootBloc>(context)
+                    .add(const ClearRootBusEvent());
                 if (busEvent is ShowSnackBar) {
                   final ShowSnackBar event = busEvent;
-                  Snack(event.message, rootScaffoldMessengerKey.currentState, event.snackType).show();
+                  Snack(event.message, rootScaffoldMessengerKey.currentState,
+                          event.snackType)
+                      .show();
                 }
               },
             ),
             BlocListener<DeeplinkBloc, DeeplinkState>(
-              listenWhen: (previous, current) => previous.inviteLinkData == null && current.inviteLinkData != null,
-              listener: (context, _) => BlocProvider.of<AuthenticationBloc>(context).add(const OnInviteLinkRecived()),
+              listenWhen: (previous, current) =>
+                  previous.inviteLinkData == null &&
+                  current.inviteLinkData != null,
+              listener: (context, _) =>
+                  BlocProvider.of<AuthenticationBloc>(context)
+                      .add(const OnInviteLinkRecived()),
             )
           ],
           child: Builder(
             builder: (context) {
               final navigator = NavigationService.of(context);
               return GestureDetector(
-                onTap: () => BlocProvider.of<AuthenticationBloc>(context).add(const InitAuthTimer()),
-                onPanDown: (_) => BlocProvider.of<AuthenticationBloc>(context).add(const InitAuthTimer()),
-                onPanUpdate: (_) => BlocProvider.of<AuthenticationBloc>(context).add(const InitAuthTimer()),
+                onTap: () => BlocProvider.of<AuthenticationBloc>(context)
+                    .add(const InitAuthTimer()),
+                onPanDown: (_) => BlocProvider.of<AuthenticationBloc>(context)
+                    .add(const InitAuthTimer()),
+                onPanUpdate: (_) => BlocProvider.of<AuthenticationBloc>(context)
+                    .add(const InitAuthTimer()),
                 child: MaterialApp(
-                  localizationsDelegates: AppLocalizations.localizationsDelegates,
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
                   supportedLocales: AppLocalizations.supportedLocales,
                   theme: SeedsAppTheme.darkTheme,
                   scaffoldMessengerKey: rootScaffoldMessengerKey,
@@ -60,8 +72,10 @@ class SeedsApp extends StatelessWidget {
                   onGenerateRoute: navigator.onGenerateRoute,
                   builder: (_, child) {
                     return I18n(
-                      child: BlocListener<AuthenticationBloc, AuthenticationState>(
-                        listenWhen: (previous, current) => previous.authStatus != current.authStatus,
+                      child:
+                          BlocListener<AuthenticationBloc, AuthenticationState>(
+                        listenWhen: (previous, current) =>
+                            previous.authStatus != current.authStatus,
                         listener: (_, state) {
                           switch (state.authStatus) {
                             case AuthStatus.emptyAccount:
@@ -76,11 +90,14 @@ class SeedsApp extends StatelessWidget {
                             case AuthStatus.emptyPasscode:
                             case AuthStatus.locked:
                               if (navigator.currentRouteName() == null ||
-                                  navigator.currentRouteName() == Routes.importKey ||
-                                  navigator.currentRouteName() == Routes.importWords) {
+                                  navigator.currentRouteName() ==
+                                      Routes.importKey ||
+                                  navigator.currentRouteName() ==
+                                      Routes.importWords) {
                                 navigator.pushAndRemoveAll(Routes.app);
                               }
-                              navigator.navigateTo(Routes.verificationUnpoppable);
+                              navigator
+                                  .navigateTo(Routes.verificationUnpoppable);
                               break;
                             case AuthStatus.unlocked:
                               navigator.pushApp();

--- a/lib/utils/placemark_extension.dart
+++ b/lib/utils/placemark_extension.dart
@@ -2,12 +2,12 @@ import 'package:geocoding/geocoding.dart';
 
 extension PlacemarkExtension on Placemark {
   String get toPlaceText {
-    final String _thoroughfare = thoroughfare ?? '';
-    final String _subThoroughfare = subThoroughfare ?? '';
-    final String _subLocality = subLocality ?? '';
-    final String _postalCode = postalCode ?? '';
-    final String _locality = locality ?? '';
-    final String _administrativeArea = administrativeArea ?? '';
-    return '$_thoroughfare $_subThoroughfare $_subLocality $_postalCode $_locality $_administrativeArea';
+    final String thoroughfare = this.thoroughfare ?? '';
+    final String subThoroughfare = this.subThoroughfare ?? '';
+    final String subLocality = this.subLocality ?? '';
+    final String postalCode = this.postalCode ?? '';
+    final String locality = this.locality ?? '';
+    final String administrativeArea = this.administrativeArea ?? '';
+    return '$thoroughfare $subThoroughfare $subLocality $postalCode $locality $administrativeArea';
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: SEEDS Wallet
 version: 2.9.4+87
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <3.6.0'
 
 analyzer:
   enable-experiment: extension-methods
@@ -19,10 +19,10 @@ dependencies:
   url_launcher: ^6.1.0
   step_progress_indicator: ^1.0.1
   uni_links: ^0.5.1
-  intl: ^0.18.0
+  intl: ^0.19.0
   flutter_localizations:
     sdk: flutter
-  i18n_extension: ^7.0.0
+  i18n_extension: ^12.0.1
   http: ^0.13.4
   shared_preferences: ^2.0.9
   flutter_secure_storage: ^5.0.2
@@ -53,9 +53,9 @@ dependencies:
   geolocator: ^8.2.0
   geocoding: ^2.0.2
   permission_handler: ^9.2.0
-  json_schema2: ^2.0.2
+  json_schema: ^5.1.7
   local_auth_android: ^1.0.32
-  local_auth_ios: ^1.1.3
+  local_auth_darwin: ^1.3.1
   firebase_dynamic_links: ^5.3.4
   firebase_remote_config: ^4.2.4
   firebase_storage: ^11.2.5

--- a/test/utils/serialize_test.dart
+++ b/test/utils/serialize_test.dart
@@ -8,13 +8,13 @@ void main() {
   group('public keys', () {
     test('serialize k1 old style', ()  {
       final keystring = 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV';
-      final sb = new SerialBuffer(new Uint8List(0));
+      final sb = SerialBuffer(Uint8List(0));
       sb.pushPublicKey(keystring);
       final serialized = sb.asUint8List();
 
       if(verbose) {
         print("keystring: $keystring");
-        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+        print("serialized: $serialized\n""   ${arrayToHex(serialized)}");
       }
       expect(serialized,
           [0, 2, 192, 222, 210, 188, 31, 19, 5, 251, 15, 170, 197, 230, 192, 62,
@@ -23,13 +23,13 @@ void main() {
     });
     test('serialize k1 new style', ()  {
       final keystring = 'PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5BoDq63';
-      final sb = new SerialBuffer(new Uint8List(0));
+      final sb = SerialBuffer(Uint8List(0));
       sb.pushPublicKey(keystring);
       final serialized = sb.asUint8List();
 
       if(verbose) {
         print("keystring: $keystring");
-        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+        print("serialized: $serialized\n""   ${arrayToHex(serialized)}");
       }
       expect(serialized,
           [0, 2, 192, 222, 210, 188, 31, 19, 5, 251, 15, 170, 197, 230, 192, 62,
@@ -40,24 +40,24 @@ void main() {
       final serialized = Uint8List.fromList([0, 2, 192, 222, 210, 188, 31, 19,
         5, 251, 15, 170, 197, 230, 192, 62, 227, 161, 146, 66, 52, 152, 84, 39,
         182, 22, 124, 165, 105, 209, 61, 244, 53, 207]);
-      final sb = new SerialBuffer(serialized);
+      final sb = SerialBuffer(serialized);
       final keystring = sb.getPublicKey();
 
       if(verbose) {
         print("keystring: $keystring");
-        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+        print("serialized: $serialized\n""   ${arrayToHex(serialized)}");
       }
       expect(keystring, 'PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5BoDq63');
     });
     test('serialize r1 new style', ()  {
       final keystring = 'PUB_R1_6eMzJfDVWvzMTYAUWQ95JcpoY8vFL62pTFm6spim25n5wqtVWP';
-      final sb = new SerialBuffer(new Uint8List(0));
+      final sb = SerialBuffer(Uint8List(0));
       sb.pushPublicKey(keystring);
       final serialized = sb.asUint8List();
 
       if(verbose) {
         print("keystring: $keystring");
-        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+        print("serialized: $serialized\n""   ${arrayToHex(serialized)}");
       }
       expect(serialized,
           [1, 2, 231, 80, 174, 4, 190, 33, 189, 1, 48, 165, 223, 203, 242,
@@ -69,12 +69,12 @@ void main() {
         [1, 2, 231, 80, 174, 4, 190, 33, 189, 1, 48, 165, 223, 203, 242,
            125, 16, 95, 97, 223, 20, 206, 120, 17, 207, 107, 49, 24, 30,
            7, 140, 39, 8, 36]);
-      final sb = new SerialBuffer(serialized);
+      final sb = SerialBuffer(serialized);
       final keystring = sb.getPublicKey();
 
       if(verbose) {
         print("keystring: $keystring");
-        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+        print("serialized: $serialized\n""   ${arrayToHex(serialized)}");
       }
       expect(keystring, 'PUB_R1_6eMzJfDVWvzMTYAUWQ95JcpoY8vFL62pTFm6spim25n5wqtVWP');
     });
@@ -84,13 +84,13 @@ void main() {
   group('private keys', () {
     test('serialize k1 old style', ()  {
       final keystring = '5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3';
-      final sb = new SerialBuffer(new Uint8List(0));
+      final sb = SerialBuffer(Uint8List(0));
       sb.pushPrivateKey(keystring);
       final serialized = sb.asUint8List();
 
       if(verbose) {
         print("keystring: $keystring");
-        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+        print("serialized: $serialized\n""   ${arrayToHex(serialized)}");
       }
       expect(serialized,
           [0, 210, 101, 63, 247, 203, 178, 216, 255, 18, 154, 194, 126, 245,
@@ -99,13 +99,13 @@ void main() {
     });
     test('serialize k1 new style', ()  {
       final keystring = 'PVT_K1_2bfGi9rYsXQSXXTvJbDAPhHLQUojjaNLomdm3cEJ1XTzMqUt3V';
-      final sb = new SerialBuffer(new Uint8List(0));
+      final sb = SerialBuffer(Uint8List(0));
       sb.pushPrivateKey(keystring);
       final serialized = sb.asUint8List();
 
       if(verbose) {
         print("keystring: $keystring");
-        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+        print("serialized: $serialized\n""   ${arrayToHex(serialized)}");
       }
       expect(serialized,
           [0, 210, 101, 63, 247, 203, 178, 216, 255, 18, 154, 194, 126, 245,
@@ -116,24 +116,24 @@ void main() {
       final serialized = Uint8List.fromList([0, 210, 101, 63, 247, 203, 178,
         216, 255, 18, 154, 194, 126, 245, 120, 28, 230, 139, 37, 88, 196,
         26, 116, 175, 31, 45, 220, 166, 53, 203, 238, 240, 125]);
-      final sb = new SerialBuffer(serialized);
+      final sb = SerialBuffer(serialized);
       final keystring = sb.getPrivateKey();
 
       if(verbose) {
         print("keystring: $keystring");
-        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+        print("serialized: $serialized\n""   ${arrayToHex(serialized)}");
       }
       expect(keystring, 'PVT_K1_2bfGi9rYsXQSXXTvJbDAPhHLQUojjaNLomdm3cEJ1XTzMqUt3V');
     });
     test('serialize r1 new style', ()  {
       final keystring = 'PVT_R1_2JrJRQXEagWobhJbHWtP11muTWi5pgCJ6uXWhGKd2KcFBGF7mT';
-      final sb = new SerialBuffer(new Uint8List(0));
+      final sb = SerialBuffer(Uint8List(0));
       sb.pushPrivateKey(keystring);
       final serialized = sb.asUint8List();
 
       if(verbose) {
         print("keystring: $keystring");
-        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+        print("serialized: $serialized\n""   ${arrayToHex(serialized)}");
       }
       expect(serialized,
           [1, 172, 58, 10, 48, 178, 188, 37, 15, 234, 129, 216, 243, 182,
@@ -145,12 +145,12 @@ void main() {
         [1, 172, 58, 10, 48, 178, 188, 37, 15, 234, 129, 216, 243, 182,
            68, 115, 41, 18, 206, 91, 223, 230, 199, 84, 66, 41, 110, 159,
            117, 45, 189, 67, 43]);
-      final sb = new SerialBuffer(serialized);
+      final sb = SerialBuffer(serialized);
       final keystring = sb.getPrivateKey();
 
       if(verbose) {
         print("keystring: $keystring");
-        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+        print("serialized: $serialized\n""   ${arrayToHex(serialized)}");
       }
       expect(keystring, 'PVT_R1_2JrJRQXEagWobhJbHWtP11muTWi5pgCJ6uXWhGKd2KcFBGF7mT');
     });


### PR DESCRIPTION
### 🗃 Migrate TextTheme and dependencies for latest version of Flutter
From Flutter 3.19, the TextTheme has been deprecated (https://docs.flutter.dev/release/breaking-changes/3-19-deprecations#texttheme). Alongside that, there are packages that have been discontinued as well. Those packages are `json_schema2` in favor of `json_schema`, `local_auth_ios` in favor of `local_auth_darwin`.

There are some miscellanious changes as well which have been recommended by the Dart Linter. For instance, in some places `Container` has been replaced with `DecoratedBox`, the `new` keyword has been omitted etc.,

### ✅ Checklist

- [x] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

_Technical explanations to help your peers review your work - including environments, credentials, etc._

### 🙈 Screenshots

_For all UI changes_

| description 1 | description 2 |
| --- | --- |
| img1 | img2 |

### 👯‍♀️ Paired with

_@github-handle or "nobody" if you did not pair._
